### PR TITLE
PSREDEV-1171: added pre-merge files

### DIFF
--- a/pre-merge-integration-tests/README.md
+++ b/pre-merge-integration-tests/README.md
@@ -1,0 +1,27 @@
+# pre-merge-integration-tests/template
+## Description
+Github action role for testing CloudFormation stack status.
+
+
+### Parameters
+The list of parameters for this template:
+
+| Parameter        | Type   | Default   | Description |
+|------------------|--------|-----------|-------------|
+| OneLoginRepositoryName | String |  | The name of Repo which is allowed to push here. |
+
+### Resources
+The list of resources this template creates:
+
+| Resource         | Type   |
+|------------------|--------|
+| LockToRegionPolicy | AWS::IAM::ManagedPolicy |
+| CloudFormationStackTestingGitHubActionsPolicy | AWS::IAM::ManagedPolicy |
+| CloudFormationStackTestingGitHubActionsRole | AWS::IAM::Role |
+
+### Outputs
+The list of outputs this template exposes:
+
+| Output           | Description   |
+|------------------|---------------|
+| GitHubActionRoleArn | The resource used by GitHub Actions for testing cloudformation stack. |

--- a/pre-merge-integration-tests/api_call.py
+++ b/pre-merge-integration-tests/api_call.py
@@ -1,0 +1,67 @@
+import boto3
+import time
+
+# Initialize a session using CloudFormation
+client = boto3.client('cloudformation')
+
+# Name of the CloudFormation stack
+stack_name = 'home-stubs'  # Replace with actual stack name
+
+def call_describe_stack_events(stack_name):
+    try:
+        response = client.describe_stack_events(StackName=stack_name)
+        return response
+    except Exception as e:
+        print(f"Error fetching stack events: {e}")
+        return None
+
+def check_stack_status(events):
+    create_in_progress = False
+    update_complete = False
+    create_complete = False
+    
+    for event in events:
+        resource_status = event['ResourceStatus']
+        if resource_status == 'CREATE_IN_PROGRESS':
+            create_in_progress = True
+        if resource_status == 'UPDATE_COMPLETE':
+            update_complete = True
+        if resource_status == 'CREATE_COMPLETE':
+            create_complete = True
+    
+    return create_in_progress, update_complete, create_complete
+
+def wait_for_stack_status(stack_name, max_attempts=10):
+    print(f"Waiting for stack {stack_name} to reach CREATE_IN_PROGRESS, CREATE_COMPLETE, or UPDATE_COMPLETE status...")
+    attempts = 0
+    while attempts < max_attempts:
+        response = call_describe_stack_events(stack_name)
+        if not response:
+            print("No response received.")
+            break
+        
+        events = response['StackEvents']
+        num_events = len(events)
+        
+        for i in range(0, num_events, 10):
+            batch_events = events[i:i + 10]
+            create_in_progress, update_complete, create_complete = check_stack_status(batch_events)
+            
+            if create_in_progress:
+                print("Stack is in CREATE_IN_PROGRESS status.")
+            if update_complete:
+                print("Stack update complete.")
+                return
+            if create_complete:
+                print("Stack creation complete.")
+                return
+        
+        attempts += 1
+        print(f"Attempt {attempts}/{max_attempts}: Waiting for stack to reach desired status...")
+        time.sleep(2)
+    
+    print("Max attempts reached or desired status not found within the attempts limit.")
+
+if __name__ == "__main__":
+    wait_for_stack_status(stack_name)
+    print("Script execution completed.")

