### PR TITLE
OLH-1949: Provide the role name to the test policy

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -3535,7 +3535,7 @@ Resources:
     Type: AWS::IAM::ManagedPolicy
     Properties:
       Roles:
-        - !Ref TestRoleArn
+        - !Select [1, !Split ["/", !Ref TestRoleArn]]
       PolicyDocument:
         Version: "2012-10-17"
         Statement:


### PR DESCRIPTION

## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->

### What changed

The pipeline provides us with the test container role ARN, but to attach a managed policy to an existing role we need the role name instead.

Thankfully ARNs are a predictable format and are always like

`arn:aws:iam::123456789:role/role-name`

Everything after the `/` is the role name. Use the Cloudformation built in functions to split the ARN and select the second item in the array which is the name.

### Why did it change

Currently the backend template is failing to create the test role when it's deployed.

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed