### PR TITLE
OLH-1299 Add GeneratorKey and WrappingKey to template outputs

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -2934,6 +2934,14 @@ Resources:
               Service: lambda.amazonaws.com
             Action: secretsmanager:GetSecretValue # pragma: allowlist secret
             Resource: !Ref StorageVerificationSecret
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: secretsmanager:GetSecretValue
+            Resource: !Ref StorageVerificationSecret
+            Condition:
+              ArnLike:
+                aws:SourceArn: !Sub arn:aws:iam::${AWS::AccountId}:role/${AccountManagementFrontendStackName}-TaskRole
 
   BackupWrappingKeyArnSSM:
     Type: AWS::SSM::Parameter
@@ -2968,3 +2976,15 @@ Resources:
       Name: !Sub "/${AWS::StackName}/SNS/SuspiciousActivity/ARN"
       Type: String
       Value: !Ref SuspiciousActivityTopic
+
+Outputs:
+  GeneratorKey:
+    Description: A generator key for generating a plaintext data key
+    Value: !GetAtt GeneratorKey.Arn
+    Export:
+      Name: !Sub "${AWS::StackName}-GeneratorKey"
+  WrappingKey:
+    Description: A key used to encrypt the data key for envelope encryption
+    Value: !GetAtt WrapperKey.Arn
+    Export:
+      Name: !Sub "${AWS::StackName}-WrappingKey"


### PR DESCRIPTION
## Proposed changes

Added new policies for the frontend

### What changed

GENERATOR_KEY_ARN and WRAPPER_KEY_ARN permissions to the frontend for envelop encryption

### Why did it change

So the frontend can decrypt data from our activity logs table

### Related links

https://govukverify.atlassian.net/browse/OLH-1299

https://github.com/govuk-one-login/di-account-management-backend/blob/main/docs/adr/0010-simplify-activity-log-data-structure-pipeline.md

https://github.com/govuk-one-login/di-account-management-frontend/pull/1172

## Checklists

<!-- Merging this PR deploys to production. Please answer accurately. -->

### Environment variables or secrets

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Added GeneratorKey and WrapperKey outputs to Cloudformation template

### Permissions

- [ ] This PR adds or changes permissions

## Testing

Deployed before deploying frontend PR and tested directly from the frontend

## How to review

Once deployed navigate to https://home.dev.account.gov.uk/security/sign-in-history 
Activity logs should be displayed in the page

