### PR TITLE
OLH-1949: Set up a basic post-deploy integration test

### DIFF
--- a/.github/workflows/sam-app-post-merge-actions.yaml
+++ b/.github/workflows/sam-app-post-merge-actions.yaml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 #pin@v2.0.1
 
       - name: Build, tag, and push testing image to Amazon ECR
         env:

--- a/.github/workflows/sam-app-post-merge-actions.yaml
+++ b/.github/workflows/sam-app-post-merge-actions.yaml
@@ -53,6 +53,19 @@ jobs:
           role-to-assume: ${{ secrets.GH_ACTIONS_ROLE_ARN }}
           aws-region: eu-west-2
 
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Build, tag, and push testing image to Amazon ECR
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: ${{ secrets.POST_DEPLOY_TESTS_IMAGE_REPOSITORY }}
+          IMAGE_TAG: latest
+        run: |
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -f post-deploy-tests.Dockerfile . 
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+
       - name: SAM validate
         run: sam validate
 

--- a/post-deploy-tests.Dockerfile
+++ b/post-deploy-tests.Dockerfile
@@ -1,0 +1,10 @@
+FROM amazonlinux:2023
+
+ENV AWS_PAGER=""
+
+RUN yum install -y awscli
+
+COPY . .
+COPY /post-deploy-tests/run-tests.sh .
+
+ENTRYPOINT ["/run-tests.sh"]

