### PR TITLE
OLH-1934: Don't give Orchestration permissions in build

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -103,6 +103,11 @@ Conditions:
     - !Equals [!Ref Environment, dev]
     - !Equals [!Ref Environment, build]
 
+  UseExternalEvents: !Or
+    - !Equals [!Ref Environment, staging]
+    - !Equals [!Ref Environment, integration]
+    - !Equals [!Ref Environment, production]
+
   ExportLogsToSplunk:
     Fn::Or:
       - !Equals [!Ref Environment, staging]
@@ -1283,21 +1288,24 @@ Resources:
             Action: sns:Subscribe
             Resource:
               - !Ref UserAccountDeletionTopic
-          - Sid: "Allow Orchestration to publish"
-            Effect: Allow
-            Principal:
-              AWS: !Join
-                - ""
-                - - "arn:aws:iam::"
-                  - !FindInMap [
-                      OrchestrationAccounts,
-                      !Ref Environment,
-                      "AccountNumber",
-                    ]
-                  - ":root"
-            Action: sns:Publish
-            Resource:
-              - !Ref UserAccountDeletionTopic
+          - !If
+            - "UseExternalEvents"
+            - Sid: "Allow Orchestration to publish"
+              Effect: Allow
+              Principal:
+                AWS: !Join
+                  - ""
+                  - - "arn:aws:iam::"
+                    - !FindInMap [
+                        OrchestrationAccounts,
+                        !Ref Environment,
+                        "AccountNumber",
+                      ]
+                    - ":root"
+              Action: sns:Publish
+              Resource:
+                - !Ref UserAccountDeletionTopic
+            - !Ref AWS::NoValue
 
   DeleteTopicArnParameter:
     Type: AWS::SSM::Parameter
@@ -3699,7 +3707,7 @@ Resources:
                 - "*"
             - !Ref AWS::NoValue
           - !If
-            - "IsNotDevelopmentOrDemo"
+            - "UseExternalEvents"
             - Effect: Allow
               Principal:
                 AWS: !Join


### PR DESCRIPTION
## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->

### What changed

Add a new condition to be clear when we're using external audit events, and use that to only enable the SNS and KMS policies in the correct environments.

### Why did it change

We only have account IDs from Orchestration in staging, integration and production environments. This is correct, as those are the only environments that get events from TxMA and therefore where data needs to be deleted.

However, the condition on this policy was to add it in build as well. This caused the deploy to fail as the principal ends up malformed.

### Related links

See #263 where these were initially added.

## Checklists

<!-- Merging this PR deploys to production. Please answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Permissions

- [x] This PR adds or changes permissions