### PR TITLE
PSREDEV-1163: added pubish to demo workflow

### DIFF
--- a/.github/workflows/publish-to-demo.yaml
+++ b/.github/workflows/publish-to-demo.yaml
@@ -22,6 +22,7 @@ permissions:
   contents: read
 
 jobs:
+  environment: Demo-test
   lint_infrastructure:
     name: Lint Infrastructure
     uses: ./.github/workflows/lint-cloudformation.yaml

--- a/.github/workflows/publish-to-demo.yaml
+++ b/.github/workflows/publish-to-demo.yaml
@@ -22,7 +22,6 @@ permissions:
   contents: read
 
 jobs:
-  environment: Demo-test
   lint_infrastructure:
     name: Lint Infrastructure
     uses: ./.github/workflows/lint-cloudformation.yaml
@@ -38,6 +37,7 @@ jobs:
       gitRef: ${{ inputs.gitRef }}
 
   deploy_to_demo:
+    environment: Demo-test
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/publish-to-demo.yaml
+++ b/.github/workflows/publish-to-demo.yaml
@@ -1,0 +1,90 @@
+name: "Verify & Publish to Demo"
+
+on:
+  workflow_dispatch:
+    inputs:
+      refType:
+        type: choice
+        description: "Find branch name, commit SHA, or tag?"
+        options:
+          - Branch name
+          - Commit SHA
+          - Tag
+        default: Branch name
+      gitRef:
+        description: "Input branch name, commit SHA, or tag"
+        required: true
+        type: string
+        default: main
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  lint_infrastructure:
+    name: Lint Infrastructure
+    uses: ./.github/workflows/lint-cloudformation.yaml
+    secrets: inherit
+    with:
+      gitRef: ${{ inputs.gitRef }}
+
+  test_application:
+    name: Test Lambdas
+    uses: ./.github/workflows/lint-and-test-lambdas.yaml
+    secrets: inherit
+    with:
+      gitRef: ${{ inputs.gitRef }}
+
+  deploy_to_demo:
+    permissions:
+      contents: read
+      id-token: write
+    name: "Deploy to Demo"
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    needs:
+      - lint_infrastructure
+      - test_application
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # pin@v3
+        with:
+          fetch-depth: 0
+
+      - name: Install Node.js
+        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # pin@v3
+        with:
+          node-version-file: ".nvmrc"
+
+      - name: Install ESbuild
+        run: npm install -g esbuild@0.21.5
+
+      - name: Set up Python 3.9
+        uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435 # pin@v4
+        with:
+          python-version: "3.9"
+
+      - name: Set up SAM cli
+        uses: aws-actions/setup-sam@b42eb7a54dac4039080975e32860b1b30935c9af # pin@v2
+
+      - name: sam fix https://github.com/aws/aws-sam-cli/issues/4527
+        run: $(dirname $(readlink $(which sam)))/pip install --force-reinstall "cryptography==38.0.4"
+
+      - name: Set up AWS creds
+        uses: aws-actions/configure-aws-credentials@e1e17a757e536f70e52b5a12b2e8d1d1c60e04ef # pin@v1-node16
+        with:
+          role-to-assume: ${{ secrets.DEMO_GH_ACTIONS_ROLE_ARN }}
+          aws-region: eu-west-2
+
+      - name: SAM validate
+        run: sam validate
+
+      - name: SAM build
+        run: sam build --manifest package.json
+
+      - name: Deploy SAM app
+        uses: alphagov/di-devplatform-upload-action@1db904c002e0f98dbcb5ab453ceb1b71de5f7dd3 # pin@v2
+        with:
+          artifact-bucket-name: ${{ secrets.DEMO_ARTIFACT_BUCKET_NAME }}
+          signing-profile-name: ${{ secrets.DEMO_SIGNING_PROFILE_NAME }}


### PR DESCRIPTION
## Proposed changes

[PSREDEV-1163] Added a Verify &Publish to Demo GitHub actions workflow.

### What changed

A new workflow file publish-to-demo.yaml has been added to .github > workflows.

### Why did it change

We need this workflow to be able to deploy the backend into our demo environment in order to test against. We also need the outputs from deploying the backend to get the home-stubs and home-backend AWS pipelines working. 

### Environment variables or secrets

- Added environment Demo-test and added 3 secrets: 1 for the GitHubActionsRoleArn and 1 for the GitHubArtifactSourceBucketName from the home-backend-pipeline stack and 1 for the SigningProfileName from the aws-signer stack.

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Added parameters to Cloudformation template
- [x] Added new secret or systems manager parameter
- [] Added new environment variable


[PSREDEV-1163]: https://govukverify.atlassian.net/browse/PSREDEV-1163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