--- a/post-deploy-tests/fixtures/delete-activity-log.json
+++ b/post-deploy-tests/fixtures/delete-activity-log.json
@@ -1,0 +1,31 @@
+{
+  "Records": [
+    {
+      "EventSource": "aws:sns",
+      "EventVersion": "1.0",
+      "EventSubscriptionArn": "arn:aws:sns:us-east-1:{{{accountId}}}:ExampleTopic",
+      "Sns": {
+        "Type": "Notification",
+        "MessageId": "95df01b4-ee98-5cb9-9903-4c221d41eb5e",
+        "TopicArn": "arn:aws:sns:us-east-1:123456789012:ExampleTopic",
+        "Subject": "example subject",
+        "Message": "{\"user_id\":\"post-deploy-tests\"}",
+        "Timestamp": "1970-01-01T00:00:00.000Z",
+        "SignatureVersion": "1",
+        "Signature": "EXAMPLE",
+        "SigningCertUrl": "EXAMPLE",
+        "UnsubscribeUrl": "EXAMPLE",
+        "MessageAttributes": {
+          "Test": {
+            "Type": "String",
+            "Value": "TestString"
+          },
+          "TestBinary": {
+            "Type": "Binary",
+            "Value": "TestBinary"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/post-deploy-tests/fixtures/delete-activity-log.json
+++ b/post-deploy-tests/fixtures/delete-activity-log.json
@@ -3,11 +3,11 @@
     {
       "EventSource": "aws:sns",
       "EventVersion": "1.0",
-      "EventSubscriptionArn": "arn:aws:sns:us-east-1:{{{accountId}}}:ExampleTopic",
+      "EventSubscriptionArn": "arn:aws:sns:eu-west-2:{{{accountId}}}:ExampleTopic",
       "Sns": {
         "Type": "Notification",
         "MessageId": "95df01b4-ee98-5cb9-9903-4c221d41eb5e",
-        "TopicArn": "arn:aws:sns:us-east-1:123456789012:ExampleTopic",
+        "TopicArn": "arn:aws:sns:eu-west-2:123456789012:ExampleTopic",
         "Subject": "example subject",
         "Message": "{\"user_id\":\"post-deploy-tests\"}",
         "Timestamp": "1970-01-01T00:00:00.000Z",

--- a/post-deploy-tests/fixtures/write-activity-log.json
+++ b/post-deploy-tests/fixtures/write-activity-log.json
@@ -13,8 +13,8 @@
       "messageAttributes": {},
       "md5OfBody": "e359050680237e70f4b71093185eca98",
       "eventSource": "aws:sqs",
-      "eventSourceARN": "arn:aws:sqs:us-east-1:123456789012:MyQueue",
-      "awsRegion": "us-east-1"
+      "eventSourceARN": "arn:aws:sqs:eu-west-2:123456789012:MyQueue",
+      "awsRegion": "eu-west-2"
     }
   ]
 }

--- a/post-deploy-tests/fixtures/write-activity-log.json
+++ b/post-deploy-tests/fixtures/write-activity-log.json
@@ -1,0 +1,20 @@
+{
+  "Records": [
+    {
+      "messageId": "19dd0b57-b21e-4ac1-bd88-01bbb068cb78",
+      "receiptHandle": "MessageReceiptHandle",
+      "body": "{\"event_id\":\"event-id-1\",\"event_type\":\"AUTH_AUTH_CODE_ISSUED\",\"session_id\":\"session-id\",\"user_id\":\"post-deploy-tests\",\"timestamp\":1720465374,\"client_id\":\"client-id\",\"reported_suspicious\":false}",
+      "attributes": {
+        "ApproximateReceiveCount": "1",
+        "SentTimestamp": "1523232000000",
+        "SenderId": "123456789012",
+        "ApproximateFirstReceiveTimestamp": "1523232000001"
+      },
+      "messageAttributes": {},
+      "md5OfBody": "e359050680237e70f4b71093185eca98",
+      "eventSource": "aws:sqs",
+      "eventSourceARN": "arn:aws:sqs:us-east-1:123456789012:MyQueue",
+      "awsRegion": "us-east-1"
+    }
+  ]
+}

--- a/post-deploy-tests/run-tests.sh
+++ b/post-deploy-tests/run-tests.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+# Script to run post-deploy tests in the build environment
+# See https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3054010402/How+to+run+tests+against+your+deployed+application+in+a+SAM+deployment+pipeline 
+# for more information as to how this is used
+
+# Exit the script with error code 1 if any command fails
+set -euxo pipefail
+
+aws lambda invoke \
+  --function-name build-account-mgmt-backend-write-activity-log:live \
+  --payload file://post-deploy-tests/fixtures/write-activity-log.json \
+  --cli-binary-format raw-in-base64-out \
+  --output json \
+  /dev/null
+
+aws lambda invoke \
+  --function-name build-account-mgmt-backend-delete-activity-log:live \
+  --payload file://post-deploy-tests/fixtures/delete-activity-log.json \
+  --cli-binary-format raw-in-base64-out \
+  --output json \
+  /dev/null

--- a/template.yaml
+++ b/template.yaml
@@ -49,6 +49,10 @@ Parameters:
   AccountManagementFrontendStackName:
     Type: String
     Default: account-mgmt-frontend
+  TestRoleArn:
+    Type: String
+    Description: The ARN of the role the post-deploy tests are run from
+    Default: "none"
   ProductTagValue:
     Description: Value for the Product Tag
     Type: String
@@ -108,6 +112,12 @@ Conditions:
       - !Equals [!Ref Environment, staging]
       - !Equals [!Ref Environment, integration]
       - !Equals [!Ref Environment, production]
+
+  GrantTestPermissions:
+    Fn::Not:
+      - Fn::Equals:
+          - !Ref TestRoleArn
+          - "none"
 
 Globals:
   Function:
@@ -3478,6 +3488,26 @@ Resources:
         - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/LowAlertNotificationTopic/ARN}}"
       ActionsEnabled: true
       TreatMissingData: notBreaching
+
+  #######################
+  # Test permissons
+  #######################
+
+  PostDeployTestPolicy:
+    Condition: GrantTestPermissions
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      Roles:
+        - !Ref TestRoleArn
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - lambda:InvokeFunction
+            Resource:
+              - !GetAtt WriteActivityLogFunction.Arn
+              - !GetAtt DeleteActivityLogFunction.Arn
 
   #######################
   # Encryption


### PR DESCRIPTION
## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->

### What changed

Set up to run a basic post-deploy integration test. This is following the dev platform team's [instructions](https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3054010402/How+to+run+tests+against+your+deployed+application+in+a+SAM+deployment+pipeline).

The test script uses the AWS cli to invoke the `write-activity-log` and`delete-activity-log` lambdas with pre-defined fixtures. It'll fail with a non-zero exit code if either invocation fails.

This is a super-simple integration test, but it checks a lot:
- The lambdas have built correctly and can run
- They have permission to use KMS and DynamoDB
- They can process the message without timing out

Notably this script won't fail if any of the payloads are invalid due to the way we catch and handle errors in the lambdas. That's ok for now.

In the future we'll probably want to migrate this to an NPM script using something like Cucumber to orchestrate the tests. This is a first go at getting a post-deploy test working; it'll catch the most broken bad releases as a start.

The default role the post-deploy tests run as doesn't have many permissions. The pipeline provides the `TestRoleArn` parameter to the deployed stack so we can build our own policy and grant it the
permissions we need.

After this is merged and the first testing image has been pushed to ECR I will update the pipeline settings to run the tests in build.

### Why did it change

We've had a couple of incidents where we've broken the lambda builds and release non-functional artifacts. We'll want to expand on this test suite to cover more of the functions of the backend, but this is a first effort to catch the type of releases that are have caused the recent problems. 

## Checklists

<!-- Merging this PR deploys to production. Please answer accurately. -->

### Environment variables or secrets

- [ ] No environment variables or secrets were added or changed
- [x] Added parameters to Cloudformation template

### Permissions

- [x] This PR adds or changes permissions

## Testing

I've built the Docker container and run the test script against build using my AWS credentials. You can do the same by running:

```bash
aws sso login --profile di-account-build-admin

eval "$(aws configure export-credentials --profile di-account-build-admin --format env)"

docker build . -t test

docker run -t \
  -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
  -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \
  -e AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN \
  -e AWS_SECURITY_TOKEN=$AWS_SECURITY_TOKEN \
  -e AWS_DEFAULT_REGION="eu-west-2" \
  test
```

The real test will be with the role's credentials once this is deployed. There's no way to test that now however. 