### PR TITLE
OLH-1816-add-a-code-deploy-service-role-to-our-backend-stack

### DIFF
--- a/src/trigger-rsa-step.ts
+++ b/src/trigger-rsa-step.ts
@@ -14,11 +14,11 @@ export const handler = async (event: SNSEvent): Promise<void> => {
       try {
         if (!STATE_MACHINE_ARN || !DLQ_URL) {
           throw new Error(
-            "Error Occurred - Required environment variables to trigger report suspicious activity steps are not provided.",
+            "Error Occurred - Required environment variables to trigger report suspicious activity steps are not provided."
           );
         }
         const receivedEvent: ReportSuspiciousActivityStepInput = JSON.parse(
-          record.Sns.Message,
+          record.Sns.Message
         );
         if (
           receivedEvent.event_id === undefined ||
@@ -27,7 +27,7 @@ export const handler = async (event: SNSEvent): Promise<void> => {
           receivedEvent.user_id === undefined
         ) {
           throw new Error(
-            "Validation Failed - Required input to trigger report suspicious activity steps are not provided",
+            "Validation Failed - Required input to trigger report suspicious activity steps are not provided"
           );
         }
         await callAsyncStepFunction(STATE_MACHINE_ARN, receivedEvent);
@@ -35,7 +35,7 @@ export const handler = async (event: SNSEvent): Promise<void> => {
         console.error(
           `[Error occurred], trigger report suspicious activity step function:, ${
             (error as Error).message
-          }`,
+          }`
         );
         const { AWS_REGION } = process.env;
         const client = new SQSClient({ region: AWS_REGION });
@@ -46,9 +46,9 @@ export const handler = async (event: SNSEvent): Promise<void> => {
         const result = await client.send(new SendMessageCommand(message));
         console.error(
           `[Message sent to DLQ] with message id = ${result.MessageId}`,
-          error,
+          error
         );
       }
-    }),
+    })
   );
 };

--- a/src/trigger-rsa-step.ts
+++ b/src/trigger-rsa-step.ts
@@ -14,11 +14,11 @@ export const handler = async (event: SNSEvent): Promise<void> => {
       try {
         if (!STATE_MACHINE_ARN || !DLQ_URL) {
           throw new Error(
-            "Error Occurred - Required environment variables to trigger report suspicious activity steps are not provided"
+            "Error Occurred - Required environment variables to trigger report suspicious activity steps are not provided.",
           );
         }
         const receivedEvent: ReportSuspiciousActivityStepInput = JSON.parse(
-          record.Sns.Message
+          record.Sns.Message,
         );
         if (
           receivedEvent.event_id === undefined ||
@@ -27,7 +27,7 @@ export const handler = async (event: SNSEvent): Promise<void> => {
           receivedEvent.user_id === undefined
         ) {
           throw new Error(
-            "Validation Failed - Required input to trigger report suspicious activity steps are not provided"
+            "Validation Failed - Required input to trigger report suspicious activity steps are not provided",
           );
         }
         await callAsyncStepFunction(STATE_MACHINE_ARN, receivedEvent);
@@ -35,7 +35,7 @@ export const handler = async (event: SNSEvent): Promise<void> => {
         console.error(
           `[Error occurred], trigger report suspicious activity step function:, ${
             (error as Error).message
-          }`
+          }`,
         );
         const { AWS_REGION } = process.env;
         const client = new SQSClient({ region: AWS_REGION });
@@ -46,9 +46,9 @@ export const handler = async (event: SNSEvent): Promise<void> => {
         const result = await client.send(new SendMessageCommand(message));
         console.error(
           `[Message sent to DLQ] with message id = ${result.MessageId}`,
-          error
+          error,
         );
       }
-    })
+    }),
   );
 };

--- a/template.yaml
+++ b/template.yaml
@@ -181,7 +181,7 @@ Globals:
         Fn::If:
           - IsDevelopment
           - Canary10Percent5Minutes
-          - !Ref LambdaCanary10Percent5Minutes
+          - AllAtOnce
       Role: !GetAtt CodeDeployServiceRole.Arn
 
 Mappings:
@@ -2941,17 +2941,6 @@ Resources:
           !Ref AWS::NoValue,
         ]
 
-  LambdaCanary10Percent5Minutes:
-    Type: AWS::CodeDeploy::DeploymentConfig
-    Properties:
-      ComputePlatform: Lambda
-      DeploymentConfigName: LambdaCanary10Percent5Minutes
-      TrafficRoutingConfig:
-        TimeBasedCanary:
-          CanaryPercentage: 10
-          CanaryInterval: 5
-        Type: TimeBasedCanary
-
   CreateSupportTicketsDeploymentAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
@@ -2969,11 +2958,16 @@ Resources:
       MetricName: "Errors"
       Dimensions:
         - Name: Resource
-          Value: !Sub "${CreateSupportTicketFunction}:live"
+          Value:
+            !Join [
+              ":",
+              [
+                !Ref CreateSupportTicketFunction,
+                !GetAtt CreateSupportTicketFunction.Version.Version,
+              ],
+            ]
         - Name: "FunctionName"
           Value: !Ref CreateSupportTicketFunction
-        - Name: ExecutedVersion
-          Value: !GetAtt CreateSupportTicketFunction.Version.Version
       Statistic: "Sum"
       Period: 60
       EvaluationPeriods: 2
@@ -3001,11 +2995,16 @@ Resources:
       MetricName: "Errors"
       Dimensions:
         - Name: Resource
-          Value: !Sub "${DeleteActivityLogFunction}:live"
+          Value:
+            !Join [
+              ":",
+              [
+                !Ref DeleteActivityLogFunction,
+                !GetAtt DeleteActivityLogFunction.Version.Version,
+              ],
+            ]
         - Name: "FunctionName"
           Value: !Ref DeleteActivityLogFunction
-        - Name: ExecutedVersion
-          Value: !GetAtt DeleteActivityLogFunction.Version.Version
       Statistic: "Sum"
       Period: 60
       EvaluationPeriods: 1