--- a/pre-merge-integration-tests/template.yaml
+++ b/pre-merge-integration-tests/template.yaml
@@ -1,0 +1,155 @@
+AWSTemplateFormatVersion: "2010-09-09"
+
+Description: >
+  Github action role for testing CloudFormation stack status.
+
+Parameters:
+
+  OneLoginRepositoryName:
+    Description: >
+      The name of Repo which is allowed to push here.
+    Type: "String"
+    AllowedPattern: "^[a-zA-Z0-9-]+$"
+    ConstraintDescription: >
+      must be a valid GitHub repo name, made of uppercase or lowercase letters,
+      numbers and hyphens
+
+Outputs:
+  GitHubActionRoleArn:
+    Description: "The resource used by GitHub Actions for testing cloudformation stack."
+    Value: !Ref CloudFormationStackTestingGitHubActionsRole
+    Export:
+      Name: !Sub "${AWS::StackName}-CloudFormationStackTestingGitHubActionsRole"
+
+Resources:
+
+  #
+  # Deny resources creation outside UK region
+  #
+
+  LockToRegionPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      ManagedPolicyName:
+        Fn::Join:
+          - "-"
+          - - !Ref AWS::StackName
+            - "LockToRegionPolicy"
+            - Fn::Select:
+                - 4
+                - Fn::Split:
+                    - "-"
+                    - Fn::Select:
+                        - 2
+                        - Fn::Split:
+                            - "/"
+                            - Ref: AWS::StackId
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Deny"
+            Resource:
+              - "*"
+            NotAction:
+              - "a4b:*"
+              - "acm:*"
+              - "aws-marketplace-management:*"
+              - "aws-marketplace:*"
+              - "budgets:*"
+              - "ce:*"
+              - "chime:*"
+              - "cloudfront:*"
+              - "cognito-idp:*"
+              - "config:*"
+              - "cur:*"
+              - "directconnect:*"
+              - "ec2:Describe*"
+              - "fms:*"
+              - "globalaccelerator:*"
+              - "health:*"
+              - "iam:*"
+              - "importexport:*"
+              - "kms:*"
+              - "mobileanalytics:*"
+              - "networkmanager:*"
+              - "organizations:*"
+              - "pricing:*"
+              - "pipes:*"
+              - "route53:*"
+              - "route53domains:*"
+              - "s3:GetAccountPublic*"
+              - "s3:ListAllMyBuckets"
+              - "s3:PutAccountPublic*"
+              - "ses:*"
+              - "shield:*"
+              - "sts:*"
+              - "support:*"
+              - "synthetics:*"
+              - "trustedadvisor:*"
+              - "waf-regional:*"
+              - "waf:*"
+              - "wafv2:*"
+              - "wellarchitected:*"
+            Condition:
+              StringNotEquals:
+                "aws:RequestedRegion": [
+                  "eu-west-2"
+                ]
+
+  CloudFormationStackTestingGitHubActionsPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      ManagedPolicyName:
+        Fn::Join:
+          - "-"
+          - - !Ref AWS::StackName
+            - "GitHubActionsPolicy"
+            - Fn::Select:
+                - 4
+                - Fn::Split:
+                    - "-"
+                    - Fn::Select:
+                        - 2
+                        - Fn::Split:
+                            - "/"
+                            - Ref: AWS::StackId
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: "TestStackAPI"
+            Effect: "Allow"
+            Action:
+              - "cloudformation:DescribeStackEvents"
+            Resource:
+              - !Sub "arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/${AWS::StackName}/*"
+
+  CloudFormationStackTestingGitHubActionsRole:
+    Type: AWS::IAM::Role
+    # checkov:skip=GDS_AWS_1:Don't run GDS_AWS_1
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+              Effect: "Allow"
+              Action: "sts:AssumeRoleWithWebIdentity"
+              Principal:
+                Federated: !ImportValue GitHubIdentityProviderArn
+              Condition:
+                StringLike:
+                  "token.actions.githubusercontent.com:sub":
+                    - !Sub "repo:govuk-one-login/${OneLoginRepositoryName}*ref:refs/heads/*"
+                    - !Sub "repo:govuk-one-login/${OneLoginRepositoryName}:environment:*"
+                    - !Sub "repo:govuk-one-login/${OneLoginRepositoryName}:pull_request"
+      ManagedPolicyArns:
+        - !Ref CloudFormationStackTestingGitHubActionsPolicy
+        - !Ref LockToRegionPolicy
+      Tags:
+        - Key: "Name"
+          Value: !Join
+            - "-"
+            - - !Ref AWS::StackName
+              - "CloudFormationStackTestingGitHubActionsRole"
+        - Key: "Service"
+          Value: "ci/cd"
+        - Key: "Source"
+          Value: "govuk-one-login/devplatform-deploy/pre-merge-integration-tests/template.yaml"


### PR DESCRIPTION
## Proposed changes

[PSREDEV-1171]: Added pre-merge files.

### What changed

Added the script api_call.py to poll a cloudformation stack and github role in template.yaml.

### Why did it change

Needed to add the files to be able to perform pre-merge checks. 

### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists

<!-- Merging this PR deploys to production. Please answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Permissions

- [ ] This PR adds or changes permissions

## Testing

<!-- Provide a summary of any manual testing you've done, for example deploying the branch to dev -->

## How to review

<!-- Describe any non-standard steps to review this work, or higlight any areas that you'd like the reviewer's opinion on -->


[PSREDEV-1171]: https://govukverify.atlassian.net/browse/PSREDEV-1171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