### PR TITLE
OLH-1562: Add Home service name for emails

### DIFF
--- a/src/config/clientRegistry.cy.json
+++ b/src/config/clientRegistry.cy.json
@@ -96,6 +96,11 @@
       "description": "Hyfforddiant ar ddatblygiad plant, gan gynnwys cyngor ar gefnogi datblygiad plant yn eich lleoliad blynyddoedd cynnar.",
       "link_text": "Ewch i'ch cyfrif hyfforddiant datblygiad plant blynyddoedd cynnar",
       "link_href": "https://child-development-training.education.gov.uk/my-modules"
+    },
+    "KcKmx2g1GH6ersWFvzMi1bhehq4": {
+      "header": "Eich GOV.UK One Login",
+      "link_text": "",
+      "link_href": "https://home.account.gov.uk"
     }
   },
   "integration": {
@@ -195,6 +200,11 @@
       "description": "Hyfforddiant ar ddatblygiad plant, gan gynnwys cyngor ar gefnogi datblygiad plant yn eich lleoliad blynyddoedd cynnar.",
       "link_text": "Ewch i'ch cyfrif hyfforddiant datblygiad plant blynyddoedd cynnar",
       "link_href": "https://child-development-training.education.gov.uk/my-modules"
+    },
+    "Y8xi2wDAaRvWYlEkoExOUZbAPaYyBEhB": {
+      "header": "Eich GOV.UK One Login",
+      "link_text": "",
+      "link_href": "https://home.integration.account.gov.uk"
     }
   },
   "staging": {
@@ -294,6 +304,11 @@
       "description": "Hyfforddiant ar ddatblygiad plant, gan gynnwys cyngor ar gefnogi datblygiad plant yn eich lleoliad blynyddoedd cynnar.",
       "link_text": "Ewch i'ch cyfrif hyfforddiant datblygiad plant blynyddoedd cynnar",
       "link_href": "https://child-development-training.education.gov.uk/my-modules"
+    },
+    "EMGmY82k-92QSakDl_9keKDFmZY": {
+      "header": "Eich GOV.UK One Login",
+      "link_text": "",
+      "link_href": "https://home.staging.account.gov.uk"
     }
   },
   "build": {
@@ -393,8 +408,12 @@
       "description": "Hyfforddiant ar ddatblygiad plant, gan gynnwys cyngor ar gefnogi datblygiad plant yn eich lleoliad blynyddoedd cynnar.",
       "link_text": "Ewch i'ch cyfrif hyfforddiant datblygiad plant blynyddoedd cynnar",
       "link_href": "https://child-development-training.education.gov.uk/my-modules"
+    },
+    "oneLoginHome": {
+      "header": "Eich GOV.UK One Login",
+      "link_text": "",
+      "link_href": "https://home.build.account.gov.uk"
     }
-
   },
   "dev": {
     "gov-uk": {
@@ -493,6 +512,11 @@
       "description": "Hyfforddiant ar ddatblygiad plant, gan gynnwys cyngor ar gefnogi datblygiad plant yn eich lleoliad blynyddoedd cynnar.",
       "link_text": "Ewch i'ch cyfrif hyfforddiant datblygiad plant blynyddoedd cynnar",
       "link_href": "https://child-development-training.education.gov.uk/my-modules"
+    },
+    "oneLoginHome": {
+      "header": "Eich GOV.UK One Login",
+      "link_text": "",
+      "link_href": "https://home.dev.account.gov.uk"
     }
   },
   "local": {
@@ -592,6 +616,11 @@
       "description": "Hyfforddiant ar ddatblygiad plant, gan gynnwys cyngor ar gefnogi datblygiad plant yn eich lleoliad blynyddoedd cynnar.",
       "link_text": "Ewch i'ch cyfrif hyfforddiant datblygiad plant blynyddoedd cynnar",
       "link_href": "https://child-development-training.education.gov.uk/my-modules"
+    },
+    "oneLoginHome": {
+      "header": "Eich GOV.UK One Login",
+      "link_text": "",
+      "link_href": "https://home.dev.account.gov.uk"
     }
   }
 }

--- a/src/config/clientRegistry.en.json
+++ b/src/config/clientRegistry.en.json
@@ -102,6 +102,11 @@
       "description": "Training on child development, including advice on supporting child development in your early years setting.",
       "link_text": "Go to your early years child development training account",
       "link_href": "https://child-development-training.education.gov.uk/my-modules"
+    },
+    "KcKmx2g1GH6ersWFvzMi1bhehq4": {
+      "header": "Your GOV.UK One Login",
+      "link_text": "",
+      "link_href": "https://home.account.gov.uk"
     }
   },
   "integration": {
@@ -201,6 +206,11 @@
       "description": "Training on child development, including advice on supporting child development in your early years setting.",
       "link_text": "Go to your early years child development training account",
       "link_href": "https://child-development-training.education.gov.uk/my-modules"
+    },
+    "Y8xi2wDAaRvWYlEkoExOUZbAPaYyBEhB": {
+      "header": "Your GOV.UK One Login",
+      "link_text": "",
+      "link_href": "https://home.integration.account.gov.uk"
     }
   },
   "staging": {
@@ -300,6 +310,11 @@
       "description": "Training on child development, including advice on supporting child development in your early years setting.",
       "link_text": "Go to your early years child development training account",
       "link_href": "https://child-development-training.education.gov.uk/my-modules"
+    },
+    "EMGmY82k-92QSakDl_9keKDFmZY": {
+      "header": "Your GOV.UK One Login",
+      "link_text": "",
+      "link_href": "https://home.staging.account.gov.uk"
     }
   },
   "build": {
@@ -399,6 +414,11 @@
       "description": "Training on child development, including advice on supporting child development in your early years setting.",
       "link_text": "Go to your early years child development training account",
       "link_href": "https://child-development-training.education.gov.uk/my-modules"
+    },
+    "oneLoginHome": {
+      "header": "Your GOV.UK One Login",
+      "link_text": "",
+      "link_href": "https://home.build.account.gov.uk"
     }
   },
   "dev": {
@@ -498,6 +518,11 @@
       "description": "Training on child development, including advice on supporting child development in your early years setting.",
       "link_text": "Go to your early years child development training account",
       "link_href": "https://child-development-training.education.gov.uk/my-modules"
+    },
+    "oneLoginHome": {
+      "header": "Your GOV.UK One Login",
+      "link_text": "",
+      "link_href": "https://home.dev.account.gov.uk"
     }
   },
   "local": {
@@ -597,6 +622,11 @@
       "description": "Training on child development, including advice on supporting child development in your early years setting.",
       "link_text": "Go to your early years child development training account",
       "link_href": "https://child-development-training.education.gov.uk/my-modules"
+    },
+    "oneLoginHome": {
+      "header": "Your GOV.UK One Login",
+      "link_text": "",
+      "link_href": "https://home.dev.account.gov.uk"
     }
   }
 }


### PR DESCRIPTION
## Proposed changes
### What changed

Add the service info for One Login Home in English and Welsh so we can reference it in the emails we send.

This uses the real client IDs for staging, integration and production so we have them available for end to end testing.

### Why did it change

We'll be showing sign in events for One Login Home in the activity history. Information about Home isn't in the mapping here because it was copied over from the service card data in the frontend and we don't have a card for Home.

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

## Testing

I plan to do a full test of this once I've done the corresponding frontend work to display the Home events.