@@ -3033,11 +3032,16 @@ Resources:
       MetricName: "Errors"
       Dimensions:
         - Name: Resource
-          Value: !Sub "${SendConfEmailFunction}:live"
+          Value:
+            !Join [
+              ":",
+              [
+                !Ref SendConfEmailFunction,
+                !GetAtt SendConfEmailFunction.Version.Version,
+              ],
+            ]
         - Name: "FunctionName"
           Value: !Ref SendConfEmailFunction
-        - Name: ExecutedVersion
-          Value: !GetAtt SendConfEmailFunction.Version.Version
       Statistic: "Sum"
       Period: 60
       EvaluationPeriods: 1
@@ -3065,11 +3069,16 @@ Resources:
       MetricName: "Errors"
       Dimensions:
         - Name: Resource
-          Value: !Sub "${FormatActivityLogFunction}:live"
+          Value:
+            !Join [
+              ":",
+              [
+                !Ref FormatActivityLogFunction,
+                !GetAtt FormatActivityLogFunction.Version.Version,
+              ],
+            ]
         - Name: "FunctionName"
           Value: !Ref FormatActivityLogFunction
-        - Name: ExecutedVersion
-          Value: !GetAtt FormatActivityLogFunction.Version.Version
       Statistic: "Sum"
       Period: 60
       EvaluationPeriods: 1
@@ -3097,11 +3106,16 @@ Resources:
       MetricName: "Errors"
       Dimensions:
         - Name: Resource
-          Value: !Sub "${QueryUserServicesFunction}:live"
+          Value:
+            !Join [
+              ":",
+              [
+                !Ref QueryUserServicesFunction,
+                !GetAtt QueryUserServicesFunction.Version.Version,
+              ],
+            ]
         - Name: "FunctionName"
           Value: !Ref QueryUserServicesFunction
-        - Name: ExecutedVersion
-          Value: !GetAtt QueryUserServicesFunction.Version.Version
       Statistic: "Sum"
       Period: 60
       EvaluationPeriods: 1
@@ -3129,11 +3143,16 @@ Resources:
       MetricName: "Errors"
       Dimensions:
         - Name: Resource
-          Value: !Sub "${WriteActivityLogFunction}:live"
+          Value:
+            !Join [
+              ":",
+              [
+                !Ref WriteActivityLogFunction,
+                !GetAtt WriteActivityLogFunction.Version.Version,
+              ],
+            ]
         - Name: "FunctionName"
           Value: !Ref WriteActivityLogFunction
-        - Name: ExecutedVersion
-          Value: !GetAtt WriteActivityLogFunction.Version.Version
       Statistic: "Sum"
       Period: 60
       EvaluationPeriods: 1
@@ -3161,11 +3180,16 @@ Resources:
       MetricName: "Errors"
       Dimensions:
         - Name: Resource
-          Value: !Sub "${DeleteUserServicesFunction}:live"
+          Value:
+            !Join [
+              ":",
+              [
+                !Ref DeleteUserServicesFunction,
+                !GetAtt DeleteUserServicesFunction.Version.Version,
+              ],
+            ]
         - Name: "FunctionName"
           Value: !Ref DeleteUserServicesFunction
-        - Name: ExecutedVersion
-          Value: !GetAtt DeleteUserServicesFunction.Version.Version
       Statistic: "Sum"
       Period: 60
       EvaluationPeriods: 1
@@ -3193,11 +3217,16 @@ Resources:
       MetricName: "Errors"
       Dimensions:
         - Name: Resource
-          Value: !Sub "${MarkActivityReportedFunction}:live"
+          Value:
+            !Join [
+              ":",
+              [
+                !Ref MarkActivityReportedFunction,
+                !GetAtt MarkActivityReportedFunction.Version.Version,
+              ],
+            ]
         - Name: "FunctionName"
           Value: !Ref MarkActivityReportedFunction
-        - Name: ExecutedVersion
-          Value: !GetAtt MarkActivityReportedFunction.Version.Version
       Statistic: "Sum"
       Period: 60
       EvaluationPeriods: 1
@@ -3225,11 +3254,16 @@ Resources:
       MetricName: "Errors"
       Dimensions:
         - Name: Resource
-          Value: !Sub "${DeleteEmailSubscriptionsFunction}:live"
+          Value:
+            !Join [
+              ":",
+              [
+                !Ref DeleteEmailSubscriptionsFunction,
+                !GetAtt DeleteEmailSubscriptionsFunction.Version.Version,
+              ],
+            ]
         - Name: "FunctionName"
           Value: !Ref DeleteEmailSubscriptionsFunction
-        - Name: ExecutedVersion
-          Value: !GetAtt DeleteEmailSubscriptionsFunction.Version.Version
       Statistic: "Sum"
       Period: 60
       EvaluationPeriods: 1
@@ -3257,11 +3291,16 @@ Resources:
       MetricName: "Errors"
       Dimensions:
         - Name: Resource
-          Value: !Sub "${SaveRawEventsFunction}:live"
+          Value:
+            !Join [
+              ":",
+              [
+                !Ref SaveRawEventsFunction,
+                !GetAtt SaveRawEventsFunction.Version.Version,
+              ],
+            ]
         - Name: "FunctionName"
           Value: !Ref SaveRawEventsFunction
-        - Name: ExecutedVersion
-          Value: !GetAtt SaveRawEventsFunction.Version.Version
       Statistic: "Sum"
       Period: 60
       EvaluationPeriods: 1
@@ -3289,11 +3328,16 @@ Resources:
       MetricName: "Errors"
       Dimensions:
         - Name: Resource
-          Value: !Sub "${WriteUserServicesFunction}:live"
+          Value:
+            !Join [
+              ":",
+              [
+                !Ref WriteUserServicesFunction,
+                !GetAtt WriteUserServicesFunction.Version.Version,
+              ],
+            ]
         - Name: "FunctionName"
           Value: !Ref WriteUserServicesFunction
-        - Name: ExecutedVersion
-          Value: !GetAtt WriteUserServicesFunction.Version.Version
       Statistic: "Sum"
       Period: 60
       EvaluationPeriods: 1
