### PR TITLE
OLH-1573: Save activity log data in production

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -94,12 +94,6 @@ Conditions:
       - !Equals [!Ref Environment, integration]
       - !Equals [!Ref Environment, production]
 
-  IsNotProduction:
-    Fn::Not: 
-      - Fn::Equals:
-        - !Ref Environment
-        - "production"
-
 Globals:
   Function:
     Environment:
@@ -1705,7 +1699,6 @@ Resources:
   #######################
   FormatActivityLogFunction:
     Type: AWS::Serverless::Function
-    Condition: IsNotProduction
     DependsOn:
       - FormatActivityLogFunctionLogGroup
     Properties:


### PR DESCRIPTION

## Proposed changes

### What changed

This PR removes the condition to not deploy the format-activity-log lambda into production. This means we'll start saving items to the database

### Why did it change

So we have data to show in the activity log.

### Related links

I enabled this in integration in #203 

## Checklists

<!-- Merging this PR deploys to production. Please answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed


## Testing

We aren't receiving events from TxMA in integration due to a separate issue so unfortunately I couldn't check there after the release. Staging is configured in exactly the same way however, so I'm confident the checks I did prior to #203 mean this will be fine in production.