### PR TITLE
PSREDEV-1154: added demo environment to mappings

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -186,6 +186,9 @@ Globals:
 
 Mappings:
   InputQueue:
+    demo:
+      QueueArn: ""
+      KeyArn: ""
     dev:
       QueueArn: ""
       KeyArn: ""


### PR DESCRIPTION
## Proposed changes

 [PSREDEV-1154]: added demo environment to mappings.

### What changed

In template.yaml under Mappings (line 187) the demo environment along with an empty placeholder for the QueueArn and KeyArn have been added.

### Why did it change

When trying to deploy the home-stubs pipeline for testing we get the following error - "Error: Failed to create changeset for the stack: home-stubs, ex: Waiter ChangeSetCreateComplete failed: Waiter encountered a terminal failure state: For expression "Status" we matched expected path: "FAILED" Status: FAILED. Reason: Template error: Unable to get mapping for TxmaDummyInputQueue::demo::QueueArn" the change is to fix this error.

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

[PSREDEV-1154]: https://govukverify.atlassian.net/browse/PSREDEV-1154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