@@ -3321,11 +3365,16 @@ Resources:
       MetricName: "Errors"
       Dimensions:
         - Name: Resource
-          Value: !Sub "${SendSuspiciousActivityFunction}:live"
+          Value:
+            !Join [
+              ":",
+              [
+                !Ref SendSuspiciousActivityFunction,
+                !GetAtt SendSuspiciousActivityFunction.Version.Version,
+              ],
+            ]
         - Name: "FunctionName"
           Value: !Ref SendSuspiciousActivityFunction
-        - Name: ExecutedVersion
-          Value: !GetAtt SendSuspiciousActivityFunction.Version.Version
       Statistic: "Sum"
       Period: 60
       EvaluationPeriods: 1
@@ -3390,11 +3439,16 @@ Resources:
       MetricName: "Errors"
       Dimensions:
         - Name: Resource
-          Value: !Sub "${FormatUserServicesFunction}:live"
+          Value:
+            !Join [
+              ":",
+              [
+                !Ref FormatUserServicesFunction,
+                !GetAtt FormatUserServicesFunction.Version.Version,
+              ],
+            ]
         - Name: "FunctionName"
           Value: !Ref FormatUserServicesFunction
-        - Name: ExecutedVersion
-          Value: !GetAtt FormatUserServicesFunction.Version.Version
       Statistic: "Sum"
       Period: 60
       EvaluationPeriods: 1

--- a/template.yaml
+++ b/template.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
-Description: "A template to create the GOV.UK One login Account backend infrastructure."
+Description: "A template to create the GOV.UK One login Account backend infrastructure"
 
 Parameters:
   UserServicesStoreTableName:
@@ -84,6 +84,11 @@ Conditions:
           - !Ref Environment
           - "dev"
 
+  IsDevelopment:
+    Fn::Equals:
+      - !Ref Environment
+      - "dev"
+
   UseInternalEvents: !Or
     - !Equals [!Ref Environment, dev]
     - !Equals [!Ref Environment, build]
@@ -100,20 +105,45 @@ Globals:
       Variables:
         AWS_LAMBDA_EXEC_WRAPPER: /opt/dynatrace
         DT_CONNECTION_AUTH_TOKEN: !Sub
-          - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_CONNECTION_AUTH_TOKEN}}'
-          - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
+          - "{{resolve:secretsmanager:${SecretArn}:SecretString:DT_CONNECTION_AUTH_TOKEN}}"
+          - SecretArn:
+              !FindInMap [
+                EnvironmentConfiguration,
+                !Ref Environment,
+                dynatraceSecretArn,
+              ]
         DT_CONNECTION_BASE_URL: !Sub
-          - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_CONNECTION_BASE_URL}}'
-          - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
+          - "{{resolve:secretsmanager:${SecretArn}:SecretString:DT_CONNECTION_BASE_URL}}"
+          - SecretArn:
+              !FindInMap [
+                EnvironmentConfiguration,
+                !Ref Environment,
+                dynatraceSecretArn,
+              ]
         DT_CLUSTER_ID: !Sub
-          - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_CLUSTER_ID}}'
-          - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
+          - "{{resolve:secretsmanager:${SecretArn}:SecretString:DT_CLUSTER_ID}}"
+          - SecretArn:
+              !FindInMap [
+                EnvironmentConfiguration,
+                !Ref Environment,
+                dynatraceSecretArn,
+              ]
         DT_LOG_COLLECTION_AUTH_TOKEN: !Sub
-          - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_LOG_COLLECTION_AUTH_TOKEN}}'
-          - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
+          - "{{resolve:secretsmanager:${SecretArn}:SecretString:DT_LOG_COLLECTION_AUTH_TOKEN}}"
+          - SecretArn:
+              !FindInMap [
+                EnvironmentConfiguration,
+                !Ref Environment,
+                dynatraceSecretArn,
+              ]
         DT_TENANT: !Sub
-          - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_TENANT}}'
-          - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
+          - "{{resolve:secretsmanager:${SecretArn}:SecretString:DT_TENANT}}"
+          - SecretArn:
+              !FindInMap [
+                EnvironmentConfiguration,
+                !Ref Environment,
+                dynatraceSecretArn,
+              ]
         DT_OPEN_TELEMETRY_ENABLE_INTEGRATION: "true"
     Architectures: ["arm64"]
     MemorySize: 128
@@ -123,8 +153,8 @@ Globals:
     Timeout: 5
     VpcConfig:
       SubnetIds:
-          - Fn::ImportValue: !Sub "${VpcStackName}-ProtectedSubnetIdA"
-          - Fn::ImportValue: !Sub "${VpcStackName}-ProtectedSubnetIdB"
+        - Fn::ImportValue: !Sub "${VpcStackName}-ProtectedSubnetIdA"
+        - Fn::ImportValue: !Sub "${VpcStackName}-ProtectedSubnetIdB"
       SecurityGroupIds:
         - Fn::ImportValue: !Sub ${VpcStackName}-AWSServicesEndpointSecurityGroupId
     CodeSigningConfigArn: !If
@@ -137,8 +167,22 @@ Globals:
       - !Ref AWS::NoValue
     Layers:
       - !Sub
-        - '{{resolve:secretsmanager:${SecretArn}:SecretString:NODEJS_LAYER}}'
-        - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
+        - "{{resolve:secretsmanager:${SecretArn}:SecretString:NODEJS_LAYER}}"
+        - SecretArn:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !Ref Environment,
+              dynatraceSecretArn,
+            ]
+    AutoPublishAlias: live
+    DeploymentPreference:
+      Enabled: true
+      Type:
+        Fn::If:
+          - IsDevelopment
+          - Canary10Percent5Minutes
+          - !Ref LambdaCanary10Percent5Minutes
+      Role: !GetAtt CodeDeployServiceRole.Arn
 
 Mappings:
   InputQueue:
