### PR TITLE
OLH-1309 - Send audit event timestamps in seconds

### DIFF
--- a/lambda/send-event-to-txma/models.ts
+++ b/lambda/send-event-to-txma/models.ts
@@ -14,6 +14,12 @@ export interface Extensions {
   reported_session_id: string;
 }
 
+export interface CurrentTimeDescriptor {
+  isoString: string;
+  milliseconds: number;
+  seconds: number;
+}
+
 export interface ReportedEvent {
   event_type: string;
   session_id: string;

--- a/lambda/send-event-to-txma/send-event-to-txma.ts
+++ b/lambda/send-event-to-txma/send-event-to-txma.ts
@@ -5,7 +5,7 @@ import {
   SendMessageRequest,
   SQSClient,
 } from "@aws-sdk/client-sqs";
-import { TxmaEvent } from "./models";
+import {CurrentTimeDescriptor, TxmaEvent} from "./models";
 import {
   COMPONENT_ID,
   EventNamesEnum,
@@ -15,10 +15,26 @@ import {
 import VALIDATOR_RULES_MAP from "./validator-rules";
 import validateObject from "./validator";
 
+/**
+ * A function for calculating and returning an object containing the current timestamp.
+ *
+ * @returns CurrentTimeDescriptor object, containing different formats of the current time
+ */
+export function getCurrentTimestamp(date = new Date()): CurrentTimeDescriptor {
+  return {
+    milliseconds: date.valueOf(),
+    isoString: date.toISOString(),
+    seconds: Math.floor(date.valueOf() / 1000),
+  };
+}
 export const transformToTxMAEvent = (event: any, eventName: string): any => {
   let txmaEvent = null;
+  const timestamps = getCurrentTimestamp();
   if (eventName === EventNamesEnum.HOME_REPORT_SUSPICIOUS_ACTIVITY) {
     txmaEvent = {
+      timestamp: timestamps.seconds,
+      event_timestamp_ms: timestamps.milliseconds,
+      event_timestamp_ms_formatted: timestamps.isoString,
       component_id: COMPONENT_ID,
       event_name: REPORT_SUSPICIOUS_ACTIVITY_EVENT_NAME,
       user: {

--- a/lambda/send-event-to-txma/tests/send-event-to.txma.test.ts
+++ b/lambda/send-event-to-txma/tests/send-event-to.txma.test.ts
@@ -140,7 +140,7 @@ describe("transform", () => {
       },
     };
     jest.useFakeTimers();
-    jest.setSystemTime(new Date(2023, 20, 14));
+    jest.setSystemTime(new Date(Date.UTC(2023, 20, 12)));
   });
 
   afterEach(() => {
@@ -154,9 +154,9 @@ describe("transform", () => {
       EVENT_NAME
     );
     const expected = {
-      timestamp: 1726268400,
-      event_timestamp_ms: 1726268400000,
-      event_timestamp_ms_formatted: "2024-09-13T23:00:00.000Z",
+      timestamp: 1726099200,
+      event_timestamp_ms: 1726099200000,
+      event_timestamp_ms_formatted: "2024-09-12T00:00:00.000Z",
       component_id: "https://home.account.gov.uk",
       event_name: "HOME_REPORT_SUSPICIOUS_ACTIVITY",
       extensions: {
@@ -189,7 +189,7 @@ describe("handler", () => {
     process.env.TXMA_QUEUE_URL = "TXMA_QUEUE_URL";
     sqsMock.on(SendMessageCommand).resolves({ MessageId: "MessageId" });
     jest.useFakeTimers();
-    jest.setSystemTime(new Date(2023, 20, 14));
+    jest.setSystemTime(new Date(Date.UTC(2023, 20, 12)));
   });
 
   afterEach(() => {
@@ -204,9 +204,9 @@ describe("handler", () => {
     expect(sqsMock).toHaveReceivedCommandWith(SendMessageCommand, {
       QueueUrl: "TXMA_QUEUE_URL",
       MessageBody: JSON.stringify({
-        timestamp: 1726268400,
-        event_timestamp_ms: 1726268400000,
-        event_timestamp_ms_formatted: "2024-09-13T23:00:00.000Z",
+        timestamp: 1726099200,
+        event_timestamp_ms: 1726099200000,
+        event_timestamp_ms_formatted: "2024-09-12T00:00:00.000Z",
         component_id: "https://home.account.gov.uk",
         event_name: "HOME_REPORT_SUSPICIOUS_ACTIVITY",
         user: {

--- a/lambda/send-event-to-txma/tests/send-event-to.txma.test.ts
+++ b/lambda/send-event-to-txma/tests/send-event-to.txma.test.ts
@@ -28,6 +28,9 @@ describe("sendAuditEventToTxMA", () => {
   test("send audit event successfully", async () => {
     const consoleLog = jest.spyOn(console, "log").mockImplementation();
     const txMAEvent = {
+      timestamp: 1726268400,
+      event_timestamp_ms: 1726268400000,
+      event_timestamp_ms_formatted: "2024-09-13T23:00:00.000Z",
       component_id: "https://home.account.gov.uk",
       event_name: "HOME_REPORT_SUSPICIOUS_ACTIVITY",
       extensions: {
@@ -136,11 +139,13 @@ describe("transform", () => {
         },
       },
     };
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date(2023, 20, 14));
   });
 
   afterEach(() => {
+    jest.useRealTimers();
     jest.clearAllMocks();
-    jest.spyOn(Date, "now").mockRestore();
   });
 
   test("transforms suspicious activity event to TxMA event successfully", async () => {
@@ -149,6 +154,9 @@ describe("transform", () => {
       EVENT_NAME
     );
     const expected = {
+      timestamp: 1726268400,
+      event_timestamp_ms: 1726268400000,
+      event_timestamp_ms_formatted: "2024-09-13T23:00:00.000Z",
       component_id: "https://home.account.gov.uk",
       event_name: "HOME_REPORT_SUSPICIOUS_ACTIVITY",
       extensions: {
@@ -180,9 +188,12 @@ describe("handler", () => {
     process.env.EVENT_NAME = "HOME_REPORT_SUSPICIOUS_ACTIVITY";
     process.env.TXMA_QUEUE_URL = "TXMA_QUEUE_URL";
     sqsMock.on(SendMessageCommand).resolves({ MessageId: "MessageId" });
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date(2023, 20, 14));
   });
 
   afterEach(() => {
+    jest.useRealTimers();
     jest.clearAllMocks();
   });
 
@@ -193,6 +204,9 @@ describe("handler", () => {
     expect(sqsMock).toHaveReceivedCommandWith(SendMessageCommand, {
       QueueUrl: "TXMA_QUEUE_URL",
       MessageBody: JSON.stringify({
+        timestamp: 1726268400,
+        event_timestamp_ms: 1726268400000,
+        event_timestamp_ms_formatted: "2024-09-13T23:00:00.000Z",
         component_id: "https://home.account.gov.uk",
         event_name: "HOME_REPORT_SUSPICIOUS_ACTIVITY",
         user: {


### PR DESCRIPTION
## Proposed changes

OLH-1309 - Send audit event timestamps in seconds

### What changed
For all audit events that we send to TxMA, it now includes three additional fields

- timestamp: number
- event_timestamp_ms: number
- event_timestamp_ms_formatted: string

This allows us to adhere to the structural requirements by TxMA for events they consume.

### Why did it change
To adhere to TxMA structural requirements for audit events.
This was requested as a fix to the existing structure we send, see here: https://gds.slack.com/archives/C011Y5SAY3U/p1702391777834979

### Related links
https://gds.slack.com/archives/C011Y5SAY3U/p1702391777834979


## Checklists

### Environment variables or secrets

- [ ] No environment variables or secrets were added or changed


### Permissions

## Testing

- Deploy to dev environment
-  trigger an audit event
- Verify the structure and content of the event on the _account-mgmt-backend-AuditOutputQueue_ matches expected

## How to review
