### PR TITLE
OLH-1459 Publish Suspicious Activity

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -3410,6 +3410,31 @@ Resources:
       DisplayName: SuspiciousActivityTopic
       KmsMasterKeyId: !Ref SnsKmsKey
       TopicName: SuspiciousActivity
+      
+  SuspiciousActivityTopicPolicy:
+    Type: AWS::SNS::TopicPolicy
+    Properties:
+      Topics:
+        - !Ref SuspiciousActivityTopic
+      PolicyDocument:
+        Statement:
+          - Action: sns:Subscribe
+            Effect: Allow
+            Principal:
+              AWS: *
+            Resource:
+              - !Ref SuspiciousActivityTopic
+            Condition:
+              AccountIs: !Ref AWS::AccountId
+          - Action: "sns:Publish"
+            Effect: Allow
+            Resource: !Ref SuspiciousActivityTopic
+            Principal:
+              AWS: *
+            Condition:
+              ArnEquals:
+                aws:SourceArn:
+                 - !Sub "arn:aws:iam:${AWS::AccountId}:role/account-mgmt-frontend-TaskRole"
 
   SuspiciousActivityArnParameter:
     Type: AWS::SSM::Parameter

--- a/template.yaml
+++ b/template.yaml
@@ -3421,7 +3421,7 @@ Resources:
           - Action: sns:Subscribe
             Effect: Allow
             Principal:
-              AWS: *
+              AWS: !Ref AWS::AccountId
             Resource:
               - !Ref SuspiciousActivityTopic
             Condition:
@@ -3430,7 +3430,7 @@ Resources:
             Effect: Allow
             Resource: !Ref SuspiciousActivityTopic
             Principal:
-              AWS: *
+              AWS: !Ref AWS::AccountId
             Condition:
               ArnEquals:
                 aws:SourceArn:

--- a/template.yaml
+++ b/template.yaml
@@ -3421,7 +3421,7 @@ Resources:
           - Action: sns:Subscribe
             Effect: Allow
             Principal:
-              AWS: !Ref AWS::AccountId
+              AWS: "*"
             Resource:
               - !Ref SuspiciousActivityTopic
             Condition:
@@ -3430,7 +3430,7 @@ Resources:
             Effect: Allow
             Resource: !Ref SuspiciousActivityTopic
             Principal:
-              AWS: !Ref AWS::AccountId
+              AWS: "*"
             Condition:
               ArnEquals:
                 aws:SourceArn:

--- a/template.yaml
+++ b/template.yaml
@@ -3418,23 +3418,26 @@ Resources:
         - !Ref SuspiciousActivityTopic
       PolicyDocument:
         Statement:
-          - Action: sns:Subscribe
+          - Sid: AllowSubscription
             Effect: Allow
             Principal:
               AWS: "*"
+            Action: sns:Subscribe
             Resource:
               - !Ref SuspiciousActivityTopic
             Condition:
-              AccountIs: !Ref AWS::AccountId
-          - Action: "sns:Publish"
+              StringEquals:
+                aws:SourceAccount: !Ref AWS::AccountId
+          - Sid: AllowPublish
             Effect: Allow
-            Resource: !Ref SuspiciousActivityTopic
             Principal:
               AWS: "*"
+            Action: sns:Publish
+            Resource: !Ref SuspiciousActivityTopic
             Condition:
               ArnEquals:
                 aws:SourceArn:
-                 - !Sub "arn:aws:iam:${AWS::AccountId}:role/account-mgmt-frontend-TaskRole"
+                  - !Sub "arn:aws:iam::${AWS::AccountId}:role/${AccountManagementFrontendStackName}-TaskRole"
 
   SuspiciousActivityArnParameter:
     Type: AWS::SSM::Parameter


### PR DESCRIPTION
## Proposed changes

Updates the template to give permissions to allow the frontend app to publish to the SNS Suspicious Activity Topic

### Why did it change

Context [here](https://gds.slack.com/archives/C011Y5SAY3U/p1709733721335279)

### Related links

Required for [this](https://github.com/govuk-one-login/di-account-management-frontend/pull/1180) to work

## Checklists

<!-- Merging this PR deploys to production. Please answer accurately. -->

### Environment variables or secrets

- [X] No environment variables or secrets were added or changed

### Permissions

- [X] This PR adds or changes permissions

## Testing

Deployed to dev, verified that I can correctly report activity as suspicious