@@ -271,7 +315,6 @@ Mappings:
       zendeskApiUrlSecretArn: arn:aws:secretsmanager:eu-west-2:026991849909:secret:/account-mgmt-backend/zendesk-api-url-key-WNGekL
       zendeskTicketFormIdSecretArn: arn:aws:secretsmanager:eu-west-2:026991849909:secret:/account-mgmt-backend/zendesk-ticket-form-id-key-cAmu3i
       notifyApiKeySecretArn: arn:aws:secretsmanager:eu-west-2:026991849909:secret:/account-mgmt-backend/notify-api-key-Ve4Yk1
-
 
 Resources:
   ######################################
@@ -571,6 +614,9 @@ Resources:
         Variables:
           TABLE_NAME: !Ref RawEventsStoreTableName
           DLQ_URL: !Ref SaveRawEventsDeadLetterQueue
+      DeploymentPreference:
+        Alarms:
+          - !Ref SaveRawEventsFunctionDeploymentAlarm
     Metadata:
       BuildMethod: esbuild
       BuildProperties:
@@ -693,6 +739,7 @@ Resources:
   ########################
   QueryUserServicesFunction:
     Type: AWS::Serverless::Function
+
     DependsOn:
       - QueryUserServicesFunctionLogGroup
     Properties:
@@ -723,6 +770,9 @@ Resources:
           TABLE_NAME: !Ref UserServicesStoreTableName
           DLQ_URL: !Ref QueryUserServicesDeadLetterQueue
           OUTPUT_QUEUE_URL: !Ref UserServicesToFormatQueue
+      DeploymentPreference:
+        Alarms:
+          - !Ref QueryUserServicesFunctionDeploymentAlarm
     Metadata:
       BuildMethod: esbuild
       BuildProperties:
@@ -880,6 +930,9 @@ Resources:
         Variables:
           DLQ_URL: !Ref FormatUserServicesDeadLetterQueue
           OUTPUT_QUEUE_URL: !Ref UserServicesToWriteQueue
+      DeploymentPreference:
+        Alarms:
+          - !Ref FormatUserServicesFunctionDeploymentAlarm
     Metadata:
       BuildMethod: esbuild
       BuildProperties:
@@ -1015,6 +1068,9 @@ Resources:
         Variables:
           TABLE_NAME: !Ref UserServicesStoreTableName
           DLQ_URL: !Ref WriteUserServicesDeadLetterQueue
+      DeploymentPreference:
+        Alarms:
+          - !Ref WriteUserServicesFunctionDeploymentAlarm
     Metadata:
       BuildMethod: esbuild
       BuildProperties:
@@ -1184,10 +1240,10 @@ Resources:
                 - ""
                 - - "arn:aws:iam::"
                   - !FindInMap [
-                    AccountInterventionsService,
-                    !Ref Environment,
-                    "AccountNumber",
-                  ]
+                      AccountInterventionsService,
+                      !Ref Environment,
+                      "AccountNumber",
+                    ]
                   - ":root"
             Action: sns:Subscribe
             Resource:
@@ -1239,6 +1295,9 @@ Resources:
         Variables:
           TABLE_NAME: !Ref UserServicesStoreTableName
           DLQ_URL: !Ref DeleteUserServicesDeadLetterQueue
+      DeploymentPreference:
+        Alarms:
+          - !Ref DeleteUserServicesFunctionDeploymentAlarm
     Metadata:
       BuildMethod: esbuild
       BuildProperties:
@@ -1468,6 +1527,9 @@ Resources:
               !Ref Environment,
               GOVACCOUNTSPUBLISHINGAPIURL,
             ]
+      DeploymentPreference:
+        Alarms:
+          - !Ref DeleteEmailSubscriptionsFunctionDeploymentAlarm
     Metadata:
       BuildMethod: esbuild
       BuildProperties:
@@ -1581,6 +1643,9 @@ Resources:
           VERIFY_ACCESS_VALUE: !Sub "{{resolve:secretsmanager:/${AWS::StackName}/Config/Storage/VerificationSecret}}"
           ACCOUNT_ID: !Sub "${AWS::AccountId}"
           ENVIRONMENT: !Ref Environment
+      DeploymentPreference:
+        Alarms:
+          - !Ref WriteActivityLogFunctionDeploymentAlarm
     Metadata:
       BuildMethod: esbuild
       BuildProperties:
@@ -1744,6 +1809,9 @@ Resources:
           ACCOUNT_ID: !Sub "${AWS::AccountId}"
           GENERATOR_KEY_ARN: !GetAtt GeneratorKey.Arn
           WRAPPING_KEY_ARN: !GetAtt WrapperKey.Arn
+      DeploymentPreference:
+        Alarms:
+          - !Ref FormatActivityLogFunctionDeploymentAlarm
     Metadata:
       BuildMethod: esbuild
       BuildProperties:
@@ -1957,6 +2025,9 @@ Resources:
         Variables:
           TABLE_NAME: !Ref ActivityLogsStoreTableName
           DLQ_URL: !Ref DeleteActivityLogDeadLetterQueue
+      DeploymentPreference:
+        Alarms:
+          - !Ref DeleteActivityLogFunctionDeploymentAlarm
     Metadata:
       BuildMethod: esbuild
       BuildProperties:
@@ -2094,9 +2165,9 @@ Resources:
         - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/LowAlertNotificationTopic/ARN}}"
       ActionsEnabled: true
 
-######################
-# Mark Suspicious Activity as Reported
-######################
+  ######################
+  # Mark Suspicious Activity as Reported
+  ######################
   MarkActivityReportedFunction:
     DependsOn:
       - MarkActivityReportedLogGroup
@@ -2115,6 +2186,9 @@ Resources:
           VERIFY_ACCESS_VALUE: !Sub "{{resolve:secretsmanager:/${AWS::StackName}/Config/Storage/VerificationSecret}}"
           ACCOUNT_ID: !Sub "${AWS::AccountId}"
           ENVIRONMENT: !Ref Environment
+      DeploymentPreference:
+        Alarms:
+          - !Ref MarkActivityReportedFunctionDeploymentAlarm
     Metadata:
       BuildMethod: esbuild
       BuildProperties:
@@ -2185,7 +2259,6 @@ Resources:
       RetentionInDays: 30
       KmsKeyId: !GetAtt LoggingKmsKey.Arn
 
