### PR TITLE
BAU: Update alarms to use new topic ARN

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -15,7 +15,7 @@ Parameters:
   AlertingStackName:
     Description: The name of the stack that defines the Alerting resources
     Type: String
-    Default: platform-alerting
+    Default: build-notifications
   DummyEventStoreTableName:
     Type: String
     Default: dummy_events
@@ -752,7 +752,8 @@ Resources:
       Threshold: 1
       ComparisonOperator: "GreaterThanOrEqualToThreshold"
       AlarmActions:
-        - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/LowAlertNotificationTopic/ARN}}"
+        - !ImportValue
+          "Fn::Sub": "${AlertingStackName}-BuildNotificationTopicArn"
       ActionsEnabled: true
 
   ########################
@@ -923,7 +924,8 @@ Resources:
       Threshold: 1
       ComparisonOperator: "GreaterThanOrEqualToThreshold"
       AlarmActions:
-        - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/LowAlertNotificationTopic/ARN}}"
+        - !ImportValue
+          "Fn::Sub": "${AlertingStackName}-BuildNotificationTopicArn"
       ActionsEnabled: true
 
   #################################
@@ -1061,7 +1063,8 @@ Resources:
       Threshold: 1
       ComparisonOperator: "GreaterThanOrEqualToThreshold"
       AlarmActions:
-        - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/LowAlertNotificationTopic/ARN}}"
+        - !ImportValue
+          Fn::Sub: "${AlertingStackName}-BuildNotificationTopicArn"
       ActionsEnabled: true
 
   #########################
@@ -1203,7 +1206,8 @@ Resources:
       Threshold: 1
       ComparisonOperator: "GreaterThanOrEqualToThreshold"
       AlarmActions:
-        - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/LowAlertNotificationTopic/ARN}}"
+        - !ImportValue
+          Fn::Sub: "${AlertingStackName}-BuildNotificationTopicArn"
       ActionsEnabled: true
 
   ##################################
@@ -1449,7 +1453,8 @@ Resources:
       Threshold: 1
       ComparisonOperator: "GreaterThanOrEqualToThreshold"
       AlarmActions:
-        - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/LowAlertNotificationTopic/ARN}}"
+        - !ImportValue
+          Fn::Sub: "${AlertingStackName}-BuildNotificationTopicArn"
       ActionsEnabled: true
 
   DeleteDeadLetterQueueAlarm:
@@ -1472,7 +1477,8 @@ Resources:
       Threshold: 1
       ComparisonOperator: "GreaterThanOrEqualToThreshold"
       AlarmActions:
-        - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/LowAlertNotificationTopic/ARN}}"
+        - !ImportValue
+          Fn::Sub: "${AlertingStackName}-BuildNotificationTopicArn"
       ActionsEnabled: true
 
   ############################
@@ -1788,7 +1794,8 @@ Resources:
       Threshold: 1
       ComparisonOperator: "GreaterThanOrEqualToThreshold"
       AlarmActions:
-        - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/LowAlertNotificationTopic/ARN}}"
+        - !ImportValue
+          Fn::Sub: "${AlertingStackName}-BuildNotificationTopicArn"
       ActionsEnabled: true
 
   #######################
@@ -1962,7 +1969,8 @@ Resources:
       Threshold: 1
       ComparisonOperator: "GreaterThanOrEqualToThreshold"
       AlarmActions:
-        - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/LowAlertNotificationTopic/ARN}}"
+        - !ImportValue
+          Fn::Sub: "${AlertingStackName}-BuildNotificationTopicArn"
       ActionsEnabled: true
 
   ################################
@@ -2025,7 +2033,8 @@ Resources:
       Threshold: 1
       ComparisonOperator: "GreaterThanOrEqualToThreshold"
       AlarmActions:
-        - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/LowAlertNotificationTopic/ARN}}"
+        - !ImportValue
+          Fn::Sub: "${AlertingStackName}-BuildNotificationTopicArn"
       ActionsEnabled: true
 
   DeleteActivityLogFunction:
@@ -2182,7 +2191,8 @@ Resources:
       Threshold: 1
       ComparisonOperator: "GreaterThanOrEqualToThreshold"
       AlarmActions:
-        - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/LowAlertNotificationTopic/ARN}}"
+        - !ImportValue
+          Fn::Sub: "${AlertingStackName}-BuildNotificationTopicArn"
       ActionsEnabled: true
 
   ######################
