### PR TITLE
OLH-1530 - Decrypt Activity Log Event Type in Backend

### DIFF
--- a/src/decrypt-data.ts
+++ b/src/decrypt-data.ts
@@ -4,6 +4,7 @@ import {
   buildDecrypt,
 } from "@aws-crypto/client-node";
 import buildKmsKeyring from "./common/kms-keyring-builder";
+import getHashedAccessCheckValue from "./common/get-access-check-value";
 
 const MAX_ENCRYPTED_DATA_KEY = 5;
 const DECODING = "utf8";
@@ -14,7 +15,9 @@ const decryptClient = buildDecrypt(decryptClientConfig);
 
 let keyring: KmsKeyringNode;
 
-export function generateExpectedContext(userId: string): EncryptionContext {
+export async function generateExpectedContext(
+  userId: string
+): Promise<EncryptionContext> {
   const { AWS_REGION, ACCOUNT_ID, ENVIRONMENT, VERIFY_ACCESS_VALUE } =
     process.env;
   if (AWS_REGION === undefined) {
@@ -33,12 +36,20 @@ export function generateExpectedContext(userId: string): EncryptionContext {
     throw new Error("Missing VERIFY_ACCESS_VALUE environment variable");
   }
 
+  let accessCheckValue;
+  try {
+    accessCheckValue = await getHashedAccessCheckValue(VERIFY_ACCESS_VALUE);
+  } catch (error) {
+    console.error("Unable to obtain Access Verification value.");
+    throw error;
+  }
+
   return {
     origin: AWS_REGION,
     accountId: ACCOUNT_ID,
     stage: ENVIRONMENT,
     userId,
-    accessCheckValue: VERIFY_ACCESS_VALUE,
+    accessCheckValue: accessCheckValue,
   };
 }
 
@@ -61,22 +72,18 @@ export async function decryptData(
   data: string,
   userId: string,
   generatorKeyArn: string,
-  wrappingKeyArn: string,
-  backupWrappingKeyArn: string
+  wrappingKeyArn: string
 ): Promise<string> {
   try {
-    keyring ??= await buildKmsKeyring(
-      generatorKeyArn,
-      wrappingKeyArn,
-      backupWrappingKeyArn
-    );
+    keyring ??= await buildKmsKeyring(generatorKeyArn, wrappingKeyArn);
     const result = await decryptClient.decrypt(
       keyring,
       Buffer.from(data, ENCODING)
     );
+    const expectedEncryptionContext = await generateExpectedContext(userId);
     validateEncryptionContext(
       result.messageHeader.encryptionContext,
-      generateExpectedContext(userId)
+      expectedEncryptionContext
     );
     return result.plaintext.toString(DECODING);
   } catch (error) {

--- a/template.yaml
+++ b/template.yaml
@@ -2097,7 +2097,6 @@ Resources:
           ACTIVITY_LOG_TABLE_NAME: !Ref ActivityLogsStoreTableName
           GENERATOR_KEY_ARN: !GetAtt GeneratorKey.Arn
           WRAPPING_KEY_ARN: !GetAtt WrapperKey.Arn
-          BACKUP_WRAPPING_KEY_ARN: !Sub "{{resolve:ssm:/${AWS::StackName}/${Environment}/Backup/KMS/WrappingKey/ARN}}"
           VERIFY_ACCESS_VALUE: !Sub "{{resolve:secretsmanager:/${AWS::StackName}/Config/Storage/VerificationSecret}}"
           ACCOUNT_ID: !Sub "${AWS::AccountId}"
           ENVIRONMENT: !Ref Environment
@@ -2141,15 +2140,10 @@ Resources:
             Action:
               - kms:Decrypt
               - kms:GenerateDataKey*
-              - kms:ReEncrypt*
             Resource:
-              - !GetAtt QueueKmsKey.Arn
-              - !GetAtt LoggingKmsKey.Arn
-              - !GetAtt LambdaKMSKey.Arn
-              - !GetAtt AuditEncryptionKey.Arn
               - !GetAtt DatabaseKmsKey.Arn
               - !GetAtt WrapperKey.Arn
-              - !Sub "{{resolve:ssm:/${AWS::StackName}/${Environment}/Backup/KMS/WrappingKey/ARN}}"
+              - !GetAtt GeneratorKey.Arn
           - Effect: Allow
             Action:
               - dynamodb:UpdateItem


### PR DESCRIPTION
## Proposed changes

OLH-1530 - Decrypt Activity Log Event Type in Backend

### What changed

Within Mark Activity as Reported Lambda, we retrieve and decrypt the activity log event type, which is then passed into input into the next lambda in the step functions chain.

### Why did it change

So that the event type is displayed in zendesk ticket and TxMA submission in a human readable format.

### Related links
https://govukverify.atlassian.net/browse/OLH-1530

## Checklists

### Environment variables or secrets

- [ ] No new environment variables or secrets were added or changed

### Permissions

- [ ] This PR adds permission to decrypt record from the activity log table to the mark activity log as reported lambda.

## Testing

Deployed to dev, publish a message to Suspicious activity SNS topic with the event ID of the activity log, verify the event type shown in Zendesk ticket is the decrypted version.

## How to review
Code quality and test completeness.
