### PR TITLE
OLH-1731 - Ensure RSA Backend Pass the new TxMA Header to Audit Event

### DIFF
--- a/src/common/call-async-step-function.ts
+++ b/src/common/call-async-step-function.ts
@@ -1,4 +1,4 @@
-import type { MarkActivityAsReportedInput } from "./model";
+import type { ReportSuspiciousActivityStepInput } from "./model";
 import {
   SFNClient,
   StartExecutionCommand,
@@ -8,7 +8,7 @@ import {
 
 export async function callAsyncStepFunction(
   stateMachineArn: string,
-  input: MarkActivityAsReportedInput
+  input: ReportSuspiciousActivityStepInput
 ): Promise<string> {
   let response: StartExecutionOutput;
   try {

--- a/src/common/model.ts
+++ b/src/common/model.ts
@@ -181,13 +181,14 @@ export type Environment =
 type ClientRegistryEnvronment = Record<string, RPClient>;
 export type ClientRegistry = Record<Environment, ClientRegistryEnvronment>;
 
-export interface MarkActivityAsReportedInput {
+export interface ReportSuspiciousActivityStepInput {
   user_id: string;
   email: string;
   event_id: string;
   persistent_session_id: string;
   session_id: string;
   reported_suspicious_time: number;
+  device_information?: string;
 }
 
 export interface ReportSuspiciousActivityEvent {

--- a/src/mark-activity-reported.ts
+++ b/src/mark-activity-reported.ts
@@ -12,7 +12,7 @@ import {
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import {
   ActivityLogEntry,
-  MarkActivityAsReportedInput,
+  ReportSuspiciousActivityStepInput,
   ReportSuspiciousActivityEvent,
 } from "./common/model";
 import assert from "node:assert";
@@ -107,7 +107,7 @@ export const queryActivityLog = async (
 };
 
 export const handler = async (
-  input: MarkActivityAsReportedInput
+  input: ReportSuspiciousActivityStepInput
 ): Promise<ReportSuspiciousActivityEvent> => {
   const { ACTIVITY_LOG_TABLE_NAME } = process.env;
   const { GENERATOR_KEY_ARN } = process.env;
@@ -157,7 +157,7 @@ export const handler = async (
     );
   }
 
-  return {
+  const reportedEvent: ReportSuspiciousActivityEvent = {
     persistent_session_id: input.persistent_session_id,
     session_id: input.session_id,
     event_id,
@@ -169,4 +169,8 @@ export const handler = async (
     event_timestamp_ms_formatted: timestamps.isoString,
     suspicious_activity: activityLog,
   };
+  if (input.device_information) {
+    reportedEvent.device_information = input.device_information;
+  }
+  return reportedEvent;
 };

--- a/src/tests/mark-activity-reported.test.ts
+++ b/src/tests/mark-activity-reported.test.ts
@@ -125,9 +125,32 @@ describe("handler", () => {
     expect(response.notify_message_id).toBeUndefined();
     expect(response.zendesk_ticket_id).toBeUndefined();
     expect(response.component_id).toEqual(COMPONENT_ID);
+    expect(response.device_information).toBeUndefined();
     expect(response.event_type).toEqual(
       EventNamesEnum.HOME_REPORT_SUSPICIOUS_ACTIVITY
     );
+  });
+
+  test("the handler creates correct output for next step function includes device_info", async () => {
+    const encodedDeviceInfo = "dsadddasa";
+    testSuspiciousActivity.device_information = encodedDeviceInfo;
+    const response = await handler(testSuspiciousActivity);
+    expect(dynamoMock.commandCalls(UpdateCommand).length).toEqual(1);
+    expect(response.event_id).not.toBeNull();
+    expect(response.email_address).toEqual(testSuspiciousActivity.email);
+    expect(response.suspicious_activity.reported_suspicious).toBe(true);
+    expect(response.timestamp).not.toBeNull();
+    expect(response.timestamp_formatted).not.toBeNull();
+    expect(response.event_timestamp_ms_formatted).not.toBeNull();
+    expect(response.event_timestamp_ms).not.toBeNull();
+    expect(response.notify_message_id).toBeUndefined();
+    expect(response.zendesk_ticket_id).toBeUndefined();
+    expect(response.component_id).toEqual(COMPONENT_ID);
+    expect(response.event_type).toEqual(
+      EventNamesEnum.HOME_REPORT_SUSPICIOUS_ACTIVITY
+    );
+    expect(response.device_information).toEqual(encodedDeviceInfo);
+    testSuspiciousActivity.device_information = undefined;
   });
 
   test("the handler log and throw an error", async () => {

--- a/src/tests/testFixtures.ts
+++ b/src/tests/testFixtures.ts
@@ -1,7 +1,7 @@
 import {
   ActivityLogEntry,
   EncryptedActivityLogEntry,
-  MarkActivityAsReportedInput,
+  ReportSuspiciousActivityStepInput,
   ReportSuspiciousActivityEvent,
   TxmaEvent,
   UserData,
@@ -274,7 +274,7 @@ export const TEST_SQS_EVENT_WITH_USER_SERVICES: SQSEvent = {
   ],
 };
 
-export const testSuspiciousActivity: MarkActivityAsReportedInput = {
+export const testSuspiciousActivity: ReportSuspiciousActivityStepInput = {
   user_id: userId,
   email: "email",
   event_id: eventId,

--- a/src/trigger-rsa-step.ts
+++ b/src/trigger-rsa-step.ts
@@ -1,5 +1,5 @@
 import { SNSEvent } from "aws-lambda";
-import { MarkActivityAsReportedInput } from "./common/model";
+import { ReportSuspiciousActivityStepInput } from "./common/model";
 import { callAsyncStepFunction } from "./common/call-async-step-function";
 import {
   SendMessageCommand,
@@ -17,7 +17,7 @@ export const handler = async (event: SNSEvent): Promise<void> => {
             "Error Occurred - Required environment variables to trigger report suspicious activity steps are not provided"
           );
         }
-        const receivedEvent: MarkActivityAsReportedInput = JSON.parse(
+        const receivedEvent: ReportSuspiciousActivityStepInput = JSON.parse(
           record.Sns.Message
         );
         if (


### PR DESCRIPTION
## Proposed changes

OLH-1731 - Ensure RSA Backend Pass the new TxMA Header to Audit Event

### What changed

Add device_information field when converting from the received SNS event to the object that will be passed across lambdas used as part of the report suspicious activity process.

### Why did it change

So that TxMA header us propagated along the chain up to the point where the report suspicious event is sent to TxMA

### Related links
https://govukverify.atlassian.net/browse/OLH-1731

## Checklists

### Environment variables or secrets

- [ ] No environment variables or secrets were added or changed

### Permissions

## Testing
Deploy to dev, record a suspicious activity and verify device information is sent to TxMA
## How to review