-
   ######################
   # Send Suspicious Activity to TxMA
   ######################
@@ -2203,6 +2276,9 @@ Resources:
         Variables:
           EVENT_NAME: HOME_REPORT_SUSPICIOUS_ACTIVITY
           TXMA_QUEUE_URL: !Ref AuditOutputQueue
+      DeploymentPreference:
+        Alarms:
+          - !Ref SendSuspiciousActivityFunctionDeploymentAlarm
     Metadata:
       BuildMethod: esbuild
       BuildProperties:
@@ -2295,8 +2371,16 @@ Resources:
       Environment:
         Variables:
           NOTIFY_API_KEY: /account-mgmt-backend/notify-api-key
-          TEMPLATE_ID: !FindInMap [ EnvironmentVariables, !Ref Environment, REPORTSUSPISCIOUSACTIVITYTEMPLATEID ]
+          TEMPLATE_ID:
+            !FindInMap [
+              EnvironmentVariables,
+              !Ref Environment,
+              REPORTSUSPISCIOUSACTIVITYTEMPLATEID,
+            ]
           ENVIRONMENT_NAME: !Ref Environment
+      DeploymentPreference:
+        Alarms:
+          - !Ref SendConfEmailFunctionDeploymentAlarm
     Metadata:
       BuildMethod: esbuild
       BuildProperties:
@@ -2342,7 +2426,11 @@ Resources:
           - Effect: Allow
             Action: secretsmanager:GetSecretValue # pragma: allowlist secret
             Resource:
-              - !FindInMap [ EnvironmentConfiguration, !Ref Environment, notifyApiKeySecretArn ]
+              - !FindInMap [
+                  EnvironmentConfiguration,
+                  !Ref Environment,
+                  notifyApiKeySecretArn,
+                ]
 
   SendConfEmailLambdaInvokePermission:
     Type: AWS::Lambda::Permission
@@ -2390,6 +2478,9 @@ Resources:
           ZENDESK_API_URL_KEY: /account-mgmt-backend/zendesk-api-url-key
           ZENDESK_TICKET_FORM_ID: /account-mgmt-backend/zendesk-ticket-form-id-key
           ACTIVITY_LOG_TABLE: !Ref ActivityLogsStoreTableName
+      DeploymentPreference:
+        Alarms:
+          - !Ref CreateSupportTicketsDeploymentAlarm
     Metadata:
       BuildMethod: esbuild
       BuildProperties:
@@ -2455,12 +2546,36 @@ Resources:
           - Effect: Allow
             Action: secretsmanager:GetSecretValue # pragma: allowlist secret
             Resource:
-              - !FindInMap [ EnvironmentConfiguration, !Ref Environment, zendeskGroupIdSecretArn ]
-              - !FindInMap [ EnvironmentConfiguration, !Ref Environment, zendeskTagsSecretArn ]
-              - !FindInMap [ EnvironmentConfiguration, !Ref Environment, zendeskApiTokenSecretArn ]
-              - !FindInMap [ EnvironmentConfiguration, !Ref Environment, zendeskApiUserSecretArn ]
-              - !FindInMap [ EnvironmentConfiguration, !Ref Environment, zendeskApiUrlSecretArn ]
-              - !FindInMap [ EnvironmentConfiguration, !Ref Environment, zendeskTicketFormIdSecretArn ]
+              - !FindInMap [
+                  EnvironmentConfiguration,
+                  !Ref Environment,
+                  zendeskGroupIdSecretArn,
+                ]
+              - !FindInMap [
+                  EnvironmentConfiguration,
+                  !Ref Environment,
+                  zendeskTagsSecretArn,
+                ]
+              - !FindInMap [
+                  EnvironmentConfiguration,
+                  !Ref Environment,
+                  zendeskApiTokenSecretArn,
+                ]
+              - !FindInMap [
+                  EnvironmentConfiguration,
+                  !Ref Environment,
+                  zendeskApiUserSecretArn,
+                ]
+              - !FindInMap [
+                  EnvironmentConfiguration,
+                  !Ref Environment,
+                  zendeskApiUrlSecretArn,
+                ]
+              - !FindInMap [
+                  EnvironmentConfiguration,
+                  !Ref Environment,
+                  zendeskTicketFormIdSecretArn,
+                ]
 
   CreateSupportTicketLambdaInvokePermission:
     Type: AWS::Lambda::Permission
@@ -2567,8 +2682,11 @@ Resources:
       Environment:
         Variables:
           STATE_MACHINE_ARN: !Ref ReportSuspiciousActivityStepFunction
-          STEP_FUNCTION_ALIAS: 'latest'
+          STEP_FUNCTION_ALIAS: "latest"
           DLQ_URL: !Ref TriggerSuspiciousActivityStepDeadLetterQueue
+      DeploymentPreference:
+        Alarms:
+          - !Ref TriggerSuspiciousActivityStepFunctionDeploymentAlarm
     Metadata:
       BuildMethod: esbuild
       BuildProperties:
@@ -2645,7 +2763,6 @@ Resources:
       DestinationArn: !Sub "{{resolve:ssm:/${Environment}/Platform/Logs/Subscription/CSLS/ARN}}"
       FilterPattern: ""
       LogGroupName: !Ref TriggerSuspiciousActivityStepFunctionLogGroup
-
 
   ######################
   # Report Suspicious Activity Step Function
@@ -2798,6 +2915,486 @@ Resources:
       EvaluationPeriods: 1
       AlarmActions:
         - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/HighAlertNotificationTopic/ARN}}"
