### PR TITLE
OLH-1300: Update structure of SNS message

### DIFF
--- a/docs/adr/0008-report-a-suspicious-activity.md
+++ b/docs/adr/0008-report-a-suspicious-activity.md
@@ -36,16 +36,11 @@ The format of the SNS payload should be
     reported: true
     reported_event: {
         event_type: EVENT_TYPE,
-        session_id: SESSION_ID,
+        session_id: EVENT_SESSION_ID,
         user_id: USER_ID,
         timestamp: TIMESTAMP,
-        activities: {
-            type: EVENT_TYPE,
-            client_id: CLIENT_ID
-            timestamp: TIMESTAMP,
-            event_id: EVENT_ID
-        }
-
+        client_id: CLIENT_ID
+        event_id: EVENT_ID
     }
 
 }


### PR DESCRIPTION


## Proposed changes

### What changed

Update the structure of the message the frontend sends to SNS when a user reports an activity. 
### Why did it change

In #161 we simplified the data model for items in the activity log table. We missed it at the time, but this new data model also means we need to change the structure of the message the frontend sends to SNS as the `activities` sub-object no longer makes sense.

### Related links

#161 

## Checklists

<!-- Merging this PR deploys to production. Please answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed
