### PR TITLE
OLH-1614 - remove PII logging.

### DIFF
--- a/src/create-support-ticket.ts
+++ b/src/create-support-ticket.ts
@@ -102,7 +102,7 @@ export async function createTicket(
     throw new Error(
       `${(error as HttpError).response.status} ${
         (error as HttpError).response.statusText
-      } - creating ticket: ${JSON.stringify(ticket)}`
+      }}`
     );
   }
 }

--- a/src/tests/create-support-ticket-errors.test.ts
+++ b/src/tests/create-support-ticket-errors.test.ts
@@ -117,7 +117,7 @@ describe("handler error handling", () => {
     }
     expect(consoleErrorMock).toHaveBeenCalledTimes(1);
     expect(consoleErrorMock.mock.calls[0][0]).toContain(
-      '[Error occurred], unable to send suspicious activity event with ID: 522c5ab4-7e66-4b2a-8f5c-4d31dc4e93e6 to Zendesk, 404 undefined - creating ticket: {"ticket":{"subject":"One Login Home - Report Suspicious Activity","comment":{"html_body":"<p><strong>Requester</strong>: email</p><p><strong>Event Name</strong>: TXMA_EVENT</p><p><strong>Event ID</strong>: ab12345a-a12b-3ced-ef12-12a3b4cd5678</p><p><strong>Reported Date and Time</strong>: Thu, 29 Nov 1973 21:33:09 GMT</p><p><strong>Client ID</strong>: gov-uk</p><p><strong>User ID</strong>: qwerty</p><p><strong>Session ID</strong>: 123456789</p>"},"group_id":111111111,"tags":["111111111"],"ticket_form_id":111111111}}'
+      "[Error occurred], unable to send suspicious activity event with ID: 522c5ab4-7e66-4b2a-8f5c-4d31dc4e93e6 to Zendesk, 404 undefined"
     );
     expect(errorThrown).toBeTruthy();
   });


### PR DESCRIPTION
## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->
Remove PII from log message when the call to Zendesk fails.
 
### What changed
Removed the Zendesk payload from the error log statement.  Updated unit test.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
We can't log PII in production and the payload to Zendesk contains various items considered PII.
<!-- Describe the reason these changes were made - the "why" -->

### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists

<!-- Merging this PR deploys to production. Please answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

### Permissions

- [ ] This PR adds or changes permissions

## Testing

<!-- Provide a summary of any manual testing you've done, for example deploying the branch to dev -->

## How to review

<!-- Describe any non-standard steps to review this work, or higlight any areas that you'd like the reviewer's opinion on -->
