### PR TITLE
OLH-1639: Restrict which lambdas the step function can invoke

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -2715,7 +2715,10 @@ Resources:
             Action:
               - "lambda:InvokeFunction"
             Resource:
-              - "*"
+              - !GetAtt CreateSupportTicketFunction.Arn
+              - !GetAtt SendConfEmailFunction.Arn
+              - !GetAtt SendSuspiciousActivityFunction.Arn
+              - !GetAtt MarkActivityReportedFunction.Arn
           - Effect: "Allow"
             Action:
               - "xray:PutTraceSegments"


### PR DESCRIPTION
## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->

### What changed

The step function which manages state when a user reports an activity doesn't need permissions to invoke every lambda function in our account. 

Restrict its access to only the four lambdas it needs to call.

### Why did it change

This was flagged as a security hotspot by Sonar.

### Related links

[Open Sonar findings](https://sonarcloud.io/project/security_hotspots?id=account-management-backend)

## Checklists

<!-- Merging this PR deploys to production. Please answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Permissions

- [x] This PR adds or changes permissions

## Testing

I've deployed this dev and checked the step function still runs.