### PR TITLE
OLH-1615 - Fix Issue Authenticating with Zendesk Prod

### DIFF
--- a/src/create-support-ticket.ts
+++ b/src/create-support-ticket.ts
@@ -87,7 +87,7 @@ export async function createTicket(
   apiUsername: string,
   apiToken: string
 ): Promise<AxiosResponse> {
-  const token = `${apiUsername}:${apiToken}`;
+  const token = `${apiUsername}/token:${apiToken}`;
   const instance = axios.create({
     baseURL: apiUrl,
     headers: {

--- a/src/tests/create-support-ticket-success.test.ts
+++ b/src/tests/create-support-ticket-success.test.ts
@@ -67,6 +67,10 @@ describe("handler", () => {
     mockAxios.onAny().reply(201, expectedBody);
     const response = await handler(testSuspiciousActivityInput);
     expect(mockAxios.history.post.length).toBe(1);
+    const authHeader =
+      mockAxios?.history?.post[0]?.headers?.Authorization.split("Basic")[1];
+    const bufferedString = Buffer.from(authHeader, "base64").toString("utf-8");
+    expect(bufferedString).toEqual("1111111/token:1111111");
     expect(dynamoMock.commandCalls(UpdateCommand).length).toEqual(1);
     expect(dynamoMock).toHaveReceivedCommandWith(UpdateCommand, {
       TableName: tableName,


### PR DESCRIPTION
## Proposed changes
OLH-1615 - Fix Issue Authenticating with Zendesk Prod

### What changed
Add missing token string to cause api token auth vs password auth

### Why did it change
So that app can authenticate successfully authenticate against Zendesk api using token 

### Related links
https://govukverify.atlassian.net/browse/OLH-1615

## Checklists

<!-- Merging this PR deploys to production. Please answer accurately. -->

### Environment variables or secrets

- [ ] No environment variables or secrets were added or changed


### Permissions

## Testing

Test in dev environment, change the dev password to something else, but leave the api token as correct. Should authenticate successfully 
## How to review

code completeness and test