### PR TITLE
OLH-1605 - Move user email into custom field/body and remove from Requestor

### DIFF
--- a/src/create-support-ticket.ts
+++ b/src/create-support-ticket.ts
@@ -26,6 +26,10 @@ export const formatCommentBody = (
 ): string => {
   const htmlBody = [];
 
+  if (event.email_address) {
+    htmlBody.push(`<p><strong>Requester</strong>: ${event.email_address}</p>`);
+  }
+
   htmlBody.push(
     `<p><strong>Event Name</strong>: ${event.suspicious_activity.event_type}</p>`
   );
@@ -184,7 +188,6 @@ export const handler = async (
           html_body: formatCommentBody(input),
         },
         group_id: Number(zendeskGroupId),
-        requester: { email: input.email_address, name: input.email_address },
         tags,
         ticket_form_id: Number(zendeskTicketFormId),
       },

--- a/src/tests/create-support-ticket-errors.test.ts
+++ b/src/tests/create-support-ticket-errors.test.ts
@@ -117,7 +117,7 @@ describe("handler error handling", () => {
     }
     expect(consoleErrorMock).toHaveBeenCalledTimes(1);
     expect(consoleErrorMock.mock.calls[0][0]).toContain(
-      '[Error occurred], unable to send suspicious activity event with ID: 522c5ab4-7e66-4b2a-8f5c-4d31dc4e93e6 to Zendesk, 404 undefined - creating ticket: {"ticket":{"subject":"One Login Home - Report Suspicious Activity","comment":{"html_body":"<p><strong>Event Name</strong>: TXMA_EVENT</p><p><strong>Event ID</strong>: ab12345a-a12b-3ced-ef12-12a3b4cd5678</p><p><strong>Reported Date and Time</strong>: Thu, 29 Nov 1973 21:33:09 GMT</p><p><strong>Client ID</strong>: gov-uk</p><p><strong>User ID</strong>: qwerty</p><p><strong>Session ID</strong>: 123456789</p>"},"group_id":111111111,"requester":{"email":"email","name":"email"},"tags":["111111111"],"ticket_form_id":111111111}}'
+      '[Error occurred], unable to send suspicious activity event with ID: 522c5ab4-7e66-4b2a-8f5c-4d31dc4e93e6 to Zendesk, 404 undefined - creating ticket: {"ticket":{"subject":"One Login Home - Report Suspicious Activity","comment":{"html_body":"<p><strong>Requester</strong>: email</p><p><strong>Event Name</strong>: TXMA_EVENT</p><p><strong>Event ID</strong>: ab12345a-a12b-3ced-ef12-12a3b4cd5678</p><p><strong>Reported Date and Time</strong>: Thu, 29 Nov 1973 21:33:09 GMT</p><p><strong>Client ID</strong>: gov-uk</p><p><strong>User ID</strong>: qwerty</p><p><strong>Session ID</strong>: 123456789</p>"},"group_id":111111111,"tags":["111111111"],"ticket_form_id":111111111}}'
     );
     expect(errorThrown).toBeTruthy();
   });

--- a/src/tests/create-support-ticket-success.test.ts
+++ b/src/tests/create-support-ticket-success.test.ts
@@ -22,7 +22,7 @@ const dynamoMock = mockClient(DynamoDBDocumentClient);
 describe("Generate zendesk ticket Body", () => {
   test("should generate ticket body successfully using the suspicious activity event", async () => {
     const expected =
-      "<p><strong>Event Name</strong>: TXMA_EVENT</p><p><strong>Event ID</strong>: ab12345a-a12b-3ced-ef12-12a3b4cd5678</p><p><strong>Reported Date and Time</strong>: Thu, 29 Nov 1973 21:33:09 GMT</p><p><strong>Client ID</strong>: gov-uk</p><p><strong>User ID</strong>: qwerty</p><p><strong>Session ID</strong>: 123456789</p>";
+      "<p><strong>Requester</strong>: email</p><p><strong>Event Name</strong>: TXMA_EVENT</p><p><strong>Event ID</strong>: ab12345a-a12b-3ced-ef12-12a3b4cd5678</p><p><strong>Reported Date and Time</strong>: Thu, 29 Nov 1973 21:33:09 GMT</p><p><strong>Client ID</strong>: gov-uk</p><p><strong>User ID</strong>: qwerty</p><p><strong>Session ID</strong>: 123456789</p>";
     const result = formatCommentBody(testSuspiciousActivityInput);
     expect(result).toEqual(expected);
   });
@@ -57,10 +57,9 @@ describe("handler", () => {
         subject: "One Login Home - Report Suspicious Activity",
         comment: {
           html_body:
-            "<p><strong>Event Name</strong>: TXMA_EVENT</p><p><strong>Event ID</strong>: ab12345a-a12b-3ced-ef12-12a3b4cd5678</p><p><strong>Reported Date and Time</strong>: Fri, 02 Jan 1970 10:17:36 GMT</p><p><strong>Client ID</strong>: gov-uk</p><p><strong>User ID</strong>: qwerty</p><p><strong>Session ID</strong>: 123456789</p>",
+            "<p><strong>Requester</strong>: email</p><p><strong>Event Name</strong>: TXMA_EVENT</p><p><strong>Event ID</strong>: ab12345a-a12b-3ced-ef12-12a3b4cd5678</p><p><strong>Reported Date and Time</strong>: Fri, 02 Jan 1970 10:17:36 GMT</p><p><strong>Client ID</strong>: gov-uk</p><p><strong>User ID</strong>: qwerty</p><p><strong>Session ID</strong>: 123456789</p>",
         },
         group_id: 1111111,
-        requester: { email: "email", name: "email" },
         tags: ["1111111"],
         ticket_form_id: 1111111,
       },
@@ -115,10 +114,9 @@ describe("handler", () => {
         subject: "One Login Home - Report Suspicious Activity",
         comment: {
           html_body:
-            "<p><strong>Event Name</strong>: TXMA_EVENT</p><p><strong>Event ID</strong>: ab12345a-a12b-3ced-ef12-12a3b4cd5678</p><p><strong>Reported Date and Time</strong>: Fri, 02 Jan 1970 10:17:36 GMT</p><p><strong>Client ID</strong>: gov-uk</p><p><strong>User ID</strong>: qwerty</p><p><strong>Session ID</strong>: 123456789</p>",
+            "<p><strong>Requester</strong>: email</p><p><strong>Event Name</strong>: TXMA_EVENT</p><p><strong>Event ID</strong>: ab12345a-a12b-3ced-ef12-12a3b4cd5678</p><p><strong>Reported Date and Time</strong>: Fri, 02 Jan 1970 10:17:36 GMT</p><p><strong>Client ID</strong>: gov-uk</p><p><strong>User ID</strong>: qwerty</p><p><strong>Session ID</strong>: 123456789</p>",
         },
         group_id: 1111111,
-        requester: { email: "email", name: "email" },
         ticket_form_id: 1111111,
       },
     };


### PR DESCRIPTION
## Proposed changes

OLH-1605 - Move user email into custom field/body and remove from Requestor

### What changed

Code to add the requester email as part of the message body and remove the requester field.

### Why did it change

So that TICF still has a way to filter tickets by user, however the generic email sent to new Zendesk users is not triggered. This is needed because the Zendesk configurations required to stop the email generic email from sending did not work without some caveats.

### Related links

## Checklists

### Environment variables or secrets

- [ ] No environment variables or secrets were added or changed


### Permissions


## Testing

Deploying to dev and test before merging
## How to review

Code completness and testing 