### PR TITLE
BAU: Use the new TxMA key in integration

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -153,7 +153,7 @@ Mappings:
       KeyArn: "arn:aws:kms:eu-west-2:178023842775:key/6dbe7362-a125-466b-a135-22c98c436f17"
     integration:
       QueueArn: "arn:aws:sqs:eu-west-2:729485541398:self-integration-EC-SQS-Output-Queue-accounts"
-      KeyArn: "arn:aws:kms:eu-west-2:729485541398:key/107fc428-3843-4bd3-9e53-41d2d794e62e"
+      KeyArn: "arn:aws:kms:eu-west-2:729485541398:key/6a4b784e-2f75-4f39-8b27-0fdf2134ca28"
     production:
       QueueArn: "arn:aws:sqs:eu-west-2:451773080033:self-production-EC-SQS-Output-Queue-accounts"
       KeyArn: "arn:aws:kms:eu-west-2:451773080033:key/e95d47b6-613d-4bea-93c9-d400cdfb31ee"


### PR DESCRIPTION

## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->

### What changed
Use the new queue encryption key in integration for our consumer queue out of TxMA.

### Why did it change

At some point in the last few months the key for our consumer queue changed in integration which means we're not getting any events through. 


## Checklists

<!-- Merging this PR deploys to production. Please answer accurately. -->

### Environment variables or secrets

- [x] Changed environment variable 

## Testing

We can't test this without deploying it as use is restricted to our integration account.

## How to review

Please check the key ARN against the one in my [support request with TxMA](https://gds.slack.com/archives/C02SPF21F7H/p1710241034019199).