### PR TITLE
BAU: Trigger the Cloudformation lint action correctly

### DIFF
--- a/.github/workflows/lint-cloudformation.yaml
+++ b/.github/workflows/lint-cloudformation.yaml
@@ -7,6 +7,9 @@ on:
         required: false
         type: string
         default: ${{ github.ref }}
+  pull_request:
+    paths:
+      - "deploy.yaml"
 
 jobs:
   lint_cloudformation:

--- a/.github/workflows/skip-lint-cloudformation.yaml
+++ b/.github/workflows/skip-lint-cloudformation.yaml
@@ -1,9 +1,9 @@
 name: CloudFormation Linter
 
-on: 
-  pull_request: 
+on:
+  pull_request:
     paths-ignore:
-      - 'infrastructure/**'
+      - "deploy.yaml"
 
 jobs:
   lint_cloudformation:


### PR DESCRIPTION

## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->

### What changed

Fix the trigger conditions on the CFN lint actions so:
1. We run the linter on a pull request whenever `deploy.yaml` is changed
2. We run the 'skip action' on all other pull requests


### Why did it change

This must have been broken since we refactored this repo into a single package but we didn't notice because we had the skip action always running on every pull request, which always passes.

This meant that we merged #260 with a malformed Cloudformation template and broke our pipeline. That was addressed separately in #261.

## Checklists

<!-- Merging this PR deploys to production. Please answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