@@ -2665,7 +2675,7 @@ Resources:
       Threshold: 10
       ComparisonOperator: "GreaterThanOrEqualToThreshold"
       AlarmActions:
-        - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/HighAlertNotificationTopic/ARN}}"
+        - BuildNoti
       ActionsEnabled: true
 
   TriggerSuspiciousActivityStepFunctionLambdaExecutionRetryAlarm:
@@ -2684,7 +2694,8 @@ Resources:
       Threshold: 10
       EvaluationPeriods: 1
       AlarmActions:
-        - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/HighAlertNotificationTopic/ARN}}"
+        - !ImportValue
+          Fn::Sub: "${AlertingStackName}-BuildNotificationTopicArn"
 
   TriggerSuspiciousActivityStepFunction:
     DependsOn:
@@ -2916,7 +2927,8 @@ Resources:
       Period: 300
       TreatMissingData: missing
       AlarmActions:
-        - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/HighAlertNotificationTopic/ARN}}"
+        - !ImportValue
+          Fn::Sub: "${AlertingStackName}-BuildNotificationTopicArn"
 
   ReportSuspiciousActivityStepFunctionExecutionRetryAlarm:
     Type: AWS::CloudWatch::Alarm
@@ -2934,7 +2946,8 @@ Resources:
       Threshold: 10
       EvaluationPeriods: 1
       AlarmActions:
-        - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/HighAlertNotificationTopic/ARN}}"
+        - !ImportValue
+          Fn::Sub: "${AlertingStackName}-BuildNotificationTopicArn"
 
   #######################
   # Canary Deployment
@@ -2994,7 +3007,8 @@ Resources:
       Threshold: 0
       ComparisonOperator: "GreaterThanThreshold"
       AlarmActions:
-        - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/LowAlertNotificationTopic/ARN}}"
+        - !ImportValue
+          Fn::Sub: "${AlertingStackName}-BuildNotificationTopicArn"
       ActionsEnabled: true
       TreatMissingData: notBreaching
 
@@ -3031,7 +3045,8 @@ Resources:
       Threshold: 0
       ComparisonOperator: "GreaterThanThreshold"
       AlarmActions:
-        - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/LowAlertNotificationTopic/ARN}}"
+        - !ImportValue
+          Fn::Sub: "${AlertingStackName}-BuildNotificationTopicArn"
       ActionsEnabled: true
       TreatMissingData: notBreaching
 
@@ -3068,7 +3083,8 @@ Resources:
       Threshold: 0
       ComparisonOperator: "GreaterThanThreshold"
       AlarmActions:
-        - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/LowAlertNotificationTopic/ARN}}"
+        - !ImportValue
+          Fn::Sub: "${AlertingStackName}-BuildNotificationTopicArn"
       ActionsEnabled: true
       TreatMissingData: notBreaching
 
@@ -3105,7 +3121,8 @@ Resources:
       Threshold: 0
       ComparisonOperator: "GreaterThanThreshold"
       AlarmActions:
-        - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/LowAlertNotificationTopic/ARN}}"
+        - !ImportValue
+          Fn::Sub: "${AlertingStackName}-BuildNotificationTopicArn"
       ActionsEnabled: true
       TreatMissingData: notBreaching
 
@@ -3142,7 +3159,8 @@ Resources:
       Threshold: 0
       ComparisonOperator: "GreaterThanThreshold"
       AlarmActions:
-        - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/LowAlertNotificationTopic/ARN}}"
+        - !ImportValue
+          Fn::Sub: "${AlertingStackName}-BuildNotificationTopicArn"
       ActionsEnabled: true
       TreatMissingData: notBreaching
 
@@ -3179,7 +3197,8 @@ Resources:
       Threshold: 0
       ComparisonOperator: "GreaterThanThreshold"
       AlarmActions:
-        - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/LowAlertNotificationTopic/ARN}}"
+        - !ImportValue
+          Fn::Sub: "${AlertingStackName}-BuildNotificationTopicArn"
       ActionsEnabled: true
       TreatMissingData: notBreaching
 
@@ -3216,7 +3235,8 @@ Resources:
       Threshold: 0
       ComparisonOperator: "GreaterThanThreshold"
       AlarmActions:
-        - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/LowAlertNotificationTopic/ARN}}"
+        - !ImportValue
+          Fn::Sub: "${AlertingStackName}-BuildNotificationTopicArn"
       ActionsEnabled: true
       TreatMissingData: notBreaching
 
@@ -3253,7 +3273,8 @@ Resources:
       Threshold: 0
       ComparisonOperator: "GreaterThanThreshold"
       AlarmActions:
-        - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/LowAlertNotificationTopic/ARN}}"
+        - !ImportValue
+          Fn::Sub: "${AlertingStackName}-BuildNotificationTopicArn"
       ActionsEnabled: true
       TreatMissingData: notBreaching
 
@@ -3290,7 +3311,8 @@ Resources:
       Threshold: 0
       ComparisonOperator: "GreaterThanThreshold"
       AlarmActions:
-        - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/LowAlertNotificationTopic/ARN}}"
+        - !ImportValue
+          Fn::Sub: "${AlertingStackName}-BuildNotificationTopicArn"
       ActionsEnabled: true
       TreatMissingData: notBreaching
 
@@ -3327,7 +3349,8 @@ Resources:
       Threshold: 0
       ComparisonOperator: "GreaterThanThreshold"
       AlarmActions:
-        - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/LowAlertNotificationTopic/ARN}}"
+        - !ImportValue
+          Fn::Sub: "${AlertingStackName}-BuildNotificationTopicArn"
       ActionsEnabled: true
       TreatMissingData: notBreaching
 
@@ -3364,7 +3387,8 @@ Resources:
       Threshold: 0
       ComparisonOperator: "GreaterThanThreshold"
       AlarmActions:
-        - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/LowAlertNotificationTopic/ARN}}"
+        - !ImportValue
+          Fn::Sub: "${AlertingStackName}-BuildNotificationTopicArn"
       ActionsEnabled: true
       TreatMissingData: notBreaching
 
@@ -3401,7 +3425,8 @@ Resources:
       Threshold: 0
       ComparisonOperator: "GreaterThanThreshold"
       AlarmActions:
-        - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/LowAlertNotificationTopic/ARN}}"
+        - !ImportValue
+          Fn::Sub: "${AlertingStackName}-BuildNotificationTopicArn"
       ActionsEnabled: true
       TreatMissingData: notBreaching
 
@@ -3438,7 +3463,8 @@ Resources:
       Threshold: 0
       ComparisonOperator: "GreaterThanThreshold"
       AlarmActions:
-        - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/LowAlertNotificationTopic/ARN}}"
+        - !ImportValue
+          Fn::Sub: "${AlertingStackName}-BuildNotificationTopicArn"
       ActionsEnabled: true
       TreatMissingData: notBreaching
 
@@ -3475,7 +3501,8 @@ Resources:
       Threshold: 0
       ComparisonOperator: "GreaterThanThreshold"
       AlarmActions:
-        - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/LowAlertNotificationTopic/ARN}}"
+        - !ImportValue
+          Fn::Sub: "${AlertingStackName}-BuildNotificationTopicArn"
       ActionsEnabled: true
       TreatMissingData: notBreaching
 

--- a/template.yaml
+++ b/template.yaml
@@ -748,7 +748,7 @@ Resources:
       Threshold: 1
       ComparisonOperator: "GreaterThanOrEqualToThreshold"
       AlarmActions:
-        - !ImportValue build-notifications-BuildNotificationTopicArn"
+        - !ImportValue build-notifications-BuildNotificationTopicArn
       ActionsEnabled: true
 
   ########################
@@ -919,7 +919,7 @@ Resources:
       Threshold: 1
       ComparisonOperator: "GreaterThanOrEqualToThreshold"
       AlarmActions:
-        - !ImportValue build-notifications-BuildNotificationTopicArn"
+        - !ImportValue build-notifications-BuildNotificationTopicArn
       ActionsEnabled: true
 
   #################################
@@ -1057,7 +1057,7 @@ Resources:
       Threshold: 1
       ComparisonOperator: "GreaterThanOrEqualToThreshold"
       AlarmActions:
-        - !ImportValue build-notifications-BuildNotificationTopicArn"
+        - !ImportValue build-notifications-BuildNotificationTopicArn
       ActionsEnabled: true
 
   #########################
