### PR TITLE
OLH-1573: Save activity log data in integration

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -94,11 +94,11 @@ Conditions:
       - !Equals [!Ref Environment, integration]
       - !Equals [!Ref Environment, production]
 
-  IsNotProdOrIntegration:
-    Fn::Or:
-      - !Equals [ !Ref Environment, build ]
-      - !Equals [ !Ref Environment, dev ]
-      - !Equals [ !Ref Environment, staging ]
+  IsNotProduction:
+    Fn::Not: 
+      - Fn::Equals:
+        - !Ref Environment
+        - "production"
 
 Globals:
   Function:
@@ -1705,7 +1705,7 @@ Resources:
   #######################
   FormatActivityLogFunction:
     Type: AWS::Serverless::Function
-    Condition: IsNotProdOrIntegration
+    Condition: IsNotProduction
     DependsOn:
       - FormatActivityLogFunctionLogGroup
     Properties:


### PR DESCRIPTION

## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->

### What changed

This deploys the format-activity-logs lambda into integration which means we'll start saving items to the activity logs table.

Nothing else in the template used the `IsNotProdOrIntegration` condition so it's safe to change.

### Why did it change

We want to test that data collection is working as expected in integration before we deploy to production. 

## Checklists

<!-- Merging this PR deploys to production. Please answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

## Testing

<!-- Provide a summary of any manual testing you've done, for example deploying the branch to dev -->
I've checked staging where this lambda is already deployed and saving real events. We've got items in the DynamoDB table and Dynatrace is reporting no Lambda errors over the last 72 hours so I'm confident it's all working like we expect.