### PR TITLE
BAU: Correct typo in condition definition

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -81,21 +81,22 @@ Conditions:
 
   IsNotDevelopmentOrDemo:
     Fn::Not:
-      - Fn::Or: 
-        - Fn::equals:
-            - !Ref Environment
-            - "dev"
-        - Fn::equals:
-            - !Ref Environment
-            - "demo"
+      - Fn::Or:
+          - Fn::Equals:
+              - !Ref Environment
+              - "dev"
+          - Fn::Equals:
+              - !Ref Environment
+              - "demo"
 
-  IsDevelopmentOrDemo: !Or
-    Fn::Equals:
-      - !Ref Environment
-      - "dev"
-    Fn::Equals:
-      - !Ref Environment
-      - "demo"
+  IsDevelopmentOrDemo:
+    Fn::Or:
+      - Fn::Equals:
+          - !Ref Environment
+          - "dev"
+      - Fn::Equals:
+          - !Ref Environment
+          - "demo"
 
   UseInternalEvents: !Or
     - !Equals [!Ref Environment, demo]


### PR DESCRIPTION
## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->

### What changed

We changed these definitions in #260 but Cloudformation is picky and `Equals` must be capitalised.

It also doesn't always like the short form `!Or` function when we have a definition spanning multiple lines, so change that to the full `Fn::Or` form. 

I'm very surprised the linter action didn't catch this - I'll investigate that separately.

### Why did it change

Currently our deploys are failing in build. 

## Checklists

<!-- Merging this PR deploys to production. Please answer accurately. -->

### Environment variables or secrets

- [x] ~Added~ Edited parameters in Cloudformation template
- [ ] Added new secret or systems manager parameter
- [ ] Added new environment variable
