### PR TITLE
OLH-1353 - Align Lambda to Process TxMA Event Structure

### DIFF
--- a/lambda/format-activity-log/format-activity-log.ts
+++ b/lambda/format-activity-log/format-activity-log.ts
@@ -19,8 +19,8 @@ const createNewActivityLogEntryFromTxmaEvent = (
 ): ActivityLogEntry => ({
   event_id: txmaEvent.event_id,
   event_type: txmaEvent.event_name,
-  session_id: txmaEvent.session_id,
-  user_id: txmaEvent.user_id,
+  session_id: txmaEvent.user?.session_id,
+  user_id: txmaEvent.user?.user_id,
   client_id: txmaEvent.client_id,
   timestamp: txmaEvent.timestamp,
   reported_suspicious: REPORT_SUSPICIOUS_ACTIVITY_DEFAULT,
@@ -29,12 +29,10 @@ const createNewActivityLogEntryFromTxmaEvent = (
 export const validateTxmaEventBody = (txmaEvent: TxmaEvent): void => {
   if (
     txmaEvent.event_id === undefined ||
-    txmaEvent.user_id === undefined ||
-    txmaEvent.timestamp === undefined ||
-    txmaEvent.timestamp_ms === undefined ||
-    txmaEvent.timestamp_ms_formatted === undefined ||
     txmaEvent.event_name === undefined ||
-    txmaEvent.session_id === undefined ||
+    txmaEvent.user?.user_id === undefined ||
+    txmaEvent.timestamp === undefined ||
+    txmaEvent.user?.session_id === undefined ||
     txmaEvent.client_id === undefined
   ) {
     throw new Error(`Could not validate TXMA Event Body`);

--- a/lambda/format-activity-log/models.ts
+++ b/lambda/format-activity-log/models.ts
@@ -7,12 +7,10 @@ export interface UserData {
 export interface TxmaEvent {
   event_id: string;
   event_name: string;
-  session_id: string;
-  user_id: string;
   timestamp: number;
-  timestamp_ms: number;
-  timestamp_ms_formatted: string;
+  timestamp_formatted: string;
   client_id: string;
+  user: UserData;
 }
 
 export interface ActivityLogEntry {

--- a/lambda/format-activity-log/tests/format-activity-log.test.ts
+++ b/lambda/format-activity-log/tests/format-activity-log.test.ts
@@ -99,6 +99,28 @@ describe("validateTxmaEventBody", () => {
     expect(validateTxmaEventBody(MUTABLE_TXMA_EVENT)).toBe(undefined);
   });
 
+  test("throws error when event_id is missing", () => {
+    const invalidTxmaEvent = {
+      ...MUTABLE_TXMA_EVENT,
+      event_id: undefined,
+    };
+    const txmaEvent = JSON.parse(JSON.stringify(invalidTxmaEvent));
+    expect(() => {
+      validateTxmaEventBody(txmaEvent);
+    }).toThrowError();
+  });
+
+  test("throws error when event name is missing", () => {
+    const invalidTxmaEvent = {
+      ...MUTABLE_TXMA_EVENT,
+      event_name: undefined,
+    };
+    const txmaEvent = JSON.parse(JSON.stringify(invalidTxmaEvent));
+    expect(() => {
+      validateTxmaEventBody(txmaEvent);
+    }).toThrowError();
+  });
+
   test("throws error when client_id is missing", () => {
     const invalidTxmaEvent = {
       ...MUTABLE_TXMA_EVENT,
@@ -121,43 +143,10 @@ describe("validateTxmaEventBody", () => {
     }).toThrowError();
   });
 
-  test("throws error when event name is missing", () => {
-    const invalidTxmaEvent = {
-      ...MUTABLE_TXMA_EVENT,
-      event_name: undefined,
-    };
-    const txmaEvent = JSON.parse(JSON.stringify(invalidTxmaEvent));
-    expect(() => {
-      validateTxmaEventBody(txmaEvent);
-    }).toThrowError();
-  });
-
-  test("throws error when timestamp ms is missing", () => {
-    const invalidTxmaEvent = {
-      ...MUTABLE_TXMA_EVENT,
-      timestamp_ms: undefined,
-    };
-    const txmaEvent = JSON.parse(JSON.stringify(invalidTxmaEvent));
-    expect(() => {
-      validateTxmaEventBody(txmaEvent);
-    }).toThrowError();
-  });
-
-  test("throws error when timestamp ms formatted is missing", () => {
-    const invalidTxmaEvent = {
-      ...MUTABLE_TXMA_EVENT,
-      timestamp_ms_formatted: undefined,
-    };
-    const txmaEvent = JSON.parse(JSON.stringify(invalidTxmaEvent));
-    expect(() => {
-      validateTxmaEventBody(txmaEvent);
-    }).toThrowError();
-  });
-
   test(" throws error when user_id is missing", () => {
     const invalidTxmaEvent = {
       ...MUTABLE_TXMA_EVENT,
-      user_id: undefined,
+      user: { user_id: undefined, session_id: "123" },
     };
     const txmaEvent = JSON.parse(JSON.stringify(invalidTxmaEvent));
     expect(() => {
@@ -168,7 +157,7 @@ describe("validateTxmaEventBody", () => {
   test("throws error when session_id  is missing", () => {
     const invalidTxmaEvent = {
       ...MUTABLE_TXMA_EVENT,
-      session_id: undefined,
+      user: { user_id: "123", session_id: undefined },
     };
     const txmaEvent = JSON.parse(JSON.stringify(invalidTxmaEvent));
     expect(() => {

--- a/lambda/format-activity-log/tests/test-helper.ts
+++ b/lambda/format-activity-log/tests/test-helper.ts
@@ -1,5 +1,5 @@
 import { DynamoDBRecord, DynamoDBStreamEvent } from "aws-lambda";
-import { TxmaEvent, ActivityLogEntry } from "../models";
+import { TxmaEvent, ActivityLogEntry, UserData } from "../models";
 
 export const txmaEventId = "12345678";
 export const eventType = "AUTH_AUTH_CODE_ISSUED";
@@ -12,15 +12,19 @@ export const queueUrl = "http://my_queue_url";
 export const messageId = "MyMessageId";
 export const tableName = "tableName";
 
+const MUTABLE_USER_DATA: UserData = {
+  user_id: userId,
+  govuk_signin_journey_id: "234567",
+  session_id: sessionId,
+};
+
 export const MUTABLE_TXMA_EVENT: TxmaEvent = {
   event_id: txmaEventId,
   timestamp,
-  timestamp_ms_formatted: "x",
-  timestamp_ms: 1234,
+  timestamp_formatted: "x",
   event_name: eventType,
   client_id: clientId,
-  session_id: sessionId,
-  user_id: userId,
+  user: MUTABLE_USER_DATA,
 };
 
 export const MUTABLE_ACTIVITY_LOG_ENTRY: ActivityLogEntry = {
@@ -48,30 +52,17 @@ const generateDynamoSteamRecord = (
       timestamp: { N: `${Date.now()}` },
       event: {
         M: {
-          event_id: {
-            S: txmaEventId,
+          event_name: { S: txmaEventName },
+          event_id: { S: txmaEventId },
+          user: {
+            M: {
+              user_id: { S: userId },
+              session_id: { S: sessionId },
+            },
           },
-          event_name: {
-            S: `${txmaEventName}`,
-          },
-          timestamp: {
-            N: `${timestamp}`,
-          },
-          timestamp_ms_formatted: {
-            S: "12345",
-          },
-          timestamp_ms: {
-            N: `${timestamp}`,
-          },
-          client_id: {
-            S: clientId,
-          },
-          session_id: {
-            S: sessionId,
-          },
-          user_id: {
-            S: userId,
-          },
+          client_id: { S: clientId },
+          txma: { M: { configVersion: { S: "2.2.1" } } },
+          timestamp: { N: `${timestamp}` },
         },
       },
     },


### PR DESCRIPTION
## Proposed changes
OLH-1353 - Align Lambda to Process TxMA Event Structure

### What changed

Due to the data structure change, an alignment needs to happen, we receive the TxMA event as it is and massage it into the new data structure

### Why did it change

So that submitted events can be handled correctly, i.e. we generate an activity log entry, add to the correct Activity log to Write Queue and consequently saved int he activity_log dynamo db table.

### Related links

## Checklists

<!-- Merging this PR deploys to production. Please answer accurately. -->

### Environment variables or secrets

- [ ] No environment variables or secrets were added or changed

### Permissions

## Testing
Add a valid TxMa event to the raw events table, and it should be picked up, transformed to an activity log and added to the activity log to write queue
## How to review
