### PR TITLE
OLH-1566 Send time and date as one string to Notify

### DIFF
--- a/src/send-conf-email.ts
+++ b/src/send-conf-email.ts
@@ -32,16 +32,11 @@ export const getClientInfo = (
 
 const formatTimestamp = (timestamp: number, language: string) => {
   const date = new Date(timestamp * 1000);
-  return {
-    date: Intl.DateTimeFormat(language, {
-      dateStyle: "long",
-      timeZone: "Europe/London",
-    }).format(date),
-    time: Intl.DateTimeFormat(language, {
-      timeStyle: "short",
-      timeZone: "Europe/London",
-    }).format(date),
-  };
+  return Intl.DateTimeFormat(language, {
+    timeStyle: "short",
+    dateStyle: "long",
+    timeZone: "Europe/London",
+  }).format(date);
 };
 
 export const formatActivityObjectForEmail = (
@@ -81,10 +76,8 @@ export const formatActivityObjectForEmail = (
     personalisation: {
       clientNameEn: clientEn.header,
       clientNameCy: clientCy.header,
-      dateEn: datetimeEn.date,
-      dateCy: datetimeCy.date,
-      timeEn: datetimeEn.time,
-      timeCy: datetimeCy.time,
+      dateEn: datetimeEn,
+      dateCy: datetimeCy,
       ticketId: event.zendesk_ticket_id,
     },
   };

--- a/src/tests/send-conf-email.test.ts
+++ b/src/tests/send-conf-email.test.ts
@@ -42,11 +42,9 @@ describe("formatActivityObjectForEmail", () => {
       personalisation: {
         clientNameEn: "GOV.UK email subscriptions",
         clientNameCy: "Tanysgrifiadau e-byst GOV.UK",
-        dateCy: "26 Chwefror 2024",
-        dateEn: "26 February 2024",
+        dateCy: "26 Chwefror 2024 am 18:24",
+        dateEn: "26 February 2024 at 18:24",
         ticketId: "123",
-        timeCy: "18:24",
-        timeEn: "18:24",
       },
     });
   });
@@ -97,11 +95,9 @@ describe("sendConfMail", () => {
         personalisation: {
           clientNameEn: "GOV.UK email subscriptions",
           clientNameCy: "Tanysgrifiadau e-byst GOV.UK",
-          dateCy: "26 Chwefror 2024",
-          dateEn: "26 February 2024",
+          dateCy: "26 Chwefror 2024 am 18:24",
+          dateEn: "26 February 2024 at 18:24",
           ticketId: "123",
-          timeCy: "18:24",
-          timeEn: "18:24",
         },
         reference: "123",
       }


### PR DESCRIPTION
## Proposed changes

Send the fully formatted date and time string to Notify, instead of a seperate date string and time string,

### Why did it change

[Context from Dana](https://gds.slack.com/archives/C012GEZBZM0/p1710157972567999?thread_ts=1710155049.156179&cid=C012GEZBZM0)

I was wondering whether there is any advantage of passing event date and event time into the Notify template separately vs passing through the entire date formatted with [Intl.DateTimeFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat) (which we use[ on the frontend](https://github.com/govuk-one-login/di-account-management-frontend/blob/172beee57f197eb33947b324919f49d8d87666ae/src/utils/prettifyDate.ts#L22), not sure whether you can do the same on the backend but I would have imagined yes since it’s still Javascript?) which should automatically output our desired format for English and Welsh when the correct arguments are used. So then the activity details in our notify template could look something like this, and we wouldn’t need to hard code the “at” in Welsh:  

> ((eventName))
> ((eventDate)) (UK time)