### PR TITLE
OLH-1410 Change the primary key for the activity log table

### DIFF
--- a/src/delete-activity-log.ts
+++ b/src/delete-activity-log.ts
@@ -33,7 +33,7 @@ export const validateUserData = (userData: UserData): UserData => {
   throw new Error(`userData did not have a user_id`);
 };
 
-export const getAllActivitiesForUser = async (
+export const getAllActivityLogEntriesForUser = async (
   tableName: string,
   userData: UserData
 ): Promise<ActivityLogEntry[] | undefined> => {
@@ -126,10 +126,10 @@ export const handler = async (event: SNSEvent): Promise<void> => {
 
         const userData: UserData = JSON.parse(record.Sns.Message);
         validateUserData(userData);
-        const activityRecords: ActivityLogEntry[] | undefined =
-          await getAllActivitiesForUser(TABLE_NAME, userData);
-        if (activityRecords) {
-          await batchDeleteActivityLog(TABLE_NAME, activityRecords);
+        const activityLogEntries: ActivityLogEntry[] | undefined =
+          await getAllActivityLogEntriesForUser(TABLE_NAME, userData);
+        if (activityLogEntries) {
+          await batchDeleteActivityLog(TABLE_NAME, activityLogEntries);
         }
       } catch (err) {
         console.error("Error in handler", err);

--- a/src/mark-activity-reported.ts
+++ b/src/mark-activity-reported.ts
@@ -9,6 +9,7 @@ import { DynamoDBDocumentClient, UpdateCommand } from "@aws-sdk/lib-dynamodb";
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { ActivityLogEntry } from "./common/model";
 import redact from "./common/redact";
+import assert from "node:assert";
 
 const dynamoClient = new DynamoDBClient({});
 const dynamoDocClient = DynamoDBDocumentClient.from(dynamoClient);
@@ -51,16 +52,9 @@ export const handler = async (event: SNSEvent): Promise<void> => {
   await Promise.all(
     event.Records.map(async (record) => {
       try {
-        if (!TABLE_NAME) {
-          throw new Error(
-            "Cannot handle event as table name has not been provided in the environment"
-          );
-        }
-        if (!DLQ_URL) {
-          throw new Error(
-            "Cannot handle event as DLQ url has not been provided in the environment"
-          );
-        }
+        assert(DLQ_URL);
+        assert(TABLE_NAME);
+
         const receivedEvent: ActivityLogEntry = JSON.parse(record.Sns.Message);
 
         await markEventAsReported(

--- a/src/mark-activity-reported.ts
+++ b/src/mark-activity-reported.ts
@@ -5,12 +5,7 @@ import {
   SendMessageRequest,
   SQSClient,
 } from "@aws-sdk/client-sqs";
-import {
-  DynamoDBDocumentClient,
-  UpdateCommand,
-  QueryCommand,
-  QueryCommandOutput,
-} from "@aws-sdk/lib-dynamodb";
+import { DynamoDBDocumentClient, UpdateCommand } from "@aws-sdk/lib-dynamodb";
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { ActivityLogEntry } from "./common/model";
 import redact from "./common/redact";
@@ -31,41 +26,16 @@ export const sendSqsMessage = async (
   return client.send(new SendMessageCommand(message));
 };
 
-export const getItemByEventId = async (
-  tableName: string,
-  indexName: string,
-  eventId: string
-): Promise<{ user_id: string; timestamp: number }> => {
-  const getItem = new QueryCommand({
-    TableName: tableName,
-    IndexName: indexName,
-    KeyConditionExpression: "event_id = :event_id",
-    ExpressionAttributeValues: {
-      ":event_id": eventId,
-    },
-  });
-
-  const result: QueryCommandOutput = await dynamoDocClient.send(getItem);
-
-  if (result.Items?.length !== 1) {
-    throw Error(
-      `Expecting exactly 1 result from getItemByEventId, but got ${result.Items?.length}`
-    );
-  }
-  const item = result.Items[0];
-  return { user_id: item.user_id, timestamp: item.timestamp };
-};
-
 export const markEventAsReported = async (
   tableName: string,
   user_id: string,
-  timestamp: number
+  event_id: string
 ) => {
   const command = new UpdateCommand({
     TableName: tableName,
     Key: {
       user_id,
-      timestamp,
+      event_id,
     },
     UpdateExpression: "set reported_suspicious = :reported_suspicious",
     ExpressionAttributeValues: {
@@ -77,18 +47,13 @@ export const markEventAsReported = async (
 };
 
 export const handler = async (event: SNSEvent): Promise<void> => {
-  const { DLQ_URL, TABLE_NAME, INDEX_NAME } = process.env;
+  const { DLQ_URL, TABLE_NAME } = process.env;
   await Promise.all(
     event.Records.map(async (record) => {
       try {
         if (!TABLE_NAME) {
           throw new Error(
             "Cannot handle event as table name has not been provided in the environment"
-          );
-        }
-        if (!INDEX_NAME) {
-          throw new Error(
-            "Cannot handle event as index name has not been provided in the environment"
           );
         }
         if (!DLQ_URL) {
@@ -98,12 +63,11 @@ export const handler = async (event: SNSEvent): Promise<void> => {
         }
         const receivedEvent: ActivityLogEntry = JSON.parse(record.Sns.Message);
 
-        const { user_id, timestamp } = await getItemByEventId(
+        await markEventAsReported(
           TABLE_NAME,
-          INDEX_NAME,
+          receivedEvent.user_id,
           receivedEvent.event_id
         );
-        await markEventAsReported(TABLE_NAME, user_id, timestamp);
       } catch (err) {
         console.error(
           "Error marking event as reported, sending to DLQ",

--- a/src/tests/delete-activity-log.test.ts
+++ b/src/tests/delete-activity-log.test.ts
@@ -6,7 +6,7 @@ import { BatchWriteItemCommand } from "@aws-sdk/client-dynamodb";
 import {
   batchDeleteActivityLog,
   buildBatchDeletionRequestArray,
-  getAllActivitiesoForUser,
+  getAllActivitiesForUser,
   handler,
   validateUserData,
 } from "../delete-activity-log";
@@ -14,6 +14,7 @@ import { ActivityLogEntry, UserData } from "../common/model";
 import {
   TEST_SNS_EVENT_WITH_TWO_RECORDS,
   TEST_USER_DATA,
+  eventId,
 } from "./testFixtures";
 
 const dynamoMock = mockClient(DynamoDBDocumentClient);
@@ -26,7 +27,7 @@ export const date = new Date();
 export const timestamp = date.valueOf();
 const activityLogEntry: ActivityLogEntry = {
   client_id: "",
-  event_id: "",
+  event_id: eventId,
   reported_suspicious: false,
   event_type: eventType,
   session_id: sessionId,
@@ -52,7 +53,7 @@ const deleteRequest = {
   DeleteRequest: {
     Key: {
       user_id: { S: userId },
-      timestamp: { N: timestamp.toString() },
+      event_id: { S: eventId },
     },
   },
 };
@@ -61,6 +62,7 @@ describe("deleteUserData", () => {
   beforeEach(() => {
     dynamoMock.reset();
     process.env.TABLE_NAME = "TABLE_NAME";
+    process.env.DQL_URL = "DQL_URL";
     // The mock will return activityLogEntry1 & 2 for the first set of requests
     // and further requests will return activityLogEntry3 & 4
     dynamoMock
@@ -87,7 +89,7 @@ describe("deleteUserData", () => {
       user_id: userId,
     };
     const activityRecords: ActivityLogEntry[] | undefined =
-      await getAllActivitiesoForUser(userData);
+      await getAllActivitiesForUser("TABLE_NAME", userData);
     expect(activityRecords?.[0]).toEqual(activityLogEntry1);
     expect(activityRecords?.[1]).toEqual(activityLogEntry2);
     expect(activityRecords?.[2]).toEqual(activityLogEntry3);
@@ -117,7 +119,7 @@ describe("deleteUserData", () => {
   test("test batch deletion request when 65 items to delete", () => {
     const arrayOf56Activities: ActivityLogEntry[] =
       Array(56).fill(activityLogEntry);
-    batchDeleteActivityLog(arrayOf56Activities);
+    batchDeleteActivityLog("TABLE_NAME", arrayOf56Activities);
     expect(dynamoMock.commandCalls(BatchWriteItemCommand).length).toEqual(3);
   });
 });
@@ -128,6 +130,7 @@ describe("handler", () => {
       dynamoMock.reset();
       sqsMock.reset();
       process.env.TABLE_NAME = "TABLE_NAME";
+      process.env.DLQ_URL = "DLQ_URL";
       dynamoMock.on(QueryCommand).resolves({ Items: [activityLogEntry] });
     });
 
@@ -147,6 +150,7 @@ describe("handler", () => {
       dynamoMock.reset();
       sqsMock.reset();
       process.env.TABLE_NAME = "TABLE_NAME";
+      process.env.DLQ_URL = "DLQ_URL";
       dynamoMock.on(QueryCommand).resolves({ Items: [] });
     });
 
@@ -179,7 +183,7 @@ describe("handler", () => {
 
     test("logs the error message", async () => {
       await handler(TEST_SNS_EVENT_WITH_TWO_RECORDS);
-      expect(consoleErrorMock).toHaveBeenCalledTimes(2);
+      expect(consoleErrorMock).toHaveBeenCalledTimes(4);
     });
 
     test("sends the event to the dead letter queue", async () => {

--- a/src/tests/delete-activity-log.test.ts
+++ b/src/tests/delete-activity-log.test.ts
@@ -6,7 +6,7 @@ import { BatchWriteItemCommand } from "@aws-sdk/client-dynamodb";
 import {
   batchDeleteActivityLog,
   buildBatchDeletionRequestArray,
-  getAllActivitiesForUser,
+  getAllActivityLogEntriesForUser,
   handler,
   validateUserData,
 } from "../delete-activity-log";
@@ -89,7 +89,7 @@ describe("deleteUserData", () => {
       user_id: userId,
     };
     const activityRecords: ActivityLogEntry[] | undefined =
-      await getAllActivitiesForUser("TABLE_NAME", userData);
+      await getAllActivityLogEntriesForUser("TABLE_NAME", userData);
     expect(activityRecords?.[0]).toEqual(activityLogEntry1);
     expect(activityRecords?.[1]).toEqual(activityLogEntry2);
     expect(activityRecords?.[2]).toEqual(activityLogEntry3);

--- a/template.yaml
+++ b/template.yaml
@@ -9,12 +9,9 @@ Parameters:
   RawEventsStoreTableName:
     Type: String
     Default: raw_events
-  ActivityLogStoreTableName:
+  ActivityLogsStoreTableName:
     Type: String
-    Default: activity_logs
-  ActivityLogStoreEventIndexName:
-    Type: String
-    Default: EventIdIndex
+    Default: activity_log
   DummyEventStoreTableName:
     Type: String
     Default: dummy_events
@@ -384,7 +381,7 @@ Resources:
   #########################
   # User Activity Log store
   #########################
-  UserActivityLogStore:
+  UserActivityLogsStore:
     Type: AWS::DynamoDB::Table
     DeletionPolicy: Delete
     UpdateReplacePolicy: Delete
@@ -392,8 +389,6 @@ Resources:
       AttributeDefinitions:
         - AttributeName: user_id
           AttributeType: S
-        - AttributeName: timestamp
-          AttributeType: N
         - AttributeName: session_id
           AttributeType: S
         - AttributeName: event_id
@@ -405,18 +400,12 @@ Resources:
               KeyType: HASH
           Projection:
             ProjectionType: ALL
-        - IndexName: !Ref ActivityLogStoreEventIndexName  
-          KeySchema:
-            - AttributeName: event_id
-              KeyType: HASH
-          Projection:
-            ProjectionType: ALL
       BillingMode: PAY_PER_REQUEST
-      TableName: !Ref ActivityLogStoreTableName
+      TableName: !Ref ActivityLogsStoreTableName
       KeySchema:
         - AttributeName: user_id
           KeyType: HASH
-        - AttributeName: timestamp
+        - AttributeName: event_id
           KeyType: RANGE
       Tags:
         - Key: Product
@@ -1564,7 +1553,7 @@ Resources:
       Role: !GetAtt WriteActivityRecordRole.Arn
       Environment:
         Variables:
-          TABLE_NAME: !Ref ActivityLogStoreTableName
+          TABLE_NAME: !Ref ActivityLogsStoreTableName
           DLQ_URL: !Ref WriteActivityLogDeadLetterQueue
           GENERATOR_KEY_ARN: !GetAtt GeneratorKey.Arn
           WRAPPING_KEY_ARN: !GetAtt WrapperKey.Arn
@@ -1631,10 +1620,10 @@ Resources:
               - dynamodb:PutItem
               - dynamodb:UpdateItem
             Resource:
-              - !GetAtt UserActivityLogStore.Arn
+              - !GetAtt UserActivityLogsStore.Arn
               - !Sub
                 - "${Arn}/*"
-                - Arn: !GetAtt UserActivityLogStore.Arn
+                - Arn: !GetAtt UserActivityLogsStore.Arn
           - Effect: Allow
             Action:
               - kms:Decrypt
@@ -1944,7 +1933,7 @@ Resources:
       Role: !GetAtt DeleteActivityLogRole.Arn
       Environment:
         Variables:
-          TABLE_NAME: !Ref ActivityLogStoreTableName
+          TABLE_NAME: !Ref ActivityLogsStoreTableName
           DLQ_URL: !Ref DeleteActivityLogDeadLetterQueue
     Metadata:
       BuildMethod: esbuild
@@ -1993,10 +1982,10 @@ Resources:
               - dynamodb:GetItem
               - dynamodb:BatchWriteItem
             Resource:
-              - !GetAtt UserActivityLogStore.Arn
+              - !GetAtt UserActivityLogsStore.Arn
               - !Sub
                 - "${Arn}/*"
-                - Arn: !GetAtt UserActivityLogStore.Arn
+                - Arn: !GetAtt UserActivityLogsStore.Arn
           - Effect: Allow
             Action:
               - kms:Decrypt
@@ -2134,8 +2123,7 @@ Resources:
       Role: !GetAtt MarkActivityReportedRole.Arn
       Environment:
         Variables:
-          TABLE_NAME: !Ref ActivityLogStoreTableName
-          INDEX_NAME: !Ref ActivityLogStoreEventIndexName
+          TABLE_NAME: !Ref ActivityLogsStoreTableName
           DLQ_URL: !Ref MarkActivityReportedDeadLetterQueue
     Metadata:
       BuildMethod: esbuild
@@ -2195,10 +2183,10 @@ Resources:
               - dynamodb:UpdateItem
               - dynamodb:Query
             Resource:
-              - !GetAtt UserActivityLogStore.Arn
+              - !GetAtt UserActivityLogsStore.Arn
               - !Sub
                 - "${Arn}/*"
-                - Arn: !GetAtt UserActivityLogStore.Arn
+                - Arn: !GetAtt UserActivityLogsStore.Arn
 
   MarkActivityReportedInvokePermission:
     Type: AWS::Lambda::Permission


### PR DESCRIPTION
## Proposed changes

This PR changes the `activity_log` from using the `timestamp` as the `sort key` to using the `event_id`.

### What changed

- Rename the `activity_log` table (from `activity_logs` to `activity_log`), this is because DynamoDB key schemas can't be changed after they have been created. By renaming the table, it deletes the old one and creates a new one (there is no data in the table so no need for moving the data over)
- Rename the name for the table name parameter in the CloudFormation template. This is because it is a bit tricky to change a parameter value in CloudFormation once it has been created, so by using a new one, we can avoid having to change the value manually.
- Update the lambdas that used the old `timestamp` property to use `event_id`
- A few minor improvements to the codebase that I spotted. 

### Why did it change

Using event_id will be more robust, as we could feasibly expect there to be duplicates of the timestamp, since it is only accurate to the second.

### Related links

This decision was logged in [ADR001](https://github.com/govuk-one-login/di-account-management-backend/blob/main/docs/adr/0010-simplify-activity-log-data-structure-pipeline.md)0

## Checklists

<!-- Merging this PR deploys to production. Please answer accurately. -->

### Environment variables or secrets

- [X] No environment variables or secrets were added or changed

### Permissions

- [ ] This PR adds or changes permissions

## Testing

I have deployed this to development, and manually tested that the two lambdas changed still work.
