### PR TITLE
OLH-1653 & OLH-1564 Send Zendesk ticket ID, and fix issue with incorrect time on emails.

### DIFF
--- a/src/create-support-ticket.ts
+++ b/src/create-support-ticket.ts
@@ -39,7 +39,7 @@ export const formatCommentBody = (
   if (event.suspicious_activity.timestamp) {
     htmlBody.push(
       `<p><strong>Reported Date and Time</strong>: ${new Date(
-        event.suspicious_activity.timestamp
+        event.suspicious_activity.timestamp * 1000
       ).toUTCString()}</p>`
     );
   }

--- a/src/send-conf-email.ts
+++ b/src/send-conf-email.ts
@@ -31,7 +31,7 @@ export const getClientInfo = (
 };
 
 const formatTimestamp = (timestamp: number, language: string) => {
-  const date = new Date(timestamp);
+  const date = new Date(timestamp * 1000);
   return {
     date: Intl.DateTimeFormat(language, {
       dateStyle: "long",
@@ -66,16 +66,15 @@ export const formatActivityObjectForEmail = (
     event.suspicious_activity.client_id
   );
 
-  assert(
-    event.suspicious_activity.timestamp,
-    "Timestamp not present in Suspicious Activity Event"
-  );
+  assert(event.timestamp, "Timestamp not present in Suspicious Activity Event");
 
-  const datetimeEn = formatTimestamp(
-    event.suspicious_activity.timestamp,
-    "en-GB"
+  const datetimeEn = formatTimestamp(event.timestamp, "en-GB");
+  const datetimeCy = formatTimestamp(event.timestamp, "cy");
+
+  assert(
+    event.zendesk_ticket_id,
+    "Zendesk ticket ID not present in Suspicious Activity Events"
   );
-  const datetimeCy = formatTimestamp(event.suspicious_activity.timestamp, "cy");
 
   return {
     email: event.email_address,
@@ -86,6 +85,7 @@ export const formatActivityObjectForEmail = (
       dateCy: datetimeCy.date,
       timeEn: datetimeEn.time,
       timeCy: datetimeCy.time,
+      ticketId: event.zendesk_ticket_id,
     },
   };
 };

--- a/src/tests/create-support-ticket-errors.test.ts
+++ b/src/tests/create-support-ticket-errors.test.ts
@@ -117,7 +117,7 @@ describe("handler error handling", () => {
     }
     expect(consoleErrorMock).toHaveBeenCalledTimes(1);
     expect(consoleErrorMock.mock.calls[0][0]).toContain(
-      '[Error occurred], unable to send suspicious activity event with ID: 522c5ab4-7e66-4b2a-8f5c-4d31dc4e93e6 to Zendesk, 404 undefined - creating ticket: {"ticket":{"subject":"One Login Home - Report Suspicious Activity","comment":{"html_body":"<p><strong>Event Name</strong>: TXMA_EVENT</p><p><strong>Event ID</strong>: ab12345a-a12b-3ced-ef12-12a3b4cd5678</p><p><strong>Reported Date and Time</strong>: Fri, 02 Jan 1970 10:17:36 GMT</p><p><strong>Client ID</strong>: gov-uk</p><p><strong>User ID</strong>: qwerty</p><p><strong>Session ID</strong>: 123456789</p>"},"group_id":111111111,"requester":{"email":"email","name":"email"},"tags":["111111111"],"ticket_form_id":111111111}}'
+      '[Error occurred], unable to send suspicious activity event with ID: 522c5ab4-7e66-4b2a-8f5c-4d31dc4e93e6 to Zendesk, 404 undefined - creating ticket: {"ticket":{"subject":"One Login Home - Report Suspicious Activity","comment":{"html_body":"<p><strong>Event Name</strong>: TXMA_EVENT</p><p><strong>Event ID</strong>: ab12345a-a12b-3ced-ef12-12a3b4cd5678</p><p><strong>Reported Date and Time</strong>: Thu, 29 Nov 1973 21:33:09 GMT</p><p><strong>Client ID</strong>: gov-uk</p><p><strong>User ID</strong>: qwerty</p><p><strong>Session ID</strong>: 123456789</p>"},"group_id":111111111,"requester":{"email":"email","name":"email"},"tags":["111111111"],"ticket_form_id":111111111}}'
     );
     expect(errorThrown).toBeTruthy();
   });

--- a/src/tests/create-support-ticket-success.test.ts
+++ b/src/tests/create-support-ticket-success.test.ts
@@ -22,7 +22,7 @@ const dynamoMock = mockClient(DynamoDBDocumentClient);
 describe("Generate zendesk ticket Body", () => {
   test("should generate ticket body successfully using the suspicious activity event", async () => {
     const expected =
-      "<p><strong>Event Name</strong>: TXMA_EVENT</p><p><strong>Event ID</strong>: ab12345a-a12b-3ced-ef12-12a3b4cd5678</p><p><strong>Reported Date and Time</strong>: Fri, 02 Jan 1970 10:17:36 GMT</p><p><strong>Client ID</strong>: gov-uk</p><p><strong>User ID</strong>: qwerty</p><p><strong>Session ID</strong>: 123456789</p>";
+      "<p><strong>Event Name</strong>: TXMA_EVENT</p><p><strong>Event ID</strong>: ab12345a-a12b-3ced-ef12-12a3b4cd5678</p><p><strong>Reported Date and Time</strong>: Thu, 29 Nov 1973 21:33:09 GMT</p><p><strong>Client ID</strong>: gov-uk</p><p><strong>User ID</strong>: qwerty</p><p><strong>Session ID</strong>: 123456789</p>";
     const result = formatCommentBody(testSuspiciousActivityInput);
     expect(result).toEqual(expected);
   });

--- a/src/tests/send-conf-email.test.ts
+++ b/src/tests/send-conf-email.test.ts
@@ -32,6 +32,7 @@ describe("formatActivityObjectForEmail", () => {
         event_id: "123",
         reported_suspicious: true,
       },
+      zendesk_ticket_id: "123",
     };
 
     const result = formatActivityObjectForEmail(input);
@@ -41,10 +42,11 @@ describe("formatActivityObjectForEmail", () => {
       personalisation: {
         clientNameEn: "GOV.UK email subscriptions",
         clientNameCy: "Tanysgrifiadau e-byst GOV.UK",
-        dateCy: "29 Medi 1970",
-        dateEn: "29 September 1970",
-        timeCy: "03:30",
-        timeEn: "03:30",
+        dateCy: "26 Chwefror 2024",
+        dateEn: "26 February 2024",
+        ticketId: "123",
+        timeCy: "18:24",
+        timeEn: "18:24",
       },
     });
   });
@@ -95,10 +97,11 @@ describe("sendConfMail", () => {
         personalisation: {
           clientNameEn: "GOV.UK email subscriptions",
           clientNameCy: "Tanysgrifiadau e-byst GOV.UK",
-          dateCy: "29 Medi 1970",
-          dateEn: "29 September 1970",
-          timeCy: "03:30",
-          timeEn: "03:30",
+          dateCy: "26 Chwefror 2024",
+          dateEn: "26 February 2024",
+          ticketId: "123",
+          timeCy: "18:24",
+          timeEn: "18:24",
         },
         reference: "123",
       }


### PR DESCRIPTION
## Proposed changes

- Fix issue where the incorrect date and time was appearing in confirmation emails and zendesk tickets
- Add the zendesk ticket ID to emails

### What changed

- Multiply the timestamp by 1000 (the timestamp is in seconds, the `Date` object expects milliseconds since epoch)
- Add the Zendesk ticket ID to the personalisation object, so we can use it in an email.

### Why did it change

These issues came up in testing

## Testing

Will test on the dev environment.