@@ -1199,7 +1199,7 @@ Resources:
       Threshold: 1
       ComparisonOperator: "GreaterThanOrEqualToThreshold"
       AlarmActions:
-        - !ImportValue build-notifications-BuildNotificationTopicArn"
+        - !ImportValue build-notifications-BuildNotificationTopicArn
       ActionsEnabled: true
 
   ##################################
@@ -1445,7 +1445,7 @@ Resources:
       Threshold: 1
       ComparisonOperator: "GreaterThanOrEqualToThreshold"
       AlarmActions:
-        - !ImportValue build-notifications-BuildNotificationTopicArn"
+        - !ImportValue build-notifications-BuildNotificationTopicArn
       ActionsEnabled: true
 
   DeleteDeadLetterQueueAlarm:
@@ -1468,7 +1468,7 @@ Resources:
       Threshold: 1
       ComparisonOperator: "GreaterThanOrEqualToThreshold"
       AlarmActions:
-        - !ImportValue build-notifications-BuildNotificationTopicArn"
+        - !ImportValue build-notifications-BuildNotificationTopicArn
       ActionsEnabled: true
 
   ############################
@@ -1784,7 +1784,7 @@ Resources:
       Threshold: 1
       ComparisonOperator: "GreaterThanOrEqualToThreshold"
       AlarmActions:
-        - !ImportValue build-notifications-BuildNotificationTopicArn"
+        - !ImportValue build-notifications-BuildNotificationTopicArn
       ActionsEnabled: true
 
   #######################
@@ -1958,7 +1958,7 @@ Resources:
       Threshold: 1
       ComparisonOperator: "GreaterThanOrEqualToThreshold"
       AlarmActions:
-        - !ImportValue build-notifications-BuildNotificationTopicArn"
+        - !ImportValue build-notifications-BuildNotificationTopicArn
       ActionsEnabled: true
 
   ################################
@@ -2021,7 +2021,7 @@ Resources:
       Threshold: 1
       ComparisonOperator: "GreaterThanOrEqualToThreshold"
       AlarmActions:
-        - !ImportValue build-notifications-BuildNotificationTopicArn"
+        - !ImportValue build-notifications-BuildNotificationTopicArn
       ActionsEnabled: true
 
   DeleteActivityLogFunction:
@@ -2178,7 +2178,7 @@ Resources:
       Threshold: 1
       ComparisonOperator: "GreaterThanOrEqualToThreshold"
       AlarmActions:
-        - !ImportValue build-notifications-BuildNotificationTopicArn"
+        - !ImportValue build-notifications-BuildNotificationTopicArn
       ActionsEnabled: true
 
   ######################
@@ -2680,7 +2680,7 @@ Resources:
       Threshold: 10
       EvaluationPeriods: 1
       AlarmActions:
-        - !ImportValue build-notifications-BuildNotificationTopicArn"
+        - !ImportValue build-notifications-BuildNotificationTopicArn
 
   TriggerSuspiciousActivityStepFunction:
     DependsOn:
@@ -2912,7 +2912,7 @@ Resources:
       Period: 300
       TreatMissingData: missing
       AlarmActions:
-        - !ImportValue build-notifications-BuildNotificationTopicArn"
+        - !ImportValue build-notifications-BuildNotificationTopicArn
 
   ReportSuspiciousActivityStepFunctionExecutionRetryAlarm:
     Type: AWS::CloudWatch::Alarm
@@ -2930,7 +2930,7 @@ Resources:
       Threshold: 10
       EvaluationPeriods: 1
       AlarmActions:
-        - !ImportValue build-notifications-BuildNotificationTopicArn"
+        - !ImportValue build-notifications-BuildNotificationTopicArn
 
   #######################
   # Canary Deployment
@@ -2990,7 +2990,7 @@ Resources:
       Threshold: 0
       ComparisonOperator: "GreaterThanThreshold"
       AlarmActions:
-        - !ImportValue build-notifications-BuildNotificationTopicArn"
+        - !ImportValue build-notifications-BuildNotificationTopicArn
       ActionsEnabled: true
       TreatMissingData: notBreaching
 
@@ -3027,7 +3027,7 @@ Resources:
       Threshold: 0
       ComparisonOperator: "GreaterThanThreshold"
       AlarmActions:
-        - !ImportValue build-notifications-BuildNotificationTopicArn"
+        - !ImportValue build-notifications-BuildNotificationTopicArn
       ActionsEnabled: true
       TreatMissingData: notBreaching
 
