### PR TITLE
OLH-1949: Validate lambda invocations in the post-deploy tests

### DIFF
--- a/post-deploy-tests.Dockerfile
+++ b/post-deploy-tests.Dockerfile
@@ -3,6 +3,7 @@ FROM amazonlinux:2023
 ENV AWS_PAGER=""
 
 RUN yum install -y awscli
+RUN yum install -y jq
 
 COPY /post-deploy-tests/run-tests.sh .
 COPY /post-deploy-tests/fixtures .

--- a/post-deploy-tests/fixtures/write-activity-log.json
+++ b/post-deploy-tests/fixtures/write-activity-log.json
@@ -1,7 +1,151 @@
 {
   "Records": [
     {
+      "messageId": "19dd0b57-b21e-4ac1-bd88-01bbb068cb70",
+      "receiptHandle": "MessageReceiptHandle",
+      "body": "{\"event_id\":\"event-id-1\",\"event_type\":\"AUTH_AUTH_CODE_ISSUED\",\"session_id\":\"session-id\",\"user_id\":\"post-deploy-tests\",\"timestamp\":1720465374,\"client_id\":\"client-id\",\"reported_suspicious\":false}",
+      "attributes": {
+        "ApproximateReceiveCount": "1",
+        "SentTimestamp": "1523232000000",
+        "SenderId": "123456789012",
+        "ApproximateFirstReceiveTimestamp": "1523232000001"
+      },
+      "messageAttributes": {},
+      "md5OfBody": "e359050680237e70f4b71093185eca98",
+      "eventSource": "aws:sqs",
+      "eventSourceARN": "arn:aws:sqs:eu-west-2:123456789012:MyQueue",
+      "awsRegion": "eu-west-2"
+    },
+    {
+      "messageId": "19dd0b57-b21e-4ac1-bd88-01bbb068cb71",
+      "receiptHandle": "MessageReceiptHandle",
+      "body": "{\"event_id\":\"event-id-1\",\"event_type\":\"AUTH_AUTH_CODE_ISSUED\",\"session_id\":\"session-id\",\"user_id\":\"post-deploy-tests\",\"timestamp\":1720465374,\"client_id\":\"client-id\",\"reported_suspicious\":false}",
+      "attributes": {
+        "ApproximateReceiveCount": "1",
+        "SentTimestamp": "1523232000000",
+        "SenderId": "123456789012",
+        "ApproximateFirstReceiveTimestamp": "1523232000001"
+      },
+      "messageAttributes": {},
+      "md5OfBody": "e359050680237e70f4b71093185eca98",
+      "eventSource": "aws:sqs",
+      "eventSourceARN": "arn:aws:sqs:eu-west-2:123456789012:MyQueue",
+      "awsRegion": "eu-west-2"
+    },
+    {
+      "messageId": "19dd0b57-b21e-4ac1-bd88-01bbb068cb72",
+      "receiptHandle": "MessageReceiptHandle",
+      "body": "{\"event_id\":\"event-id-1\",\"event_type\":\"AUTH_AUTH_CODE_ISSUED\",\"session_id\":\"session-id\",\"user_id\":\"post-deploy-tests\",\"timestamp\":1720465374,\"client_id\":\"client-id\",\"reported_suspicious\":false}",
+      "attributes": {
+        "ApproximateReceiveCount": "1",
+        "SentTimestamp": "1523232000000",
+        "SenderId": "123456789012",
+        "ApproximateFirstReceiveTimestamp": "1523232000001"
+      },
+      "messageAttributes": {},
+      "md5OfBody": "e359050680237e70f4b71093185eca98",
+      "eventSource": "aws:sqs",
+      "eventSourceARN": "arn:aws:sqs:eu-west-2:123456789012:MyQueue",
+      "awsRegion": "eu-west-2"
+    },
+    {
+      "messageId": "19dd0b57-b21e-4ac1-bd88-01bbb068cb73",
+      "receiptHandle": "MessageReceiptHandle",
+      "body": "{\"event_id\":\"event-id-1\",\"event_type\":\"AUTH_AUTH_CODE_ISSUED\",\"session_id\":\"session-id\",\"user_id\":\"post-deploy-tests\",\"timestamp\":1720465374,\"client_id\":\"client-id\",\"reported_suspicious\":false}",
+      "attributes": {
+        "ApproximateReceiveCount": "1",
+        "SentTimestamp": "1523232000000",
+        "SenderId": "123456789012",
+        "ApproximateFirstReceiveTimestamp": "1523232000001"
+      },
+      "messageAttributes": {},
+      "md5OfBody": "e359050680237e70f4b71093185eca98",
+      "eventSource": "aws:sqs",
+      "eventSourceARN": "arn:aws:sqs:eu-west-2:123456789012:MyQueue",
+      "awsRegion": "eu-west-2"
+    },
+    {
+      "messageId": "19dd0b57-b21e-4ac1-bd88-01bbb068cb74",
+      "receiptHandle": "MessageReceiptHandle",
+      "body": "{\"event_id\":\"event-id-1\",\"event_type\":\"AUTH_AUTH_CODE_ISSUED\",\"session_id\":\"session-id\",\"user_id\":\"post-deploy-tests\",\"timestamp\":1720465374,\"client_id\":\"client-id\",\"reported_suspicious\":false}",
+      "attributes": {
+        "ApproximateReceiveCount": "1",
+        "SentTimestamp": "1523232000000",
+        "SenderId": "123456789012",
+        "ApproximateFirstReceiveTimestamp": "1523232000001"
+      },
+      "messageAttributes": {},
+      "md5OfBody": "e359050680237e70f4b71093185eca98",
+      "eventSource": "aws:sqs",
+      "eventSourceARN": "arn:aws:sqs:eu-west-2:123456789012:MyQueue",
+      "awsRegion": "eu-west-2"
+    },
+    {
+      "messageId": "19dd0b57-b21e-4ac1-bd88-01bbb068cb75",
+      "receiptHandle": "MessageReceiptHandle",
+      "body": "{\"event_id\":\"event-id-1\",\"event_type\":\"AUTH_AUTH_CODE_ISSUED\",\"session_id\":\"session-id\",\"user_id\":\"post-deploy-tests\",\"timestamp\":1720465374,\"client_id\":\"client-id\",\"reported_suspicious\":false}",
+      "attributes": {
+        "ApproximateReceiveCount": "1",
+        "SentTimestamp": "1523232000000",
+        "SenderId": "123456789012",
+        "ApproximateFirstReceiveTimestamp": "1523232000001"
+      },
+      "messageAttributes": {},
+      "md5OfBody": "e359050680237e70f4b71093185eca98",
+      "eventSource": "aws:sqs",
+      "eventSourceARN": "arn:aws:sqs:eu-west-2:123456789012:MyQueue",
+      "awsRegion": "eu-west-2"
+    },
+    {
+      "messageId": "19dd0b57-b21e-4ac1-bd88-01bbb068cb76",
+      "receiptHandle": "MessageReceiptHandle",
+      "body": "{\"event_id\":\"event-id-1\",\"event_type\":\"AUTH_AUTH_CODE_ISSUED\",\"session_id\":\"session-id\",\"user_id\":\"post-deploy-tests\",\"timestamp\":1720465374,\"client_id\":\"client-id\",\"reported_suspicious\":false}",
+      "attributes": {
+        "ApproximateReceiveCount": "1",
+        "SentTimestamp": "1523232000000",
+        "SenderId": "123456789012",
+        "ApproximateFirstReceiveTimestamp": "1523232000001"
+      },
+      "messageAttributes": {},
+      "md5OfBody": "e359050680237e70f4b71093185eca98",
+      "eventSource": "aws:sqs",
+      "eventSourceARN": "arn:aws:sqs:eu-west-2:123456789012:MyQueue",
+      "awsRegion": "eu-west-2"
+    },
+    {
+      "messageId": "19dd0b57-b21e-4ac1-bd88-01bbb068cb77",
+      "receiptHandle": "MessageReceiptHandle",
+      "body": "{\"event_id\":\"event-id-1\",\"event_type\":\"AUTH_AUTH_CODE_ISSUED\",\"session_id\":\"session-id\",\"user_id\":\"post-deploy-tests\",\"timestamp\":1720465374,\"client_id\":\"client-id\",\"reported_suspicious\":false}",
+      "attributes": {
+        "ApproximateReceiveCount": "1",
+        "SentTimestamp": "1523232000000",
+        "SenderId": "123456789012",
+        "ApproximateFirstReceiveTimestamp": "1523232000001"
+      },
+      "messageAttributes": {},
+      "md5OfBody": "e359050680237e70f4b71093185eca98",
+      "eventSource": "aws:sqs",
+      "eventSourceARN": "arn:aws:sqs:eu-west-2:123456789012:MyQueue",
+      "awsRegion": "eu-west-2"
+    },
+    {
       "messageId": "19dd0b57-b21e-4ac1-bd88-01bbb068cb78",
+      "receiptHandle": "MessageReceiptHandle",
+      "body": "{\"event_id\":\"event-id-1\",\"event_type\":\"AUTH_AUTH_CODE_ISSUED\",\"session_id\":\"session-id\",\"user_id\":\"post-deploy-tests\",\"timestamp\":1720465374,\"client_id\":\"client-id\",\"reported_suspicious\":false}",
+      "attributes": {
+        "ApproximateReceiveCount": "1",
+        "SentTimestamp": "1523232000000",
+        "SenderId": "123456789012",
+        "ApproximateFirstReceiveTimestamp": "1523232000001"
+      },
+      "messageAttributes": {},
+      "md5OfBody": "e359050680237e70f4b71093185eca98",
+      "eventSource": "aws:sqs",
+      "eventSourceARN": "arn:aws:sqs:eu-west-2:123456789012:MyQueue",
+      "awsRegion": "eu-west-2"
+    },
+    {
+      "messageId": "19dd0b57-b21e-4ac1-bd88-01bbb068cb79",
       "receiptHandle": "MessageReceiptHandle",
       "body": "{\"event_id\":\"event-id-1\",\"event_type\":\"AUTH_AUTH_CODE_ISSUED\",\"session_id\":\"session-id\",\"user_id\":\"post-deploy-tests\",\"timestamp\":1720465374,\"client_id\":\"client-id\",\"reported_suspicious\":false}",
       "attributes": {

--- a/post-deploy-tests/run-tests.sh
+++ b/post-deploy-tests/run-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Script to run post-deploy tests in the build environment
 # See https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3054010402/How+to+run+tests+against+your+deployed+application+in+a+SAM+deployment+pipeline 
@@ -9,14 +9,12 @@ set -euxo pipefail
 
 aws lambda invoke \
   --function-name build-account-mgmt-backend-write-activity-log:live \
-  --payload file://./write-activity-log.json \
-  --cli-binary-format raw-in-base64-out \
+  --payload "$(cat /write-activity-log.json | base64)" \
   --output json \
   /dev/null
 
 aws lambda invoke \
   --function-name build-account-mgmt-backend-delete-activity-log:live \
-  --payload file://./delete-activity-log.json \
-  --cli-binary-format raw-in-base64-out \
+  --payload "$(cat /delete-activity-log.json | base64)" \
   --output json \
   /dev/null

--- a/post-deploy-tests/run-tests.sh
+++ b/post-deploy-tests/run-tests.sh
@@ -11,10 +11,10 @@ aws lambda invoke \
   --function-name build-account-mgmt-backend-write-activity-log:live \
   --payload "$(cat /write-activity-log.json | base64)" \
   --output json \
-  /dev/null
+  /dev/null | jq -e -n 'if input.StatusCode == 200 then true else halt_error(1) end'
 
 aws lambda invoke \
   --function-name build-account-mgmt-backend-delete-activity-log:live \
   --payload "$(cat /delete-activity-log.json | base64)" \
   --output json \
-  /dev/null
+  /dev/null | jq -e -n 'if input.StatusCode == 200 then true else halt_error(1) end'


### PR DESCRIPTION
## Proposed changes

### What changed

The response we get back from the Lambda service looks like:
```json
{
    "StatusCode": 200,
    "ExecutedVersion": "60"
}
```

Use JQ to parse this response and check the status code was 200. If it's not, halt processing with exit code 1. This will propagate up and cause the script to exit, failing the tests in Codebuild.

Also increase the `write-activity-log` fixture to 10 messages. This was the original plan for these tests as we discovered that the `write-activity-log` lambda timed out when it processed a full batch of 10 messages on the default timeout settings.

Don't merge this until #305 has been merged into `main`. 

### Why did it change

At the moment any errors raised by these tests will be to do with the test setup - either in the script or AWS permissions related. We also need to check the lambda responses and make sure the function succeeded for this to be a useful test suite.

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

## Testing

I've built the test container locally and run it against build, following the instructions in the README.
