### PR TITLE
OLH-1949: Move the test role permissions to the lambda policies

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -3530,21 +3530,21 @@ Resources:
   # Test permissons
   #######################
 
-  PostDeployTestPolicy:
+  WriteActivityLogFunctionTestPolicy:
     Condition: GrantTestPermissions
-    Type: AWS::IAM::ManagedPolicy
+    Type: AWS::Lambda::Permission
     Properties:
-      Roles:
-        - !Select [1, !Split ["/", !Ref TestRoleArn]]
-      PolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          - Effect: Allow
-            Action:
-              - lambda:InvokeFunction
-            Resource:
-              - !GetAtt WriteActivityLogFunction.Arn
-              - !GetAtt DeleteActivityLogFunction.Arn
+      Action: lambda:InvokeFunction
+      FunctionName: !Ref WriteActivityLogFunction
+      Principal: !Ref TestRoleArn
+
+  DeleteActivityLogFunctionTestPolicy:
+    Condition: GrantTestPermissions
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !Ref DeleteActivityLogFunction
+      Principal: !Ref TestRoleArn
 
   #######################
   # Encryption


### PR DESCRIPTION
## Proposed changes
### What changed

Move the post-deploy test role permissions to the lambda policies.

### Why did it change

The deploy pipeline doesn't have permissions to attach a managed policy to the test role. This is the cause of [the error](https://gds.slack.com/archives/C04D3SQNJ4B/p1720537538836309) I saw when enabling the tests in the pipeline:
```
User: arn:aws:sts::301577035144:assumed-role/PL-account-mgmt-backend-pipeline-DeployRole-0a649fe12144/AWS CodeBuild-e6657a15-f8dc-4e88-bb54-3b7bb4025d6e 
is not authorized to perform: iam:AttachRolePolicy on resource: role PL-account-mgmt-backend-pipeline-TestRole-0a649fe12144  
because no identity-based policy allows the iam:AttachRolePolicy action
```

Instead of making one managed policy, we can add the permissions on the lambda side instead which uses only resources created within this template. This has another advantage of not needing to split the role ARN to get the name.

See
https://github.com/govuk-one-login/txma-event-replay/blob/main/template.yaml#L1376 as an example of another team doing this.

### Related links

#278 & #282 

## Checklists

<!-- Merging this PR deploys to production. Please answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Permissions

- [x] This PR adds or changes permissions

## Testing

Merging this PR won't enable the tests or break anything. Once it's been deployed I can go back to the pipeline, re-enable the test step and then try the deploy again. 