@@ -3064,7 +3064,7 @@ Resources:
       Threshold: 0
       ComparisonOperator: "GreaterThanThreshold"
       AlarmActions:
-        - !ImportValue build-notifications-BuildNotificationTopicArn"
+        - !ImportValue build-notifications-BuildNotificationTopicArn
       ActionsEnabled: true
       TreatMissingData: notBreaching
 
@@ -3101,7 +3101,7 @@ Resources:
       Threshold: 0
       ComparisonOperator: "GreaterThanThreshold"
       AlarmActions:
-        - !ImportValue build-notifications-BuildNotificationTopicArn"
+        - !ImportValue build-notifications-BuildNotificationTopicArn
       ActionsEnabled: true
       TreatMissingData: notBreaching
 
@@ -3138,7 +3138,7 @@ Resources:
       Threshold: 0
       ComparisonOperator: "GreaterThanThreshold"
       AlarmActions:
-        - !ImportValue build-notifications-BuildNotificationTopicArn"
+        - !ImportValue build-notifications-BuildNotificationTopicArn
       ActionsEnabled: true
       TreatMissingData: notBreaching
 
@@ -3175,7 +3175,7 @@ Resources:
       Threshold: 0
       ComparisonOperator: "GreaterThanThreshold"
       AlarmActions:
-        - !ImportValue build-notifications-BuildNotificationTopicArn"
+        - !ImportValue build-notifications-BuildNotificationTopicArn
       ActionsEnabled: true
       TreatMissingData: notBreaching
 
@@ -3212,7 +3212,7 @@ Resources:
       Threshold: 0
       ComparisonOperator: "GreaterThanThreshold"
       AlarmActions:
-        - !ImportValue build-notifications-BuildNotificationTopicArn"
+        - !ImportValue build-notifications-BuildNotificationTopicArn
       ActionsEnabled: true
       TreatMissingData: notBreaching
 
@@ -3249,7 +3249,7 @@ Resources:
       Threshold: 0
       ComparisonOperator: "GreaterThanThreshold"
       AlarmActions:
-        - !ImportValue build-notifications-BuildNotificationTopicArn"
+        - !ImportValue build-notifications-BuildNotificationTopicArn
       ActionsEnabled: true
       TreatMissingData: notBreaching
 
@@ -3286,7 +3286,7 @@ Resources:
       Threshold: 0
       ComparisonOperator: "GreaterThanThreshold"
       AlarmActions:
-        - !ImportValue build-notifications-BuildNotificationTopicArn"
+        - !ImportValue build-notifications-BuildNotificationTopicArn
       ActionsEnabled: true
       TreatMissingData: notBreaching
 
@@ -3323,7 +3323,7 @@ Resources:
       Threshold: 0
       ComparisonOperator: "GreaterThanThreshold"
       AlarmActions:
-        - !ImportValue build-notifications-BuildNotificationTopicArn"
+        - !ImportValue build-notifications-BuildNotificationTopicArn
       ActionsEnabled: true
       TreatMissingData: notBreaching
 
@@ -3360,7 +3360,7 @@ Resources:
       Threshold: 0
       ComparisonOperator: "GreaterThanThreshold"
       AlarmActions:
-        - !ImportValue build-notifications-BuildNotificationTopicArn"
+        - !ImportValue build-notifications-BuildNotificationTopicArn
       ActionsEnabled: true
       TreatMissingData: notBreaching
 
@@ -3397,7 +3397,7 @@ Resources:
       Threshold: 0
       ComparisonOperator: "GreaterThanThreshold"
       AlarmActions:
-        - !ImportValue build-notifications-BuildNotificationTopicArn"
+        - !ImportValue build-notifications-BuildNotificationTopicArn
       ActionsEnabled: true
       TreatMissingData: notBreaching
 
@@ -3434,7 +3434,7 @@ Resources:
       Threshold: 0
       ComparisonOperator: "GreaterThanThreshold"
       AlarmActions:
-        - !ImportValue build-notifications-BuildNotificationTopicArn"
+        - !ImportValue build-notifications-BuildNotificationTopicArn
       ActionsEnabled: true
       TreatMissingData: notBreaching
 
