### PR TITLE
OLH-1711 - Add new device information to TxMA suspicious activity event.

### DIFF
--- a/src/common/model.ts
+++ b/src/common/model.ts
@@ -204,6 +204,7 @@ export interface ReportSuspiciousActivityEvent {
   event_timestamp_ms_formatted?: string;
   suspicious_activity: ActivityLogEntry;
   component_id?: string;
+  device_information?: string;
 }
 
 export interface Personalisation {

--- a/src/send-suspicious-activity.ts
+++ b/src/send-suspicious-activity.ts
@@ -68,6 +68,13 @@ export const transformToTxMAEvent = (
           },
         ],
       },
+      ...(event.device_information !== undefined
+        ? {
+            restricted: {
+              device_information: { encoded: event.device_information },
+            },
+          }
+        : {}),
     };
   } else {
     throw new Error(

--- a/src/tests/send-suspicious-activity.test.ts
+++ b/src/tests/send-suspicious-activity.test.ts
@@ -166,6 +166,73 @@ describe("handler", () => {
 
   test("handler successfully sends audit event to txma", async () => {
     const consoleLog = jest.spyOn(console, "log").mockImplementation();
+    const BASE64_ENCODED_DEVICE_INFO: string =
+      "WEwuLXxLeGZPO2Fgcyo2V2R+KUQmUjFcc3V0SU4+L25WIT0+KzNVdkdKLGUnJVZKdzheUmtjblokNEhCLzNvaUB2PTZ3SVhMWDNua1d3a2tlSm1BPk8nVnYlKC9I%";
+    const input: ReportSuspiciousActivityEvent = {
+      event_id: "522c5ab4-7e66-4b2a-8f5c-4d31dc4e93e6",
+      event_type: "HOME_REPORT_SUSPICIOUS_ACTIVITY",
+      persistent_session_id: "persistent_session_id",
+      session_id: "session_id",
+      email_address: "email",
+      component_id: "https://home.account.gov.uk",
+      timestamp: 1708971886,
+      event_timestamp_ms: 1708971886515,
+      event_timestamp_ms_formatted: "2024-02-26T18:24:46.515Z",
+      suspicious_activity: {
+        event_type: "TXMA_EVENT",
+        session_id: "123456789",
+        user_id: "qwerty",
+        timestamp: 123456789,
+        client_id: "gov-uk",
+        event_id: "ab12345a-a12b-3ced-ef12-12a3b4cd5678",
+        reported_suspicious: true,
+      },
+      zendesk_ticket_id: "12345677",
+      notify_message_id: "12345678",
+      device_information: BASE64_ENCODED_DEVICE_INFO,
+    };
+    await handler(input);
+    expect(sqsMock.commandCalls(SendMessageCommand).length).toEqual(1);
+    expect(sqsMock).toHaveReceivedCommandWith(SendMessageCommand, {
+      QueueUrl: "TXMA_QUEUE_URL",
+      MessageBody: JSON.stringify({
+        user: {
+          user_id: "qwerty",
+          persistent_session_id: "persistent_session_id",
+          session_id: "session_id",
+        },
+        component_id: "https://home.account.gov.uk",
+        event_name: "HOME_REPORT_SUSPICIOUS_ACTIVITY",
+        timestamp: 1708971886,
+        event_timestamp_ms: 1708971886515,
+        event_timestamp_ms_formatted: "2024-02-26T18:24:46.515Z",
+        extensions: {
+          zendesk_ticket_number: "12345677",
+          notify_reference: "12345678",
+          suspicious_activities: [
+            {
+              event_id: "ab12345a-a12b-3ced-ef12-12a3b4cd5678",
+              event_type: "TXMA_EVENT",
+              session_id: "123456789",
+              timestamp: 123456789,
+              client_id: "gov-uk",
+            },
+          ],
+        },
+        restricted: {
+          device_information: {
+            encoded: BASE64_ENCODED_DEVICE_INFO,
+          },
+        },
+      }),
+    });
+    expect(consoleLog).toHaveBeenCalledWith(
+      "[Message sent to QUEUE] with message id = MessageId"
+    );
+  });
+
+  test("handler successfully sends audit event to txma when no device information provided", async () => {
+    const consoleLog = jest.spyOn(console, "log").mockImplementation();
     const input: ReportSuspiciousActivityEvent = {
       event_id: "522c5ab4-7e66-4b2a-8f5c-4d31dc4e93e6",
       event_type: "HOME_REPORT_SUSPICIOUS_ACTIVITY",


### PR DESCRIPTION
## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->
Allow the RSA backend to include the TxMA header value in audit events.

### What changed

<!-- Describe the changes in detail - the "what"-->

Added new restricted section to the TxMA audit event.

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

To support fraud analysis.

### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists

<!-- Merging this PR deploys to production. Please answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->


### Permissions

- [ ] This PR adds or changes permissions

## Testing

<!-- Provide a summary of any manual testing you've done, for example deploying the branch to dev -->

## How to review

<!-- Describe any non-standard steps to review this work, or higlight any areas that you'd like the reviewer's opinion on -->
