### PR TITLE
OLH-1053 update reported flag on activity

### DIFF
--- a/src/common/model.ts
+++ b/src/common/model.ts
@@ -1,3 +1,5 @@
+import { QueryCommandOutput } from "@aws-sdk/lib-dynamodb";
+
 export interface UserData {
   user_id: string;
   email?: string;

--- a/src/common/model.ts
+++ b/src/common/model.ts
@@ -1,5 +1,3 @@
-import { QueryCommandOutput } from "@aws-sdk/lib-dynamodb";
-
 export interface UserData {
   user_id: string;
   email?: string;

--- a/src/common/redact.ts
+++ b/src/common/redact.ts
@@ -1,0 +1,20 @@
+const redact = (jsonString: string, fieldsToRedact: string[]): string => {
+  const jsonObject: Record<string, unknown> = JSON.parse(jsonString);
+
+  function redact(obj: Record<string, unknown>) {
+    for (const key in obj) {
+      if (typeof obj[key] === "object") {
+        redact(obj[key] as Record<string, unknown>);
+      } else {
+        if (fieldsToRedact.includes(key)) {
+          obj[key] = "REDACTED";
+        }
+      }
+    }
+  }
+
+  redact(jsonObject);
+  return JSON.stringify(jsonObject);
+};
+
+export default redact;

--- a/src/mark-suspicious-activity-as-reported.ts
+++ b/src/mark-suspicious-activity-as-reported.ts
@@ -9,6 +9,7 @@ import {
   DynamoDBDocumentClient,
   UpdateCommand,
   QueryCommand,
+  QueryCommandOutput,
 } from "@aws-sdk/lib-dynamodb";
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { ActivityLogEntry } from "./common/model";
@@ -43,11 +44,11 @@ export const getItemByEventId = async (
     },
   });
 
-  const result = await dynamoDocClient.send(getItem);
+  const result: QueryCommandOutput = await dynamoDocClient.send(getItem);
 
