### PR TITLE
OLH-1949: Copy test fixtures to Dockerfile root

### DIFF
--- a/post-deploy-tests.Dockerfile
+++ b/post-deploy-tests.Dockerfile
@@ -4,7 +4,7 @@ ENV AWS_PAGER=""
 
 RUN yum install -y awscli
 
-COPY . .
 COPY /post-deploy-tests/run-tests.sh .
+COPY /post-deploy-tests/fixtures .
 
 ENTRYPOINT ["/run-tests.sh"]

--- a/post-deploy-tests/run-tests.sh
+++ b/post-deploy-tests/run-tests.sh
@@ -9,14 +9,14 @@ set -euxo pipefail
 
 aws lambda invoke \
   --function-name build-account-mgmt-backend-write-activity-log:live \
-  --payload file://post-deploy-tests/fixtures/write-activity-log.json \
+  --payload file://./write-activity-log.json \
   --cli-binary-format raw-in-base64-out \
   --output json \
   /dev/null
 
 aws lambda invoke \
   --function-name build-account-mgmt-backend-delete-activity-log:live \
-  --payload file://post-deploy-tests/fixtures/delete-activity-log.json \
+  --payload file://./delete-activity-log.json \
   --cli-binary-format raw-in-base64-out \
   --output json \
   /dev/null


### PR DESCRIPTION
## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->

### What changed

Switch to only copying the files we need and use relative file paths for the fixtures so hopefully they can be found when run in the pipeline.

### Why did it change

I can run the test container in the pipeline but it fails with `Unable to load paramfile file://post-deploy-tests/fixtures/write-activity-log.json: [Errno 2] No such file or directory:`

I think this is to do with the working directory and where the script is run from. I also realised we don't need to copy the whole repo into the container - we only need the test script and the fixtures for this.

## Checklists

<!-- Merging this PR deploys to production. Please answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

## Testing

I've built this container locally and run it against `build`.
