### PR TITLE
INCIDEN-657: Don't log full SQS message

### DIFF
--- a/lambda/format-activity-log/format-activity-log.ts
+++ b/lambda/format-activity-log/format-activity-log.ts
@@ -55,7 +55,6 @@ export const sendSqsMessage = async (
     QueueUrl: queueUrl,
     MessageBody: messageBody,
   };
-  console.log(`[Send Message Request is] :  ${JSON.stringify(message)}`);
   const result = await client.send(new SendMessageCommand(message));
   return result.MessageId;
 };


### PR DESCRIPTION


## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->

### What changed

Remove line which logs the full SQS message when sending.

### Why did it change

This lambda was deployed to production for ~45 minutes before we pulled it. During that time it processed 281 messages, errored on each one and logged the full message to Cloudwatch when passing it on to the DLQ. These messages contained user IDs which shouldn't be sent to Cloudwatch or Splunk.

This was likely left in while doing testing and can be safely removed. We already have error handling and sensible log messages for when something goes wrong which include the message ID if we need to retrieve the message later.

### Related links

https://govukverify.atlassian.net/browse/INCIDEN-657