-  if (result?.Items?.length !== 1) {
+  if (result.Items?.length !== 1) {
     throw Error(
-      `Expecting exactly 1 result from getItemByEventId, but got ${result?.Items?.length}`
+      `Expecting exactly 1 result from getItemByEventId, but got ${result.Items?.length}`
     );
   }
   const item = result.Items[0];
@@ -87,6 +88,11 @@ export const handler = async (event: SNSEvent): Promise<void> => {
         if (!INDEX_NAME) {
           throw new Error(
             "Cannot handle event as index name has not been provided in the environment"
+          );
+        }
+        if (!DLQ_URL) {
+          throw new Error(
+            "Cannot handle event as DLQ url has not been provided in the environment"
           );
         }
         const receivedEvent: ActivityLogEntry = JSON.parse(record.Sns.Message);

--- a/src/mark-suspicious-activity-as-reported.ts
+++ b/src/mark-suspicious-activity-as-reported.ts
@@ -1,0 +1,109 @@
+import { SNSEvent } from "aws-lambda";
+import {
+  SendMessageCommand,
+  SendMessageCommandOutput,
+  SendMessageRequest,
+  SQSClient,
+} from "@aws-sdk/client-sqs";
+import {
+  DynamoDBDocumentClient,
+  UpdateCommand,
+  QueryCommand,
+} from "@aws-sdk/lib-dynamodb";
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { ActivityLogEntry } from "./common/model";
+
+const dynamoClient = new DynamoDBClient({});
+const dynamoDocClient = DynamoDBDocumentClient.from(dynamoClient);
+
+export const sendSqsMessage = async (
+  messageBody: string,
+  queueUrl: string | undefined
+): Promise<SendMessageCommandOutput> => {
+  const { AWS_REGION } = process.env;
+  const client = new SQSClient({ region: AWS_REGION });
+  const message: SendMessageRequest = {
+    QueueUrl: queueUrl,
+    MessageBody: messageBody,
+  };
+  return client.send(new SendMessageCommand(message));
+};
+
+export const getItemByEventId = async (
+  tableName: string,
+  indexName: string,
+  eventId: string
+): Promise<{ user_id: string; timestamp: number }> => {
+  const getItem = new QueryCommand({
+    TableName: tableName,
+    IndexName: indexName,
+    KeyConditionExpression: "event_id = :event_id",
+    ExpressionAttributeValues: {
+      ":event_id": eventId,
+    },
+  });
+
+  const result = await dynamoDocClient.send(getItem);
+
+  if (result?.Items?.length !== 1) {
+    throw Error(
+      `Expecting exactly 1 result from getItemByEventId, but got ${result?.Items?.length}`
+    );
+  }
+  const item = result.Items[0];
+  return { user_id: item.user_id, timestamp: item.timestamp };
+};
+
+export const markEventAsReported = async (
+  tableName: string,
+  user_id: string,
+  timestamp: number
+) => {
+  const command = new UpdateCommand({
+    TableName: tableName,
+    Key: {
+      user_id,
+      timestamp,
+    },
+    UpdateExpression: "set reported_suspicious = :reported_suspicious",
+    ExpressionAttributeValues: {
+      ":reported_suspicious": true,
+    },
+  });
+
+  return dynamoDocClient.send(command);
+};
+
+export const handler = async (event: SNSEvent): Promise<void> => {
+  const { DLQ_URL, TABLE_NAME, INDEX_NAME } = process.env;
+  await Promise.all(
+    event.Records.map(async (record) => {
+      try {
+        if (!TABLE_NAME) {
+          throw new Error(
+            "Cannot handle event as table name has not been provided in the environment"
+          );
+        }
+        if (!INDEX_NAME) {
+          throw new Error(
+            "Cannot handle event as index name has not been provided in the environment"
+          );
+        }
+        const receivedEvent: ActivityLogEntry = JSON.parse(record.Sns.Message);
+
+        const { user_id, timestamp } = await getItemByEventId(
+          TABLE_NAME,
+          INDEX_NAME,
+          receivedEvent.event_id
+        );
+        await markEventAsReported(TABLE_NAME, user_id, timestamp);
+      } catch (err) {
+        const response = await sendSqsMessage(record.Sns.Message, DLQ_URL);
+        console.error(
+          `[Message sent to DLQ] with message id = ${response.MessageId}`,
+          err as Error
+        );
+      }
+    })
+  );
+};

--- a/src/tests/mark-suspicious-activity-as-reported.test.ts
+++ b/src/tests/mark-suspicious-activity-as-reported.test.ts
@@ -1,0 +1,172 @@
+import "aws-sdk-client-mock-jest";
+import {
+  getItemByEventId,
+  handler,
+  markEventAsReported,
+  sendSqsMessage,
+} from "../mark-suspicious-activity-as-reported";
+import { SendMessageCommand, SQSClient } from "@aws-sdk/client-sqs";
+import { mockClient } from "aws-sdk-client-mock";
+import {
+  DynamoDBDocumentClient,
+  QueryCommand,
+  UpdateCommand,
+} from "@aws-sdk/lib-dynamodb";
+import {
+  TEST_SNS_EVENT_WITH_EVENT,
+  queueUrl,
+  eventId,
+  indexName,
+  tableName,
+  timestamp,
+  userId,
+} from "./testFixtures";
+
+const sqsMock = mockClient(SQSClient);
+const dynamoMock = mockClient(DynamoDBDocumentClient);
+
+describe("getItemByEventId", () => {
+  beforeEach(() => {
+    dynamoMock.reset();
+    dynamoMock.on(QueryCommand).resolves({
+      Items: [{ user_id: userId, timestamp: timestamp }],
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("correctly retreives the event from the datastore", async () => {
+    await getItemByEventId(tableName, indexName, eventId);
+    expect(dynamoMock.commandCalls(QueryCommand).length).toEqual(1);
+    expect(dynamoMock).toHaveReceivedCommandWith(QueryCommand, {
+      TableName: tableName,
+      IndexName: indexName,
+      ExpressionAttributeValues: {
+        ":event_id": eventId,
+      },
+    });
+  });
+
+  test("returns the user id and timestamp", async () => {
+    const response = await getItemByEventId(tableName, indexName, eventId);
+    expect(response).toEqual({ user_id: userId, timestamp: timestamp });
+  });
+});
+
+describe("markEventAsReported", () => {
+  beforeEach(() => {
+    dynamoMock.reset();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("updates the correct event as reported", async () => {
+    await markEventAsReported(tableName, userId, timestamp);
+    expect(dynamoMock.commandCalls(UpdateCommand).length).toEqual(1);
+    expect(dynamoMock).toHaveReceivedCommandWith(UpdateCommand, {
+      TableName: tableName,
+      Key: {
+        user_id: userId,
+        timestamp: timestamp,
+      },
+      UpdateExpression: "set reported_suspicious = :reported_suspicious",
+      ExpressionAttributeValues: {
+        ":reported_suspicious": true,
+      },
+    });
+  });
+});
+
+describe("handler", () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+
+    process.env = { ...OLD_ENV };
+    process.env.TABLE_NAME = tableName;
+    process.env.DLQ_URL = queueUrl;
+    process.env.INDEX_NAME = indexName;
+
+    dynamoMock.reset();
+
+    dynamoMock.on(QueryCommand).resolves({
+      Items: [{ user_id: userId, timestamp: timestamp }],
+    });
+
+    sqsMock.on(SendMessageCommand).resolves({ MessageId: "MessageId" });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    process.env = OLD_ENV;
+  });
+
+  test("the handler makes the correct queries", async () => {
+    await handler(TEST_SNS_EVENT_WITH_EVENT);
+    expect(dynamoMock.commandCalls(QueryCommand).length).toEqual(1);
+    expect(dynamoMock.commandCalls(UpdateCommand).length).toEqual(1);
+
+    expect(dynamoMock).toHaveReceivedCommandWith(QueryCommand, {
+      TableName: tableName,
+      IndexName: indexName,
+      KeyConditionExpression: "event_id = :event_id",
+      ExpressionAttributeValues: {
+        ":event_id": eventId,
+      },
+    });
+
+    expect(dynamoMock).toHaveReceivedCommandWith(UpdateCommand, {
+      TableName: tableName,
+      Key: {
+        user_id: userId,
+        timestamp: timestamp,
+      },
+      UpdateExpression: "set reported_suspicious = :reported_suspicious",
+      ExpressionAttributeValues: {
+        ":reported_suspicious": true,
+      },
+    });
+  });
+
+  test("the handler sends to DLQ if there is an error", async () => {
+    process.env.TABLE_NAME = undefined;
+    await handler(TEST_SNS_EVENT_WITH_EVENT);
+    expect(sqsMock.commandCalls(SendMessageCommand).length).toEqual(1);
+  });
+});
+
+describe("sendSQSMessage", () => {
+  beforeEach(() => {
+    sqsMock.reset();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("send sqs successfully", async () => {
+    const txMAEvent = {
+      component_id: "https://home.account.gov.uk",
+      event_name: "HOME_REPORT_SUSPICIOUS_ACTIVITY",
+      extensions: {
+        reported_session_id: "111111",
+      },
+      user: {
+        persistent_session_id: "111111",
+        session_id: "111112",
+        user_id: "1234567",
+      },
+    };
+    await sendSqsMessage(JSON.stringify(txMAEvent), "TXMA_QUEUE_URL");
+    expect(sqsMock.commandCalls(SendMessageCommand).length).toEqual(1);
+    expect(sqsMock).toHaveReceivedCommandWith(SendMessageCommand, {
+      QueueUrl: "TXMA_QUEUE_URL",
+      MessageBody: JSON.stringify(txMAEvent),
+    });
+  });
+});

--- a/src/tests/redact.test.ts
+++ b/src/tests/redact.test.ts
@@ -1,0 +1,122 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import redact from "../common/redact";
+
+describe("Redact tests", (): void => {
+  it("Redacts a field from a JSON document.", (): void => {
+    // Arrange
+    const json: string = `
+      {
+        "name": "John Doe",
+        "age": 42,
+        "address": {
+          "house": 12,
+          "street": "Arcadia Avenue",
+          "town": "Hyperion",
+          "postcode": "HY1 1AA"
+        }
+      }
+    `;
+
+    // Act
+    const result: string = redact(json, ["name"]);
+
+    // Assert
+    const resultAsObject: any = JSON.parse(result);
+    expect(resultAsObject["name"]).toEqual("REDACTED");
+  });
+  it("Redacts multiple fields with the same name from a JSON document.", (): void => {
+    // Arrange
+    const json: string = `
+      {
+        "name": "John Doe",
+        "age": 42,
+        "address": {
+          "house": 12,
+          "name": "Dunroamin",
+          "street": "Arcadia Avenue",
+          "town": "Hyperion",
+          "postcode": "HY1 1AA"
+        }
+      }
+    `;
+
+    // Act
+    const result: string = redact(json, ["name"]);
+
+    // Assert
+    const resultAsObject: any = JSON.parse(result);
+    expect(resultAsObject["name"]).toEqual("REDACTED");
+    expect(resultAsObject["address"]["name"]).toEqual("REDACTED");
+  });
+  it("Redacts multiple fields with different names from a JSON document.", (): void => {
+    // Arrange
+    const json: string = `
+      {
+        "name": "John Doe",
+        "age": 42,
+        "address": {
+          "house": 12,
+          "street": "Arcadia Avenue",
+          "town": "Hyperion",
+          "postcode": "HY1 1AA"
+        }
+      }
+    `;
+
+    // Act
+    const result: string = redact(json, ["name", "house"]);
+
+    // Assert
+    const resultAsObject: any = JSON.parse(result);
+    expect(resultAsObject["name"]).toEqual("REDACTED");
+    expect(resultAsObject["address"]["house"]).toEqual("REDACTED");
+  });
+  it("Redacts multiple fields from a list of names from a JSON document.", (): void => {
+    // Arrange
+    const json: string = `
+      {
+        "name": "John Doe",
+        "age": 42,
+        "address": {
+          "house": 12,
+          "name": "Dunroamin",
+          "street": "Arcadia Avenue",
+          "town": "Hyperion",
+          "postcode": "HY1 1AA"
+        }
+      }
+    `;
+
+    // Act
+    const result: string = redact(json, ["name", "town"]);
+
+    // Assert
+    const resultAsObject: any = JSON.parse(result);
+    expect(resultAsObject["name"]).toEqual("REDACTED");
+    expect(resultAsObject["address"]["name"]).toEqual("REDACTED");
+    expect(resultAsObject["address"]["town"]).toEqual("REDACTED");
+  });
+  it("Does not redact objects.", (): void => {
+    // Arrange
+    const json: string = `
+      {
+        "name": "John Doe",
+        "age": 42,
+        "address": {
+          "house": 12,
+          "street": "Arcadia Avenue",
+          "town": "Hyperion",
+          "postcode": "HY1 1AA"
+        }
+      }
+    `;
+
+    // Act
+    const result: string = redact(json, ["name", "town", "address"]);
+
+    // Assert
+    const resultAsObject: any = JSON.parse(result);
+    expect(resultAsObject["name"]).toEqual("REDACTED");
+    expect(resultAsObject["address"]["town"]).toEqual("REDACTED");
+  });
+});

--- a/src/tests/testFixtures.ts
+++ b/src/tests/testFixtures.ts
@@ -28,11 +28,23 @@ export const randomEventType = "AUTH_OTHER_RANDOM_EVENT";
 export const queueUrl = "http://my_queue_url";
 export const messageId = "MyMessageId";
 export const tableName = "tableName";
+export const indexName = "indexName";
 
 export const user: UserData = {
   user_id: userId,
   session_id: sessionId,
 };
+
+export const TEST_ACTIVITY_LOG_ENTRY: ActivityLogEntry = {
+  event_type: eventType,
+  session_id: sessionId,
+  user_id: userId,
+  timestamp,
+  event_id: eventId,
+  client_id: clientId,
+  reported_suspicious: reportedSuspicious,
+};
+
 export const TEST_USER_DATA: UserData = {
   user_id: "user-id",
   access_token: "access_token",
@@ -67,11 +79,32 @@ export const TEST_SNS_MESSAGE: SNSMessage = {
   Subject: "Subject",
 };
 
+export const TEST_SNS_EVENT_MESSAGE: SNSMessage = {
+  SignatureVersion: "SignatureVersion",
+  Timestamp: "Timestamp",
+  Signature: "Signature",
+  SigningCertUrl: "SigningCertUrl",
+  MessageId: "MessageId",
+  Message: JSON.stringify(TEST_ACTIVITY_LOG_ENTRY),
+  MessageAttributes: {},
+  Type: "Type",
+  UnsubscribeUrl: "unsubscribeUrl",
+  TopicArn: "TopicArn",
+  Subject: "Subject",
+};
+
 export const TEST_SNS_EVENT_RECORD: SNSEventRecord = {
   EventVersion: "1",
   EventSubscriptionArn: "arn",
   EventSource: "source",
   Sns: TEST_SNS_MESSAGE,
+};
+
+export const TEST_SNS_EVENT_RECORD_WITH_EVENT: SNSEventRecord = {
+  EventVersion: "1",
+  EventSubscriptionArn: "arn",
+  EventSource: "source",
+  Sns: TEST_SNS_EVENT_MESSAGE,
 };
 
 export const TEST_SNS_EVENT: SNSEvent = {
@@ -82,14 +115,8 @@ export const TEST_SNS_EVENT_WITH_TWO_RECORDS: SNSEvent = {
   Records: [TEST_SNS_EVENT_RECORD, TEST_SNS_EVENT_RECORD],
 };
 
-export const TEST_ACTIVITY_LOG_ENTRY: ActivityLogEntry = {
-  event_type: eventType,
-  session_id: sessionId,
-  user_id: userId,
-  timestamp,
-  event_id: eventId,
-  client_id: clientId,
-  reported_suspicious: reportedSuspicious,
+export const TEST_SNS_EVENT_WITH_EVENT: SNSEvent = {
+  Records: [TEST_SNS_EVENT_RECORD_WITH_EVENT],
 };
 
 const NO_ACTIVITY_ARRAY = { ...TEST_ACTIVITY_LOG_ENTRY, activities: undefined };

--- a/template.yaml
+++ b/template.yaml
@@ -12,6 +12,9 @@ Parameters:
   ActivityLogStoreTableName:
     Type: String
     Default: activity_logs
+  ActivityLogStoreEventIndexName:
+    Type: String
+    Default: EventIdIndex
   DummyEventStoreTableName:
     Type: String
     Default: dummy_events
@@ -368,10 +371,18 @@ Resources:
           AttributeType: N
         - AttributeName: session_id
           AttributeType: S
+        - AttributeName: event_id
+          AttributeType: S
       GlobalSecondaryIndexes:
         - IndexName: SessionIdIndex
           KeySchema:
             - AttributeName: session_id
+              KeyType: HASH
+          Projection:
+            ProjectionType: ALL
+        - IndexName: !Ref ActivityLogStoreEventIndexName  
+          KeySchema:
+            - AttributeName: event_id
               KeyType: HASH
           Projection:
             ProjectionType: ALL
@@ -2045,6 +2056,141 @@ Resources:
       AlarmActions:
         - !Ref AlarmNotificationTopic
       ActionsEnabled: true
+
+######################
+# Mark Suspicious Activity as Reported
+######################
+  MarkActivityReportedSubscription:
+    Type: AWS::SNS::Subscription
+    Properties:
+      Endpoint: !GetAtt MarkActivityReportedFunction.Arn
+      Protocol: lambda
+      RedrivePolicy:
+        deadLetterTargetArn: !GetAtt MarkActivityReportedDeadLetterQueue.Arn
+      TopicArn: !Ref SuspiciousActivityTopic
+
+
+  MarkActivityReportedDeadLetterQueue:
+    Type: AWS::SQS::Queue
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Properties:
+      MessageRetentionPeriod: 1209600
+      KmsMasterKeyId: !GetAtt QueueKmsKey.Arn
+
+  MarkActivityReportedDeadLetterQueuePolicy:
+    Type: AWS::SQS::QueuePolicy
+    Properties:
+      Queues:
+        - !Ref MarkActivityReportedDeadLetterQueue
+      PolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: sns.amazonaws.com
+            Action: "sqs:SendMessage"
+            Resource: !GetAtt MarkActivityReportedDeadLetterQueue.Arn
+            Condition:
+              ArnEquals:
+                "aws:SourceArn": !Ref SuspiciousActivityTopic
+
+  MarkActivityReportedFunction:
+    DependsOn:
+      - MarkActivityReportedLogGroup
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Sub ${Environment}-${AWS::StackName}-mark-suspicious-activity-reported
+      CodeUri: src
+      DeadLetterQueue:
+        Type: SQS
+        TargetArn: !GetAtt MarkActivityReportedDeadLetterQueue.Arn
+      Handler: mark-suspicious-activity-as-reported.handler
+      PackageType: Zip
+      Role: !GetAtt MarkActivityReportedRole.Arn
+      Environment:
+        Variables:
+          TABLE_NAME: !Ref ActivityLogStoreTableName
+          INDEX_NAME: !Ref ActivityLogStoreEventIndexName
+          DLQ_URL: !Ref MarkActivityReportedDeadLetterQueue
+    Metadata:
+      BuildMethod: esbuild
+      BuildProperties:
+        Minify: true
+        Target: "es2020"
+        Sourcemap: true
+        EntryPoints:
+          - mark-suspicious-activity-as-reported.ts
+
+  MarkActivityReportedRole:
+    Type: AWS::IAM::Role
+    Properties:
+      PermissionsBoundary: !If
+        - UsePermissionsBoundary
+        - !Ref PermissionsBoundary
+        - !Ref AWS::NoValue
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
+        - !Ref MarkActivityReportedPolicy
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - "sts:AssumeRole"
+
+  MarkActivityReportedPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - sqs:SendMessage
+            Resource:
+              - !GetAtt MarkActivityReportedDeadLetterQueue.Arn
+              - !GetAtt AuditOutputQueue.Arn
+          - Effect: Allow
+            Action:
+              - kms:Decrypt
+              - kms:GenerateDataKey*
+              - kms:ReEncrypt*
+            Resource:
+              - !GetAtt QueueKmsKey.Arn
+              - !GetAtt LoggingKmsKey.Arn
+              - !GetAtt LambdaKMSKey.Arn
+              - !GetAtt AuditEncryptionKey.Arn
+              - !GetAtt DatabaseKmsKey.Arn
+          - Effect: Allow
+            Action:
+              - dynamodb:UpdateItem
+              - dynamodb:Query
+            Resource:
+              - !GetAtt UserActivityLogStore.Arn
+              - !Sub
+                - "${Arn}/*"
+                - Arn: !GetAtt UserActivityLogStore.Arn
+
+  MarkActivityReportedInvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      Principal: sns.amazonaws.com
+      SourceArn:
+        Ref: SuspiciousActivityTopic
+      FunctionName: !GetAtt MarkActivityReportedFunction.Arn
+
+  MarkActivityReportedLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/${Environment}-${AWS::StackName}-mark-suspicious-activity-reported"
+      RetentionInDays: 30
+      KmsKeyId: !GetAtt LoggingKmsKey.Arn
+
 
   ######################
   # Send Suspicious Activity to TxMA


### PR DESCRIPTION
## Proposed changes

When a user reports an activity as suspicious, we should record that in the activity log, so that we can ensure we don't report things twice, and provide feedback to the user.

### What changed

- Create a new lambda, and all the infrastructure that goes along with that (log groups, policies etc...), in the CloudFormation template
- Add a secondary index to the `activity_log` table, so that we can query the table based on the `event_id`
- When the new lambda is triggered, we retrieve the event from the event log (based on the event_id), and update it, setting `reported_suspicious` to `true`

### Why did it change

When we build functionality for users to report activity as suspicious, we want to a) give feedback to the user, and b) ensure that we don't make multiple tickets in zendesk.

By setting this flag to true, we can show that to the user, so that they know we have received the report. This will work even if there is an issue with Zendesk, and we haven't got a ticket number yet.

### Related links

https://github.com/govuk-one-login/di-account-management-backend/pull/181

## Checklists

<!-- Merging this PR deploys to production. Please answer accurately. -->

### Environment variables or secrets

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [X] Added parameters to Cloudformation template
- [X] Added new environment variable

## Testing

I manually tested this by...

Deploying the changes to the dev environment

Getting an `event_id` from the `activity_log` table (through the AWS console)
<img width="1434" alt="Screenshot 2024-01-30 at 14 22 01" src="https://github.com/govuk-one-login/di-account-management-backend/assets/748653/e37a2417-bf2d-4e07-b424-45fea9acfc9d">

Publishing a message on the `SuspiciousActivity` topic with the following body (replacing event_id with the one I got in the previous step)
```
{
  "event_id": "b62c6ec9-30e6-4f7d-9769-02e25b81baf6",
  "event_name": "event_name",
  "timestamp": 1609462861,
  "timestamp_formatted": "timestamp_formatted",
  "client_id": "client_id",
  "user": {
    "user_id": "user_id",
    "session_id": "session_id",
    "govuk_signin_journey_id": "govuk_signin_journey_id"
  },
  "reported_suspicious": true
}
```

Refreshing the DyanamoDB view, and checking that the `reported_suspicious` property has been set to true for the event I chose.