+
+  #######################
+  # Canary Deployment
+  #######################
+
+  CodeDeployServiceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Action:
+              - sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service:
+                - codedeploy.amazonaws.com
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda
+      PermissionsBoundary:
+        !If [
+          UsePermissionsBoundary,
+          !Ref PermissionsBoundary,
+          !Ref AWS::NoValue,
+        ]
+
+  LambdaCanary10Percent5Minutes:
+    Type: AWS::CodeDeploy::DeploymentConfig
+    Properties:
+      ComputePlatform: Lambda
+      DeploymentConfigName: LambdaCanary10Percent5Minutes
+      TrafficRoutingConfig:
+        TimeBasedCanary:
+          CanaryPercentage: 10
+          CanaryInterval: 5
+        Type: TimeBasedCanary
+
+  CreateSupportTicketsDeploymentAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName:
+        !Join [
+          "-",
+          [
+            !Ref AWS::StackName,
+            !Ref Environment,
+            "CreateSupportTicketsDeploymentAlarm",
+          ],
+        ]
+      AlarmDescription: "Alarm for Lambda function errors during canary deployment"
+      Namespace: "AWS/Lambda"
+      MetricName: "Errors"
+      Dimensions:
+        - Name: Resource
+          Value: !Sub "${CreateSupportTicketFunction}:live"
+        - Name: "FunctionName"
+          Value: !Ref CreateSupportTicketFunction
+        - Name: ExecutedVersion
+          Value: !GetAtt CreateSupportTicketFunction.Version.Version
+      Statistic: "Sum"
+      Period: 60
+      EvaluationPeriods: 2
+      Threshold: 0
+      ComparisonOperator: "GreaterThanThreshold"
+      AlarmActions:
+        - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/LowAlertNotificationTopic/ARN}}"
+      ActionsEnabled: true
+      TreatMissingData: notBreaching
+
+  DeleteActivityLogFunctionDeploymentAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName:
+        !Join [
+          "-",
+          [
+            !Ref AWS::StackName,
+            !Ref Environment,
+            "DeleteActivityLogFunctionDeploymentAlarm",
+          ],
+        ]
+      AlarmDescription: "Alarm for Lambda function errors during canary deployment"
+      Namespace: "AWS/Lambda"
+      MetricName: "Errors"
+      Dimensions:
+        - Name: Resource
+          Value: !Sub "${DeleteActivityLogFunction}:live"
+        - Name: "FunctionName"
+          Value: !Ref DeleteActivityLogFunction
+        - Name: ExecutedVersion
+          Value: !GetAtt DeleteActivityLogFunction.Version.Version
+      Statistic: "Sum"
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 0
+      ComparisonOperator: "GreaterThanThreshold"
+      AlarmActions:
+        - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/LowAlertNotificationTopic/ARN}}"
+      ActionsEnabled: true
+      TreatMissingData: notBreaching
+
+  SendConfEmailFunctionDeploymentAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName:
+        !Join [
+          "-",
+          [
+            !Ref AWS::StackName,
+            !Ref Environment,
+            "SendConfEmailFunctionDeploymentAlarm",
+          ],
+        ]
+      AlarmDescription: "Alarm for Lambda function errors during canary deployment"
+      Namespace: "AWS/Lambda"
+      MetricName: "Errors"
+      Dimensions:
+        - Name: Resource
+          Value: !Sub "${SendConfEmailFunction}:live"
+        - Name: "FunctionName"
+          Value: !Ref SendConfEmailFunction
+        - Name: ExecutedVersion
+          Value: !GetAtt SendConfEmailFunction.Version.Version
+      Statistic: "Sum"
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 0
+      ComparisonOperator: "GreaterThanThreshold"
+      AlarmActions:
+        - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/LowAlertNotificationTopic/ARN}}"
+      ActionsEnabled: true
+      TreatMissingData: notBreaching
+
+  FormatActivityLogFunctionDeploymentAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName:
+        !Join [
+          "-",
+          [
+            !Ref AWS::StackName,
+            !Ref Environment,
+            "FormatActivityLogFunctionDeploymentAlarm",
+          ],
+        ]
+      AlarmDescription: "Alarm for Lambda function errors during canary deployment"
+      Namespace: "AWS/Lambda"
+      MetricName: "Errors"
+      Dimensions:
+        - Name: Resource
+          Value: !Sub "${FormatActivityLogFunction}:live"
+        - Name: "FunctionName"
+          Value: !Ref FormatActivityLogFunction
+        - Name: ExecutedVersion
+          Value: !GetAtt FormatActivityLogFunction.Version.Version
+      Statistic: "Sum"
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 0
+      ComparisonOperator: "GreaterThanThreshold"
+      AlarmActions:
+        - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/LowAlertNotificationTopic/ARN}}"
+      ActionsEnabled: true
+      TreatMissingData: notBreaching
+
+  QueryUserServicesFunctionDeploymentAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName:
+        !Join [
+          "-",
+          [
+            !Ref AWS::StackName,
+            !Ref Environment,
+            "QueryUserServicesFunctionDeploymentAlarm",
+          ],
+        ]
+      AlarmDescription: "Alarm for Lambda function errors during canary deployment"
+      Namespace: "AWS/Lambda"
+      MetricName: "Errors"
+      Dimensions:
+        - Name: Resource
+          Value: !Sub "${QueryUserServicesFunction}:live"
+        - Name: "FunctionName"
+          Value: !Ref QueryUserServicesFunction
+        - Name: ExecutedVersion
+          Value: !GetAtt QueryUserServicesFunction.Version.Version
+      Statistic: "Sum"
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 0
+      ComparisonOperator: "GreaterThanThreshold"
+      AlarmActions:
+        - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/LowAlertNotificationTopic/ARN}}"
+      ActionsEnabled: true
+      TreatMissingData: notBreaching
+
+  WriteActivityLogFunctionDeploymentAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName:
+        !Join [
+          "-",
+          [
+            !Ref AWS::StackName,
+            !Ref Environment,
+            "WriteActivityLogFunctionDeploymentAlarm",
+          ],
+        ]
+      AlarmDescription: "Alarm for Lambda function errors during canary deployment"
+      Namespace: "AWS/Lambda"
+      MetricName: "Errors"
+      Dimensions:
+        - Name: Resource
+          Value: !Sub "${WriteActivityLogFunction}:live"
+        - Name: "FunctionName"
+          Value: !Ref WriteActivityLogFunction
+        - Name: ExecutedVersion
+          Value: !GetAtt WriteActivityLogFunction.Version.Version
+      Statistic: "Sum"
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 0
+      ComparisonOperator: "GreaterThanThreshold"
+      AlarmActions:
+        - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/LowAlertNotificationTopic/ARN}}"
+      ActionsEnabled: true
+      TreatMissingData: notBreaching
+
+  DeleteUserServicesFunctionDeploymentAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName:
+        !Join [
+          "-",
+          [
+            !Ref AWS::StackName,
+            !Ref Environment,
+            "DeleteUserServicesFunctionDeploymentAlarm",
+          ],
+        ]
+      AlarmDescription: "Alarm for Lambda function errors during canary deployment"
+      Namespace: "AWS/Lambda"
+      MetricName: "Errors"
+      Dimensions:
+        - Name: Resource
+          Value: !Sub "${DeleteUserServicesFunction}:live"
+        - Name: "FunctionName"
+          Value: !Ref DeleteUserServicesFunction
+        - Name: ExecutedVersion
+          Value: !GetAtt DeleteUserServicesFunction.Version.Version
+      Statistic: "Sum"
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 0
+      ComparisonOperator: "GreaterThanThreshold"
+      AlarmActions:
+        - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/LowAlertNotificationTopic/ARN}}"
+      ActionsEnabled: true
+      TreatMissingData: notBreaching
+
+  MarkActivityReportedFunctionDeploymentAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName:
+        !Join [
+          "-",
+          [
+            !Ref AWS::StackName,
+            !Ref Environment,
+            "MarkActivityReportedFunctionDeploymentAlarm",
+          ],
+        ]
+      AlarmDescription: "Alarm for Lambda function errors during canary deployment"
+      Namespace: "AWS/Lambda"
+      MetricName: "Errors"
+      Dimensions:
+        - Name: Resource
+          Value: !Sub "${MarkActivityReportedFunction}:live"
+        - Name: "FunctionName"
+          Value: !Ref MarkActivityReportedFunction
+        - Name: ExecutedVersion
+          Value: !GetAtt MarkActivityReportedFunction.Version.Version
+      Statistic: "Sum"
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 0
+      ComparisonOperator: "GreaterThanThreshold"
+      AlarmActions:
+        - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/LowAlertNotificationTopic/ARN}}"
+      ActionsEnabled: true
+      TreatMissingData: notBreaching
+
+  DeleteEmailSubscriptionsFunctionDeploymentAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName:
+        !Join [
+          "-",
+          [
+            !Ref AWS::StackName,
+            !Ref Environment,
+            "DeleteEmailSubscriptionsFunctionDeploymentAlarm",
+          ],
+        ]
+      AlarmDescription: "Alarm for Lambda function errors during canary deployment"
+      Namespace: "AWS/Lambda"
+      MetricName: "Errors"
+      Dimensions:
+        - Name: Resource
+          Value: !Sub "${DeleteEmailSubscriptionsFunction}:live"
+        - Name: "FunctionName"
+          Value: !Ref DeleteEmailSubscriptionsFunction
+        - Name: ExecutedVersion
+          Value: !GetAtt DeleteEmailSubscriptionsFunction.Version.Version
+      Statistic: "Sum"
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 0
+      ComparisonOperator: "GreaterThanThreshold"
+      AlarmActions:
+        - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/LowAlertNotificationTopic/ARN}}"
+      ActionsEnabled: true
+      TreatMissingData: notBreaching
+
+  SaveRawEventsFunctionDeploymentAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName:
+        !Join [
+          "-",
+          [
+            !Ref AWS::StackName,
+            !Ref Environment,
+            "SaveRawEventsFunctionDeploymentAlarm",
+          ],
+        ]
+      AlarmDescription: "Alarm for Lambda function errors during canary deployment"
+      Namespace: "AWS/Lambda"
+      MetricName: "Errors"
+      Dimensions:
+        - Name: Resource
+          Value: !Sub "${SaveRawEventsFunction}:live"
+        - Name: "FunctionName"
+          Value: !Ref SaveRawEventsFunction
+        - Name: ExecutedVersion
+          Value: !GetAtt SaveRawEventsFunction.Version.Version
+      Statistic: "Sum"
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 0
+      ComparisonOperator: "GreaterThanThreshold"
+      AlarmActions:
+        - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/LowAlertNotificationTopic/ARN}}"
+      ActionsEnabled: true
+      TreatMissingData: notBreaching
+
+  WriteUserServicesFunctionDeploymentAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName:
+        !Join [
+          "-",
+          [
+            !Ref AWS::StackName,
+            !Ref Environment,
+            "WriteUserServicesFunctionDeploymentAlarm",
+          ],
+        ]
+      AlarmDescription: "Alarm for Lambda function errors during canary deployment"
+      Namespace: "AWS/Lambda"
+      MetricName: "Errors"
+      Dimensions:
+        - Name: Resource
+          Value: !Sub "${WriteUserServicesFunction}:live"
+        - Name: "FunctionName"
+          Value: !Ref WriteUserServicesFunction
+        - Name: ExecutedVersion
+          Value: !GetAtt WriteUserServicesFunction.Version.Version
+      Statistic: "Sum"
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 0
+      ComparisonOperator: "GreaterThanThreshold"
+      AlarmActions:
+        - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/LowAlertNotificationTopic/ARN}}"
+      ActionsEnabled: true
+      TreatMissingData: notBreaching
+
+  SendSuspiciousActivityFunctionDeploymentAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName:
+        !Join [
+          "-",
+          [
+            !Ref AWS::StackName,
+            !Ref Environment,
+            "SendSuspiciousActivityFunctionDeploymentAlarm",
+          ],
+        ]
+      AlarmDescription: "Alarm for Lambda function errors during canary deployment"
+      Namespace: "AWS/Lambda"
+      MetricName: "Errors"
+      Dimensions:
+        - Name: "FunctionName"
+          Value: !Ref SendSuspiciousActivityFunction
+        - Name: ExecutedVersion
+          Value: !GetAtt SendSuspiciousActivityFunction.Version.Version
+      Statistic: "Sum"
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 0
+      ComparisonOperator: "GreaterThanThreshold"
+      AlarmActions:
+        - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/LowAlertNotificationTopic/ARN}}"
+      ActionsEnabled: true
+      TreatMissingData: notBreaching
+
+  TriggerSuspiciousActivityStepFunctionDeploymentAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName:
+        !Join [
+          "-",
+          [
+            !Ref AWS::StackName,
+            !Ref Environment,
+            "TriggerSuspiciousActivityStepFunctionDeploymentAlarm",
+          ],
+        ]
+      AlarmDescription: "Alarm for Lambda function errors during canary deployment"
+      Namespace: "AWS/Lambda"
+      MetricName: "Errors"
+      Dimensions:
+        - Name: "FunctionName"
+          Value: !Ref TriggerSuspiciousActivityStepFunction
+        - Name: ExecutedVersion
+          Value: !GetAtt TriggerSuspiciousActivityStepFunction.Version.Version
+      Statistic: "Sum"
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 0
+      ComparisonOperator: "GreaterThanThreshold"
+      AlarmActions:
+        - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/LowAlertNotificationTopic/ARN}}"
+      ActionsEnabled: true
+      TreatMissingData: notBreaching
+
+  FormatUserServicesFunctionDeploymentAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName:
+        !Join [
+          "-",
+          [
+            !Ref AWS::StackName,
+            !Ref Environment,
+            "FormatUserServicesFunctionDeploymentAlarm",
+          ],
+        ]
+      AlarmDescription: "Alarm for Lambda function errors during canary deployment"
+      Namespace: "AWS/Lambda"
+      MetricName: "Errors"
+      Dimensions:
+        - Name: Resource
+          Value: !Sub "${FormatUserServicesFunction}:live"
+        - Name: "FunctionName"
+          Value: !Ref FormatUserServicesFunction
+        - Name: ExecutedVersion
+          Value: !GetAtt FormatUserServicesFunction.Version.Version
+      Statistic: "Sum"
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 0
+      ComparisonOperator: "GreaterThanThreshold"
+      AlarmActions:
+        - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/LowAlertNotificationTopic/ARN}}"
+      ActionsEnabled: true
+      TreatMissingData: notBreaching
 
   #######################
   # Encryption
