### PR TITLE
BAU: Fix typo in action config

### DIFF
--- a/.github/workflows/skip-lint-cloudformation.yaml
+++ b/.github/workflows/skip-lint-cloudformation.yaml
@@ -2,7 +2,7 @@ name: CloudFormation Linter
 
 on: 
   pull_request: 
-    paths-ingnore:
+    paths-ignore:
       - 'infrastructure/**'
 
 jobs:


### PR DESCRIPTION
This action was running on every PR, including those which made changes to files in the `infrastructure/` folder. The other action was also running, so we didn't miss out on any CI but it's a bit confusing.

Fix the typo so this will work as expected