@@ -3471,7 +3471,7 @@ Resources:
       Threshold: 0
       ComparisonOperator: "GreaterThanThreshold"
       AlarmActions:
-        - !ImportValue build-notifications-BuildNotificationTopicArn"
+        - !ImportValue build-notifications-BuildNotificationTopicArn
       ActionsEnabled: true
       TreatMissingData: notBreaching
 

--- a/template.yaml
+++ b/template.yaml
@@ -12,10 +12,6 @@ Parameters:
   ActivityLogsStoreTableName:
     Type: String
     Default: activity_log
-  AlertingStackName:
-    Description: The name of the stack that defines the Alerting resources
-    Type: String
-    Default: build-notifications
   DummyEventStoreTableName:
     Type: String
     Default: dummy_events
@@ -752,8 +748,7 @@ Resources:
       Threshold: 1
       ComparisonOperator: "GreaterThanOrEqualToThreshold"
       AlarmActions:
-        - !ImportValue
-          "Fn::Sub": "${AlertingStackName}-BuildNotificationTopicArn"
+        - !ImportValue build-notifications-BuildNotificationTopicArn"
       ActionsEnabled: true
 
   ########################
@@ -924,8 +919,7 @@ Resources:
       Threshold: 1
       ComparisonOperator: "GreaterThanOrEqualToThreshold"
       AlarmActions:
-        - !ImportValue
-          "Fn::Sub": "${AlertingStackName}-BuildNotificationTopicArn"
+        - !ImportValue build-notifications-BuildNotificationTopicArn"
       ActionsEnabled: true
 
   #################################
@@ -1063,8 +1057,7 @@ Resources:
       Threshold: 1
       ComparisonOperator: "GreaterThanOrEqualToThreshold"
       AlarmActions:
-        - !ImportValue
-          Fn::Sub: "${AlertingStackName}-BuildNotificationTopicArn"
+        - !ImportValue build-notifications-BuildNotificationTopicArn"
       ActionsEnabled: true
 
   #########################
@@ -1206,8 +1199,7 @@ Resources:
       Threshold: 1
       ComparisonOperator: "GreaterThanOrEqualToThreshold"
       AlarmActions:
-        - !ImportValue
-          Fn::Sub: "${AlertingStackName}-BuildNotificationTopicArn"
+        - !ImportValue build-notifications-BuildNotificationTopicArn"
       ActionsEnabled: true
 
   ##################################
@@ -1453,8 +1445,7 @@ Resources:
       Threshold: 1
       ComparisonOperator: "GreaterThanOrEqualToThreshold"
       AlarmActions:
-        - !ImportValue
-          Fn::Sub: "${AlertingStackName}-BuildNotificationTopicArn"
+        - !ImportValue build-notifications-BuildNotificationTopicArn"
       ActionsEnabled: true
 
   DeleteDeadLetterQueueAlarm:
@@ -1477,8 +1468,7 @@ Resources:
       Threshold: 1
       ComparisonOperator: "GreaterThanOrEqualToThreshold"
       AlarmActions:
-        - !ImportValue
-          Fn::Sub: "${AlertingStackName}-BuildNotificationTopicArn"
+        - !ImportValue build-notifications-BuildNotificationTopicArn"
       ActionsEnabled: true
 
   ############################
@@ -1794,8 +1784,7 @@ Resources:
       Threshold: 1
       ComparisonOperator: "GreaterThanOrEqualToThreshold"
       AlarmActions:
-        - !ImportValue
-          Fn::Sub: "${AlertingStackName}-BuildNotificationTopicArn"
+        - !ImportValue build-notifications-BuildNotificationTopicArn"
       ActionsEnabled: true
 
   #######################
@@ -1969,8 +1958,7 @@ Resources:
       Threshold: 1
       ComparisonOperator: "GreaterThanOrEqualToThreshold"
       AlarmActions:
-        - !ImportValue
-          Fn::Sub: "${AlertingStackName}-BuildNotificationTopicArn"
+        - !ImportValue build-notifications-BuildNotificationTopicArn"
       ActionsEnabled: true
 
   ################################
@@ -2033,8 +2021,7 @@ Resources:
       Threshold: 1
       ComparisonOperator: "GreaterThanOrEqualToThreshold"
       AlarmActions:
-        - !ImportValue
-          Fn::Sub: "${AlertingStackName}-BuildNotificationTopicArn"
+        - !ImportValue build-notifications-BuildNotificationTopicArn"
       ActionsEnabled: true
 
   DeleteActivityLogFunction:
@@ -2191,8 +2178,7 @@ Resources:
       Threshold: 1
       ComparisonOperator: "GreaterThanOrEqualToThreshold"
       AlarmActions:
-        - !ImportValue
-          Fn::Sub: "${AlertingStackName}-BuildNotificationTopicArn"
+        - !ImportValue build-notifications-BuildNotificationTopicArn"
       ActionsEnabled: true
 
   ######################
@@ -2694,8 +2680,7 @@ Resources:
       Threshold: 10
       EvaluationPeriods: 1
       AlarmActions:
-        - !ImportValue
-          Fn::Sub: "${AlertingStackName}-BuildNotificationTopicArn"
+        - !ImportValue build-notifications-BuildNotificationTopicArn"
 
   TriggerSuspiciousActivityStepFunction:
     DependsOn:
@@ -2927,8 +2912,7 @@ Resources:
       Period: 300
       TreatMissingData: missing
       AlarmActions:
-        - !ImportValue
-          Fn::Sub: "${AlertingStackName}-BuildNotificationTopicArn"
+        - !ImportValue build-notifications-BuildNotificationTopicArn"
 
   ReportSuspiciousActivityStepFunctionExecutionRetryAlarm:
     Type: AWS::CloudWatch::Alarm
@@ -2946,8 +2930,7 @@ Resources:
       Threshold: 10
       EvaluationPeriods: 1
       AlarmActions:
-        - !ImportValue
-          Fn::Sub: "${AlertingStackName}-BuildNotificationTopicArn"
+        - !ImportValue build-notifications-BuildNotificationTopicArn"
 
   #######################
   # Canary Deployment
@@ -3007,8 +2990,7 @@ Resources:
       Threshold: 0
       ComparisonOperator: "GreaterThanThreshold"
       AlarmActions:
-        - !ImportValue
-          Fn::Sub: "${AlertingStackName}-BuildNotificationTopicArn"
+        - !ImportValue build-notifications-BuildNotificationTopicArn"
       ActionsEnabled: true
       TreatMissingData: notBreaching
 
@@ -3045,8 +3027,7 @@ Resources:
       Threshold: 0
       ComparisonOperator: "GreaterThanThreshold"
       AlarmActions:
-        - !ImportValue
-          Fn::Sub: "${AlertingStackName}-BuildNotificationTopicArn"
+        - !ImportValue build-notifications-BuildNotificationTopicArn"
       ActionsEnabled: true
       TreatMissingData: notBreaching
 
@@ -3083,8 +3064,7 @@ Resources:
       Threshold: 0
       ComparisonOperator: "GreaterThanThreshold"
       AlarmActions:
-        - !ImportValue
-          Fn::Sub: "${AlertingStackName}-BuildNotificationTopicArn"
+        - !ImportValue build-notifications-BuildNotificationTopicArn"
       ActionsEnabled: true
       TreatMissingData: notBreaching
 
@@ -3121,8 +3101,7 @@ Resources:
       Threshold: 0
       ComparisonOperator: "GreaterThanThreshold"
       AlarmActions:
-        - !ImportValue
-          Fn::Sub: "${AlertingStackName}-BuildNotificationTopicArn"
+        - !ImportValue build-notifications-BuildNotificationTopicArn"
       ActionsEnabled: true
       TreatMissingData: notBreaching
 
@@ -3159,8 +3138,7 @@ Resources:
       Threshold: 0
       ComparisonOperator: "GreaterThanThreshold"
       AlarmActions:
-        - !ImportValue
-          Fn::Sub: "${AlertingStackName}-BuildNotificationTopicArn"
+        - !ImportValue build-notifications-BuildNotificationTopicArn"
       ActionsEnabled: true
       TreatMissingData: notBreaching
 
@@ -3197,8 +3175,7 @@ Resources:
       Threshold: 0
       ComparisonOperator: "GreaterThanThreshold"
       AlarmActions:
-        - !ImportValue
-          Fn::Sub: "${AlertingStackName}-BuildNotificationTopicArn"
+        - !ImportValue build-notifications-BuildNotificationTopicArn"
       ActionsEnabled: true
       TreatMissingData: notBreaching
 
