### PR TITLE
OLH-1649 - Onboard RP: Find and use a DfE API - Make corrections.

### DIFF
--- a/src/config/clientRegistry.cy.json
+++ b/src/config/clientRegistry.cy.json
@@ -105,7 +105,7 @@
     },
     "9uEx86ZHEp8ycgdHNqC8VK87E1A": {
       "header": "Dod o hyd a defnyddio API gan yr Adran Addysg",
-      "description": "Darganfyddwch a defnyddiwch API yr Adran Addysg a'i defnyddio i gysylltu â'u gwasanaethau digidol.",
+      "description": "Darganfyddwch a defnyddiwch API yr Adran Addysg (DfE) a'i defnyddio i gysylltu â'u gwasanaethau digidol.",
       "link_text": "Ewch i'ch cyfrif DfE dod o hyd i a defnyddio API",
       "link_href": "https://beta-find-and-use-an-api.education.gov.uk/identity/signin"
     }
@@ -216,7 +216,7 @@
     },
     "9uEx86ZHEp8ycgdHNqC8VK87E1A": {
       "header": "Dod o hyd a defnyddio API gan yr Adran Addysg",
-      "description": "Darganfyddwch a defnyddiwch API yr Adran Addysg a'i defnyddio i gysylltu â'u gwasanaethau digidol.",
+      "description": "Darganfyddwch a defnyddiwch API yr Adran Addysg (DfE) a'i defnyddio i gysylltu â'u gwasanaethau digidol.",
       "link_text": "Ewch i'ch cyfrif DfE dod o hyd i a defnyddio API",
       "link_href": "https://beta-find-and-use-an-api.education.gov.uk/identity/signin"
     }
@@ -327,7 +327,7 @@
     },
     "dfeFindAndUseAnApi": {
       "header": "Dod o hyd a defnyddio API gan yr Adran Addysg",
-      "description": "Darganfyddwch a defnyddiwch API yr Adran Addysg a'i defnyddio i gysylltu â'u gwasanaethau digidol.",
+      "description": "Darganfyddwch a defnyddiwch API yr Adran Addysg (DfE) a'i defnyddio i gysylltu â'u gwasanaethau digidol.",
       "link_text": "Ewch i'ch cyfrif DfE dod o hyd i a defnyddio API",
       "link_href": "https://beta-find-and-use-an-api.education.gov.uk/identity/signin"
     }
@@ -438,7 +438,7 @@
     },
     "dfeFindAndUseAnApi": {
       "header": "Dod o hyd a defnyddio API gan yr Adran Addysg",
-      "description": "Darganfyddwch a defnyddiwch API yr Adran Addysg a'i defnyddio i gysylltu â'u gwasanaethau digidol.",
+      "description": "Darganfyddwch a defnyddiwch API yr Adran Addysg (DfE) a'i defnyddio i gysylltu â'u gwasanaethau digidol.",
       "link_text": "Ewch i'ch cyfrif DfE dod o hyd i a defnyddio API",
       "link_href": "https://beta-find-and-use-an-api.education.gov.uk/identity/signin"
     }
@@ -549,7 +549,7 @@
     },
     "dfeFindAndUseAnApi": {
       "header": "Dod o hyd a defnyddio API gan yr Adran Addysg",
-      "description": "Darganfyddwch a defnyddiwch API yr Adran Addysg a'i defnyddio i gysylltu â'u gwasanaethau digidol.",
+      "description": "Darganfyddwch a defnyddiwch API yr Adran Addysg (DfE) a'i defnyddio i gysylltu â'u gwasanaethau digidol.",
       "link_text": "Ewch i'ch cyfrif DfE dod o hyd i a defnyddio API",
       "link_href": "https://beta-find-and-use-an-api.education.gov.uk/identity/signin"
     }
@@ -660,7 +660,7 @@
     },
     "dfeFindAndUseAnApi": {
       "header": "Dod o hyd a defnyddio API gan yr Adran Addysg",
-      "description": "Darganfyddwch a defnyddiwch API yr Adran Addysg a'i defnyddio i gysylltu â'u gwasanaethau digidol.",
+      "description": "Darganfyddwch a defnyddiwch API yr Adran Addysg (DfE) a'i defnyddio i gysylltu â'u gwasanaethau digidol.",
       "link_text": "Ewch i'ch cyfrif DfE dod o hyd i a defnyddio API",
       "link_href": "https://beta-find-and-use-an-api.education.gov.uk/identity/signin"
     }


### PR DESCRIPTION
## Proposed changes

OLH-1649 - Onboard RP: Find and use a DfE API

### What changed

Make corrections to link text and service description

### Why did it change

Found this as part of UCD review

### Related links

Fix on top of https://github.com/govuk-one-login/di-account-management-backend/pull/219

## Checklists

### Environment variables or secrets

- [ ] No environment variables or secrets were added or changed


### Permissions

## Testing

UCD Demo
## How to review

