### PR TITLE
Adding AIS Account Numbers

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -192,6 +192,18 @@ Mappings:
     production:
       AccountNumber: "499563136613"
 
+  AccountInterventionsService:
+    dev:
+      AccountNumber: "013758878511"
+    build:
+      AccountNumber: "688341086169"
+    staging:
+      AccountNumber: "922902741880"
+    integration:
+      AccountNumber: "217747075921"
+    production:
+      AccountNumber: "324281879537"
+
   TxmaAccounts:
     dev:
       AccountNumber: "248098332657"
@@ -1112,6 +1124,21 @@ Resources:
                       !Ref Environment,
                       "AccountNumber",
                     ]
+                  - ":root"
+            Action: sns:Subscribe
+            Resource:
+              - !Ref UserAccountDeletionTopic
+          - Sid: "Allow Account Interventions Service"
+            Effect: Allow
+            Principal:
+              AWS: !Join
+                - ""
+                - - "arn:aws:iam::"
+                  - !FindInMap [
+                    AccountInterventionsService,
+                    !Ref Environment,
+                    "AccountNumber",
+                  ]
                   - ":root"
             Action: sns:Subscribe
             Resource:
@@ -2316,6 +2343,23 @@ Resources:
                         !Ref Environment,
                         "AccountNumber",
                       ]
+                    - ":root"
+              Action: kms:Decrypt
+              Resource:
+                - "*"
+            - !Ref AWS::NoValue
+          - !If
+            - "IsNotDevelopment"
+            - Effect: Allow
+              Principal:
+                AWS: !Join
+                  - ""
+                  - - "arn:aws:iam::"
+                    - !FindInMap [
+                      AccountInterventionsService,
+                      !Ref Environment,
+                      "AccountNumber",
+                    ]
                     - ":root"
               Action: kms:Decrypt
               Resource:


### PR DESCRIPTION
## Proposed changes

This PR merges changes to the template to allow AIS solution to receive notification from the the `UserAccountDeletionTopic` 

### What changed

- added new mapping section with account numbers for all environment for the AIS solution (please note that dev, build, and staging account numbers are going to be same as in the `CredentialStoreAccounts` mapping, as those accounts are shared between the two solutions)
- added `sns:Subscribe` permission on the `UserAccountDeletionTopic` for AIS accounts 
- added `kms:Decrypt` permission on `SnsKmsKey` for AIS accounts

### Why did it change

To allow the AIS solution to receive messages from the UserAccountDeletionTopic

### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists

<!-- Merging this PR deploys to production. Please answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Permissions

- [x] This PR adds or changes permissions

## Testing

<!-- Provide a summary of any manual testing you've done, for example deploying the branch to dev -->

## How to review

<!-- Describe any non-standard steps to review this work, or higlight any areas that you'd like the reviewer's opinion on -->