@@ -3235,8 +3212,7 @@ Resources:
       Threshold: 0
       ComparisonOperator: "GreaterThanThreshold"
       AlarmActions:
-        - !ImportValue
-          Fn::Sub: "${AlertingStackName}-BuildNotificationTopicArn"
+        - !ImportValue build-notifications-BuildNotificationTopicArn"
       ActionsEnabled: true
       TreatMissingData: notBreaching
 
@@ -3273,8 +3249,7 @@ Resources:
       Threshold: 0
       ComparisonOperator: "GreaterThanThreshold"
       AlarmActions:
-        - !ImportValue
-          Fn::Sub: "${AlertingStackName}-BuildNotificationTopicArn"
+        - !ImportValue build-notifications-BuildNotificationTopicArn"
       ActionsEnabled: true
       TreatMissingData: notBreaching
 
@@ -3311,8 +3286,7 @@ Resources:
       Threshold: 0
       ComparisonOperator: "GreaterThanThreshold"
       AlarmActions:
-        - !ImportValue
-          Fn::Sub: "${AlertingStackName}-BuildNotificationTopicArn"
+        - !ImportValue build-notifications-BuildNotificationTopicArn"
       ActionsEnabled: true
       TreatMissingData: notBreaching
 
@@ -3349,8 +3323,7 @@ Resources:
       Threshold: 0
       ComparisonOperator: "GreaterThanThreshold"
       AlarmActions:
-        - !ImportValue
-          Fn::Sub: "${AlertingStackName}-BuildNotificationTopicArn"
+        - !ImportValue build-notifications-BuildNotificationTopicArn"
       ActionsEnabled: true
       TreatMissingData: notBreaching
 
@@ -3387,8 +3360,7 @@ Resources:
       Threshold: 0
       ComparisonOperator: "GreaterThanThreshold"
       AlarmActions:
-        - !ImportValue
-          Fn::Sub: "${AlertingStackName}-BuildNotificationTopicArn"
+        - !ImportValue build-notifications-BuildNotificationTopicArn"
       ActionsEnabled: true
       TreatMissingData: notBreaching
 
@@ -3425,8 +3397,7 @@ Resources:
       Threshold: 0
       ComparisonOperator: "GreaterThanThreshold"
       AlarmActions:
-        - !ImportValue
-          Fn::Sub: "${AlertingStackName}-BuildNotificationTopicArn"
+        - !ImportValue build-notifications-BuildNotificationTopicArn"
       ActionsEnabled: true
       TreatMissingData: notBreaching
 
@@ -3463,8 +3434,7 @@ Resources:
       Threshold: 0
       ComparisonOperator: "GreaterThanThreshold"
       AlarmActions:
-        - !ImportValue
-          Fn::Sub: "${AlertingStackName}-BuildNotificationTopicArn"
+        - !ImportValue build-notifications-BuildNotificationTopicArn"
       ActionsEnabled: true
       TreatMissingData: notBreaching
 
@@ -3501,8 +3471,7 @@ Resources:
       Threshold: 0
       ComparisonOperator: "GreaterThanThreshold"
       AlarmActions:
-        - !ImportValue
-          Fn::Sub: "${AlertingStackName}-BuildNotificationTopicArn"
+        - !ImportValue build-notifications-BuildNotificationTopicArn"
       ActionsEnabled: true
       TreatMissingData: notBreaching
 

--- a/template.yaml
+++ b/template.yaml
@@ -2661,7 +2661,7 @@ Resources:
       Threshold: 10
       ComparisonOperator: "GreaterThanOrEqualToThreshold"
       AlarmActions:
-        - BuildNoti
+        - !ImportValue build-notifications-BuildNotificationTopicArn
       ActionsEnabled: true
 
   TriggerSuspiciousActivityStepFunctionLambdaExecutionRetryAlarm:


### PR DESCRIPTION

## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->

### What changed
Update all our alarms to use the new notification topic that's created by the dev platform's `build-notifications` stack.

DO NOT MERGE this until the `build-notifications` stack has been deployed into all our accounts.

### Why did it change

The topic has changed now we've switched to the dev platform's notifications topic. It's exported as an output of that stack, so update all our alarms here to reference the output.


## Checklists

<!-- Merging this PR deploys to production. Please answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

## Testing

I've deployed this branch to dev where the new notifications stack is set up to check for errors.
