### PR TITLE
OLH-1949: Use `cat` to read test fixtures

### DIFF
--- a/post-deploy-tests/run-tests.sh
+++ b/post-deploy-tests/run-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Script to run post-deploy tests in the build environment
 # See https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3054010402/How+to+run+tests+against+your+deployed+application+in+a+SAM+deployment+pipeline 
@@ -9,14 +9,12 @@ set -euxo pipefail
 
 aws lambda invoke \
   --function-name build-account-mgmt-backend-write-activity-log:live \
-  --payload file://./write-activity-log.json \
-  --cli-binary-format raw-in-base64-out \
+  --payload "$(cat /write-activity-log.json | base64)" \
   --output json \
   /dev/null
 
 aws lambda invoke \
   --function-name build-account-mgmt-backend-delete-activity-log:live \
-  --payload file://./delete-activity-log.json \
-  --cli-binary-format raw-in-base64-out \
+  --payload "$(cat /delete-activity-log.json | base64)" \
   --output json \
   /dev/null


### PR DESCRIPTION

## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->

### What changed

Use `cat` to read test fixtures in the post-deploy test script. 

### Why did it change

We are still seeing `[Errno 2] No such file or directory` when the test container runs in the pipeline but not locally.

The `file://` URIs are notoriously picky so stop using them completely and switch to using `cat` to read the files in place. This means we need to run the script with bash and not plain sh. I've checked and the Amazon Linux image does include bash.

## Checklists

<!-- Merging this PR deploys to production. Please answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

## Testing

I can build and run the container locally and the pipeline step is still disabled. Once this is merged I'll go back and re-try it. 
