### PR TITLE
PSREDEV-1174: Changed IsNotDvelopment to IsNotDevelopmentOrDemo

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -23,6 +23,7 @@ Parameters:
     Description: "The environment type"
     Type: "String"
     AllowedValues:
+      - "demo"
       - "dev"
       - "build"
       - "staging"
@@ -80,16 +81,24 @@ Conditions:
 
   IsNotDevelopment:
     Fn::Not:
-      - Fn::Equals:
-          - !Ref Environment
-          - "dev"
+      - Fn::Or: 
+        - Fn::equals:
+            - !Ref Environment
+            - "dev"
+        - Fn::equals:
+            - !Ref Environment
+            - "demo"
 
-  IsDevelopment:
+  IsDevelopmentOrDemo: !Or
     Fn::Equals:
       - !Ref Environment
       - "dev"
+    Fn::Equals:
+      - !Ref Environment
+      - "demo"
 
   UseInternalEvents: !Or
+    - !Equals [!Ref Environment, demo]
     - !Equals [!Ref Environment, dev]
     - !Equals [!Ref Environment, build]
 
@@ -179,7 +188,7 @@ Globals:
       Enabled: true
       Type:
         Fn::If:
-          - IsDevelopment
+          - IsDevelopmentOrDemo
           - Canary10Percent5Minutes
           - AllAtOnce
       Role: !GetAtt CodeDeployServiceRole.Arn
@@ -1199,7 +1208,7 @@ Resources:
       TopicName: UserAccountDeletion
 
   UserAccountDeletionTopicPolicy:
-    Condition: IsNotDevelopment
+    Condition: IsNotDevelopmentOrDemo
     Type: AWS::SNS::TopicPolicy
     Properties:
       Topics:
@@ -3600,7 +3609,7 @@ Resources:
             Resource:
               - "*"
           - !If
-            - "IsNotDevelopment"
+            - "IsNotDevelopmentOrDemo"
             - Effect: Allow
               Principal:
                 AWS: !Join
@@ -3617,7 +3626,7 @@ Resources:
                 - "*"
             - !Ref AWS::NoValue
           - !If
-            - "IsNotDevelopment"
+            - "IsNotDevelopmentOrDemo"
             - Effect: Allow
               Principal:
                 AWS: !Join
@@ -3634,7 +3643,7 @@ Resources:
                 - "*"
             - !Ref AWS::NoValue
           - !If
-            - "IsNotDevelopment"
+            - "IsNotDevelopmentOrDemo"
             - Effect: Allow
               Principal:
                 AWS: !Join

--- a/template.yaml
+++ b/template.yaml
@@ -79,7 +79,7 @@ Conditions:
           - !Ref PermissionsBoundary
           - "none"
 
-  IsNotDevelopment:
+  IsNotDevelopmentOrDemo:
     Fn::Not:
       - Fn::Or: 
         - Fn::equals:


### PR DESCRIPTION
## Proposed changes

[PSREDEV-1174]: Changed IsNotDvelopment to IsNotDevelopmentOrDemo along with any refs and added "Demo" under AllowedValues.

### Why did it change

To fix an error occurring in the home-backend-pipeline in the di-account-test account. 

### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists

<!-- Merging this PR deploys to production. Please answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Permissions

- [ ] This PR adds or changes permissions

## Testing

<!-- Provide a summary of any manual testing you've done, for example deploying the branch to dev -->

## How to review

<!-- Describe any non-standard steps to review this work, or higlight any areas that you'd like the reviewer's opinion on -->


[PSREDEV-1174]: https://govukverify.atlassian.net/browse/PSREDEV-1174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