@@ -2963,10 +3560,10 @@ Resources:
                   - ""
                   - - "arn:aws:iam::"
                     - !FindInMap [
-                      AccountInterventionsService,
-                      !Ref Environment,
-                      "AccountNumber",
-                    ]
+                        AccountInterventionsService,
+                        !Ref Environment,
+                        "AccountNumber",
+                      ]
                     - ":root"
               Action: kms:Decrypt
               Resource:
@@ -3204,7 +3801,6 @@ Resources:
       LogGroupName:
         Fn::ImportValue:
           Fn::Sub: "${VpcStackName}-FlowLogLogGroup"
-
 
   SuspiciousActivityTopic:
     Type: AWS::SNS::Topic

--- a/template.yaml
+++ b/template.yaml
@@ -3350,6 +3350,8 @@ Resources:
       Namespace: "AWS/Lambda"
       MetricName: "Errors"
       Dimensions:
+        - Name: Resource
+          Value: !Sub "${TriggerSuspiciousActivityStepFunction}:live"
         - Name: "FunctionName"
           Value: !Ref TriggerSuspiciousActivityStepFunction
         - Name: ExecutedVersion

--- a/template.yaml
+++ b/template.yaml
@@ -3320,6 +3320,8 @@ Resources:
       Namespace: "AWS/Lambda"
       MetricName: "Errors"
       Dimensions:
