### PR TITLE
OLH-1355 - Disable Deployment of FormatActivityLog to Prod and Integration

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -90,6 +90,12 @@ Conditions:
       - !Equals [!Ref Environment, integration]
       - !Equals [!Ref Environment, production]
 
+  IsNotProdOrIntegration:
+    Fn::Or:
+      - !Equals [ !Ref Environment, build ]
+      - !Equals [ !Ref Environment, dev ]
+      - !Equals [ !Ref Environment, staging ]
+
 Globals:
   Function:
     Environment:
@@ -1659,6 +1665,7 @@ Resources:
   #######################
   FormatActivityLogFunction:
     Type: AWS::Serverless::Function
+    Condition: IsNotProdOrIntegration
     DependsOn:
       - FormatActivityLogFunctionLogGroup
     Properties:


### PR DESCRIPTION
## Proposed changes

OLH-1355 - Disable Deployment of FormatActivityLog to Prod and Integration

### What changed

OLH-1355 - Disable Deployment of FormatActivityLog to Prod and Integration

### Why did it change

So that TxMA events are not picked up and sent to the activity log database because with the latest changes, the current TxMA events will fail validation and the write to dynamo is timing out

### Related links
https://govukverify.atlassian.net/browse/OLH-1353 
https://govukverify.atlassian.net/browse/OLH-1352
<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists


### Environment variables or secrets


- [ ] Added parameters **`IsNotProdOrIntegration`** to Cloudformation template

### Permissions

## Testing

Deploy successfully to dev environment

## How to review
