### PR TITLE
OLH-1213 Use globals in SAM definition of SendSuspiciousActivityFunct…

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -2243,30 +2243,18 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       FunctionName: !Sub ${Environment}-${AWS::StackName}-send-suspicious-activity
-      Architectures: [ "arm64" ]
       CodeUri: ../lambda/send-event-to-txma/
       DeadLetterQueue:
         Type: SQS
         TargetArn: !GetAtt SendSuspiciousActivityDeadLetterQueue.Arn
       Handler: send-event-to-txma.handler
-      KmsKeyArn: !GetAtt LambdaKMSKey.Arn
       PackageType: Zip
-      MemorySize: 128
-      ReservedConcurrentExecutions: 10
-      Runtime: nodejs18.x
       Role: !GetAtt SendSuspiciousActivityRole.Arn
-      Timeout: 5
       Environment:
         Variables:
           EVENT_NAME: HOME_REPORT_SUSPICIOUS_ACTIVITY
           DLQ_URL: !Ref SendSuspiciousActivityDeadLetterQueue
           TXMA_QUEUE_URL: !Ref AuditOutputQueue
-      VpcConfig:
-        SubnetIds:
-          - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdA
-          - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdB
-        SecurityGroupIds:
-          - Fn::ImportValue: !Sub ${VpcStackName}-AWSServicesEndpointSecurityGroupId
     Metadata:
       BuildMethod: esbuild
       BuildProperties:


### PR DESCRIPTION
## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->
Use global values in definition of SendSuspiciousActivityFunction

### What changed

<!-- Describe the changes in detail - the "what"-->
Change function definition in SAM template to use global values where appropriate.

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->
As part of the work to add the Dynatrace configuration for the lambdas the opportunity was taken to move common values into global values.  The SendSuspiciousActivityFunction was added after these changes were made on the Dynatrace branch and the Architecture property was defined twice for this function which resulted in an array rather than a single value being defined.  This caused the Github action to fail when trying to deploy it.

### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists

<!-- Merging this PR deploys to production. Please answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->


### Permissions

- [ ] This PR adds or changes permissions

## Testing

<!-- Provide a summary of any manual testing you've done, for example deploying the branch to dev -->

## How to review

<!-- Describe any non-standard steps to review this work, or higlight any areas that you'd like the reviewer's opinion on -->