+        - Name: Resource
+          Value: !Sub "${SendSuspiciousActivityFunction}:live"
         - Name: "FunctionName"
           Value: !Ref SendSuspiciousActivityFunction
         - Name: ExecutedVersion

--- a/template.yaml
+++ b/template.yaml
@@ -3353,11 +3353,16 @@ Resources:
       MetricName: "Errors"
       Dimensions:
         - Name: Resource
-          Value: !Sub "${TriggerSuspiciousActivityStepFunction}:live"
+          Value:
+            !Join [
+              ":",
+              [
+                !Ref TriggerSuspiciousActivityStepFunction,
+                !GetAtt TriggerSuspiciousActivityStepFunction.Version.Version,
+              ],
+            ]
         - Name: "FunctionName"
           Value: !Ref TriggerSuspiciousActivityStepFunction
-        - Name: ExecutedVersion
-          Value: !GetAtt TriggerSuspiciousActivityStepFunction.Version.Version
       Statistic: "Sum"
       Period: 60
       EvaluationPeriods: 1


### PR DESCRIPTION
## Proposed changes

Enabling canary deployment for our backend lambda's to observe behaviour.

### What changed

1. Formatted automatically caused by prettier on commit.
2. Conditional to enable canary deployment on dev only.
3. Addition of deployment alarms for all back end lambda's to check for errors.
4. Addition of Code deploy role with Lambda permissions.
5. Enabled Lambda alias auto published with "live".
6. Configured canary deployment to deploy 10% of instances for 5 mins, if there are no errors deploy to all.

### Why did it change

To automate rollback in case of errors in newly deployed lambda.

### Related links

https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3823436177/Lambda+-+Canary+Deployment+Migration+Guidance#Pre-requisites

## Checklists

<!-- Merging this PR deploys to production. Please answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [x] Added parameters to Cloudformation template
- [ ] Added new secret or systems manager parameter
- [ ] Added new environment variable

### Permissions

- [x] This PR adds or changes permissions

## Testing

1. Validated lambda displays live alias.
2. On deployment validated 10% of lambda's have the new version of code.
3. Validated new alarms are created.
4. Validated a roll back caused by manually triggering alarm.

## How to review

1. This will add 5 mins to dev deployment time to see your new code. Opinions on a different frequency e.g. 25% every 1 minute will cut full changes to 4 mins and you are more likely to hit a instance with your new code earlier. (for a separate ticket)
2. Suggestions on custom alarm metrics as we are currently just looking at Lambda Errors which may not be the best. (for a separate ticket)
