### PR TITLE
INCIDEN-839: Increase write activity log lambda timeout

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -1642,6 +1642,7 @@ Resources:
       FunctionName: !Sub ${Environment}-${AWS::StackName}-write-activity-log
       CodeUri: src
       PackageType: Zip
+      Timeout: 30
       Events:
         ActivityLogToWriteQueue:
           Type: SQS


### PR DESCRIPTION

## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->

### What changed

Increase the timeout to 30 seconds for the `write-activity-log` lambda.

### Why did it change

The ESBuild reverts in #268 and #270 did fix the problem building the lambdas, but the write activity log lambda was still failing with timeouts.

It turns out this was for a different reason - the input queue for this function was backed up with ~100k events. We have batch sizes of 10 events per invocation, but under normal operation the batches are much smaller than this. This lambda does a lot per event because it has to encrypt and write each to DynamoDB seperately. That meant once it was processing 10 events per invocation these were legitimately timing out because all the operations take longer than 5 seconds.

This is the only lambda that does so much on each invocation. I can see that batches of 10 events are taking ~9 seconds to process in production now, so this is comfortably above that. I've manually changed this in integration and production already and proved that it has solved the problem.

## Checklists

<!-- Merging this PR deploys to production. Please answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed