### PR TITLE
OLH-1485: Increase message visibility for audit events

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -444,6 +444,7 @@ Resources:
     Properties:
       KmsMasterKeyId: !Ref AuditEncryptionKey
       MessageRetentionPeriod: 1209600
+      VisibilityTimeout: 70
       RedrivePolicy:
         deadLetterTargetArn: !GetAtt AuditDeadLetterQueue.Arn
         maxReceiveCount: 5


### PR DESCRIPTION

## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->

### What changed

Change the timeout on our audit event queue from the default of 30 seconds to the requested 70 seconds.

### Why did it change

TxMA are changing the timeout on their event processing pipeline to 60 seconds. Before they can do that, all event producers need to increase the message visibility on their queues to reflect the new timeout (see [TT2-1450](https://govukverify.atlassian.net/browse/TT2-1450)).

### Related links

[TT2-1450](https://govukverify.atlassian.net/browse/TT2-1450)

## Checklists

<!-- Merging this PR deploys to production. Please answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

## Testing
TxMA will be testing this change on their side.

[TT2-1450]: https://govukverify.atlassian.net/browse/TT2-1450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TT2-1450]: https://govukverify.atlassian.net/browse/TT2-1450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