### PR TITLE
OLH-1949: Refactor post-deploy test script

### DIFF
--- a/post-deploy-tests/run-tests.sh
+++ b/post-deploy-tests/run-tests.sh
@@ -7,14 +7,14 @@
 # Exit the script with error code 1 if any command fails
 set -euxo pipefail
 
-aws lambda invoke \
-  --function-name build-account-mgmt-backend-write-activity-log:live \
-  --payload "$(cat /write-activity-log.json | base64)" \
-  --output json \
-  /dev/null | jq -e -n 'if input.StatusCode == 200 then true else halt_error(1) end'
+check_lambda_invocation () {
+  aws lambda invoke \
+    --function-name build-account-mgmt-backend-$1:live \
+    --payload "$(cat /$1.json | base64)" \
+    --output json \
+    /dev/null | jq -e -n 'if input.StatusCode == 200 then true else halt_error(1) end'
+}
 
-aws lambda invoke \
-  --function-name build-account-mgmt-backend-delete-activity-log:live \
-  --payload "$(cat /delete-activity-log.json | base64)" \
-  --output json \
-  /dev/null | jq -e -n 'if input.StatusCode == 200 then true else halt_error(1) end'
+for lambda_name in write-activity-log delete-activity-log; do
+  check_lambda_invocation $lambda_name
+done


### PR DESCRIPTION
## Proposed changes

### What changed

Extract the testing out into a function and then call the new function iterating over all the lambda names.

### Why did it change

We're using the same AWS CLI command to perform the same invocation and same validation step on both lambdas.

This will make it easier and cleaner to add new lambdas in the future if we want to - we'll just need to add a fixture and then update the array on line 18.

### Related links

#305 and #306 

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

## Testing

I've built and run the test container locally against `build`. 
