### PR TITLE
BAU: Setup pre-commit to run prettier

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v3.1.0
+    hooks:
+      - id: prettier
+        additional_dependencies:
+          - prettier@3.2.5

--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ We transpile and package the Lambda functions using `sam build`. This needs `esb
 npm install -g esbuild
 ```
 
+### Pre-commit
+
+This repository uses [pre-commit](https://pre-commit.com/) to run linting on all staged files before they're committed.
+Install & setup pre-commit by running:
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
 ## Testing
 
 Each Lambda function is a separate NPM application and has its own unit tests.
@@ -58,9 +68,11 @@ gds aws di-account-dev -- aws sqs send-message \
 ## Sending support ticket for reported suspicious activity
 
 ### Summary
+
 - When a suspicious activity is added to the SNS topic, this create-support-ticket lambda is triggered, it creates a Zendesk Ticket using the key value pair of the event body.
 
 ### What the Lambda does
+
 - Ensure all environment variables required to successfully connect to, create ticket and send to Zendesk are provided
 - Validates the fields in the received event
 - Retrieves the values for the environment variable keys in AWS Secrets


### PR DESCRIPTION


## Proposed changes
### What changed

This will run prettier on all staged files before a new commit is created. If any files are modified, the hook will fail and we'll need to check and stage the changes.

### Why did it change

To keep our formatting consistent and reduce the number of linting changes / commits we need to review.
### Related links

See also https://github.com/govuk-one-login/di-account-management-frontend/pull/1271
