### PR TITLE
OLH-1593: Include hint text in emails for One Login Home

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -22,3 +22,19 @@ export const allowedTxmaEvents: Array<string> = [
 export const REPORT_SUSPICIOUS_ACTIVITY_DEFAULT = false;
 export const CREATE_TICKET_PATH = "/tickets.json";
 export const SUSPICIOUS_ACTIVITY_EVENT_NAME = "HOME_REPORT_SUSPICIOUS_ACTIVITY";
+
+export const HOME_CLIENT_ID_TEST = "oneLoginHome";
+const HOME_CLIENT_ID_DEV = "Vcer7-iz9BNrdVFG-JVqJ4k2mvw";
+const HOME_CLIENT_ID_BUILD = "UJtd0gskJAqo1MR0liyVU1FykG8";
+const HOME_CLIENT_ID_STAGING = "EMGmY82k-92QSakDl_9keKDFmZY";
+const HOME_CLIENT_ID_INTEGRATION = "Y8xi2wDAaRvWYlEkoExOUZbAPaYyBEhB";
+const HOME_CLIENT_ID_PRODUCTION = "KcKmx2g1GH6ersWFvzMi1bhehq4";
+
+export const homeClientIds: string[] = [
+  HOME_CLIENT_ID_TEST,
+  HOME_CLIENT_ID_DEV,
+  HOME_CLIENT_ID_BUILD,
+  HOME_CLIENT_ID_STAGING,
+  HOME_CLIENT_ID_INTEGRATION,
+  HOME_CLIENT_ID_PRODUCTION,
+];

--- a/src/config/clientRegistry.cy.json
+++ b/src/config/clientRegistry.cy.json
@@ -99,6 +99,7 @@
     },
     "KcKmx2g1GH6ersWFvzMi1bhehq4": {
       "header": "Eich GOV.UK One Login",
+      "description": "Mae hyn yn cynnwys 'Diogelwch' a 'Eich gwasanaethau'",
       "link_text": "",
       "link_href": "https://home.account.gov.uk"
     }
@@ -203,6 +204,7 @@
     },
     "Y8xi2wDAaRvWYlEkoExOUZbAPaYyBEhB": {
       "header": "Eich GOV.UK One Login",
+      "description": "Mae hyn yn cynnwys 'Diogelwch' a 'Eich gwasanaethau'",
       "link_text": "",
       "link_href": "https://home.integration.account.gov.uk"
     }
@@ -307,6 +309,7 @@
     },
     "EMGmY82k-92QSakDl_9keKDFmZY": {
       "header": "Eich GOV.UK One Login",
+      "description": "Mae hyn yn cynnwys 'Diogelwch' a 'Eich gwasanaethau'",
       "link_text": "",
       "link_href": "https://home.staging.account.gov.uk"
     }
@@ -411,6 +414,7 @@
     },
     "oneLoginHome": {
       "header": "Eich GOV.UK One Login",
+      "description": "Mae hyn yn cynnwys 'Diogelwch' a 'Eich gwasanaethau'",
       "link_text": "",
       "link_href": "https://home.build.account.gov.uk"
     }
@@ -515,6 +519,7 @@
     },
     "oneLoginHome": {
       "header": "Eich GOV.UK One Login",
+      "description": "Mae hyn yn cynnwys 'Diogelwch' a 'Eich gwasanaethau'",
       "link_text": "",
       "link_href": "https://home.dev.account.gov.uk"
     }
@@ -619,6 +624,7 @@
     },
     "oneLoginHome": {
       "header": "Eich GOV.UK One Login",
+      "description": "Mae hyn yn cynnwys 'Diogelwch' a 'Eich gwasanaethau'",
       "link_text": "",
       "link_href": "https://home.dev.account.gov.uk"
     }

--- a/src/config/clientRegistry.en.json
+++ b/src/config/clientRegistry.en.json
@@ -105,6 +105,7 @@
     },
     "KcKmx2g1GH6ersWFvzMi1bhehq4": {
       "header": "Your GOV.UK One Login",
+      "description": "This includes ‘Security’ and ‘Your services’",
       "link_text": "",
       "link_href": "https://home.account.gov.uk"
     }
@@ -209,6 +210,7 @@
     },
     "Y8xi2wDAaRvWYlEkoExOUZbAPaYyBEhB": {
       "header": "Your GOV.UK One Login",
+      "description": "This includes ‘Security’ and ‘Your services’",
       "link_text": "",
       "link_href": "https://home.integration.account.gov.uk"
     }
@@ -313,6 +315,7 @@
     },
     "EMGmY82k-92QSakDl_9keKDFmZY": {
       "header": "Your GOV.UK One Login",
+      "description": "This includes ‘Security’ and ‘Your services’",
       "link_text": "",
       "link_href": "https://home.staging.account.gov.uk"
     }
@@ -417,6 +420,7 @@
     },
     "oneLoginHome": {
       "header": "Your GOV.UK One Login",
+      "description": "This includes ‘Security’ and ‘Your services’",
       "link_text": "",
       "link_href": "https://home.build.account.gov.uk"
     }
@@ -521,6 +525,7 @@
     },
     "oneLoginHome": {
       "header": "Your GOV.UK One Login",
+      "description": "This includes ‘Security’ and ‘Your services’",
       "link_text": "",
       "link_href": "https://home.dev.account.gov.uk"
     }
@@ -625,6 +630,7 @@
     },
     "oneLoginHome": {
       "header": "Your GOV.UK One Login",
+      "description": "This includes ‘Security’ and ‘Your services’",
       "link_text": "",
       "link_href": "https://home.dev.account.gov.uk"
     }

--- a/src/send-conf-email.ts
+++ b/src/send-conf-email.ts
@@ -4,6 +4,7 @@ import {
   ReportSuspiciousActivityEvent,
   RPClient,
 } from "./common/model";
+import { homeClientIds } from "./common/constants";
 import assert from "node:assert/strict";
 import { NotifyClient } from "notifications-node-client";
 import { getSecret } from "@aws-lambda-powertools/parameters/secrets";
@@ -89,6 +90,9 @@ export const formatActivityObjectForEmail = (
       dateEn: datetimeEn,
       dateCy: datetimeCy,
       ticketId: event.zendesk_ticket_id,
+      showHomeHintText: homeClientIds.includes(
+        event.suspicious_activity.client_id
+      ),
     },
   };
 };


### PR DESCRIPTION
## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->

### What changed

Include hint text in emails for One Login Home. 

This does hard code the client IDs for the Home frontend, but we have all the rest of the content duplicated here anyway so I didn't think that was too bad. 

I'm using Notify's [Optional content feature](https://www.notifications.service.gov.uk/using-notify/optional-content) to show / hide the hint text line for events about One Login Home.

This relies on a template update which I've made in the Test Notify service. Once the PR is merged I'll apply the same template update to the live service

### Why did it change

To explain to users what 'Your GOV.UK One Login Home' means

### Related links

## Checklists

<!-- Merging this PR deploys to production. Please answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

## Testing

I've deployed this to dev and triggered an email. I've also checked that the hint text doesn't show up when the variable is set to false.

<img width="618" alt="image" src="https://github.com/govuk-one-login/di-account-management-backend/assets/6362602/836f9210-62ba-4ea5-a4ea-c553f8c3780d">


<img width="618" alt="image" src="https://github.com/govuk-one-login/di-account-management-backend/assets/6362602/b909d562-98f5-437f-8bf0-b06e0fb6255e">
