### PR TITLE
OLH-2025-throw-errors-in-backend-lambdas

### DIFF
--- a/src/create-support-ticket.ts
+++ b/src/create-support-ticket.ts
@@ -189,13 +189,8 @@ export const handler = async (
     console.log(`finished processing event with ID: ${eventIdentifier}`);
     return input;
   } catch (error) {
-    console.error(
-      `[Error occurred], unable to send suspicious activity event with ID: ${eventIdentifier} to Zendesk, ${
-        (error as Error).message
-      }`
-    );
     throw new Error(
-      `[Error occurred], unable to send suspicious activity event with ID: ${eventIdentifier} to Zendesk, ${
+      `Unable to send suspicious activity event with ID: ${eventIdentifier} to Zendesk, ${
         (error as Error).message
       }`
     );

--- a/src/format-activity-log.ts
+++ b/src/format-activity-log.ts
@@ -44,7 +44,6 @@ export const formatIntoActivityLogEntry = (
 export const handler = async (event: DynamoDBStreamEvent): Promise<void> => {
   const { Records } = event;
   const OUTPUT_QUEUE_URL = getEnvironmentVariable("OUTPUT_QUEUE_URL");
-  const DLQ_URL = getEnvironmentVariable("DLQ_URL");
   await Promise.all(
     Records.map(async (record) => {
       try {
@@ -68,15 +67,11 @@ export const handler = async (event: DynamoDBStreamEvent): Promise<void> => {
           );
         }
         console.log(`finished processing event with ID: ${record.eventID}`);
-      } catch (err) {
-        console.error(
-          "[Error occurred] unable to format activity log event",
-          err
-        );
-        const messageId = await sendSqsMessage(JSON.stringify(record), DLQ_URL);
-        console.error(
-          `[Message sent to DLQ] with message id = ${messageId}`,
-          err
+      } catch (error) {
+        throw new Error(
+          `Unable to format activity log for event with ID: ${record.eventID}, ${
+            (error as Error).message
+          }`
         );
       }
     })

--- a/src/format-user-services.ts
+++ b/src/format-user-services.ts
@@ -121,7 +121,6 @@ export const formatRecord = (record: UserRecordEvent) => {
 export const handler = async (event: SQSEvent): Promise<void> => {
   const { Records } = event;
   const OUTPUT_QUEUE_URL = getEnvironmentVariable("OUTPUT_QUEUE_URL");
-  const DLQ_URL = getEnvironmentVariable("DLQ_URL");
   await Promise.all(
     Records.map(async (record) => {
       try {
@@ -133,11 +132,11 @@ export const handler = async (event: SQSEvent): Promise<void> => {
         );
         console.log(`[Message sent to QUEUE] with message id = ${messageId}`);
         console.log(`finished processing message with ID: ${record.messageId}`);
-      } catch (err) {
-        const messageId = await sendSqsMessage(record.body, DLQ_URL);
-        console.error(
-          `[Message sent to DLQ] with message id = ${messageId}`,
-          err
+      } catch (error) {
+        throw new Error(
+          `Unable to format user services for message with ID: ${record.messageId}, ${
+            (error as Error).message
+          }`
         );
       }
     })

--- a/src/mark-activity-reported.ts
+++ b/src/mark-activity-reported.ts
@@ -76,11 +76,7 @@ export const queryActivityLog = async (
     };
     const response = await dynamoDocClient.send(new QueryCommand(command));
     return response.Items ? (response.Items[0] as ActivityLogEntry) : undefined;
-  } catch (error: unknown) {
-    console.error(
-      `Error querying activity log with user_id: ${userId} and event_id: ${eventId} Error message is: `,
-      (error as Error).message
-    );
+  } catch (error) {
     throw Error(
       `Error querying activity log with user_id: ${userId} 
       and timestamp_group_id: ${eventId} Error is: ${(error as Error).message}`
@@ -128,10 +124,6 @@ export const handler = async (
       );
     }
   } else {
-    console.error(
-      `No activity log exist in DB for with user_id : ${input.user_id} " +
-        and event id: ${input.event_id}`
-    );
     throw new Error(
       `No activity log exist in DB for with user_id : ${input.user_id} " +
         and event id: ${input.event_id}`

--- a/src/send-suspicious-activity.ts
+++ b/src/send-suspicious-activity.ts
@@ -118,9 +118,6 @@ export const handler = async (
     await sendAuditEvent(txMAEvent, TXMA_QUEUE_URL);
     console.log(`finished processing event with ID: ${input.event_id}`);
   } catch (err: unknown) {
-    console.error(
-      `Error occurred sending event to TxMA: ${(err as Error).message}`
-    );
     throw new Error(
       `Error occurred sending event to TxMA: ${(err as Error).message}`
     );

--- a/src/tests/delete-activity-log.test.ts
+++ b/src/tests/delete-activity-log.test.ts
@@ -163,22 +163,13 @@ describe("handler", () => {
   });
 
   describe("error handling", () => {
-    let consoleErrorMock: jest.SpyInstance;
-
     beforeEach(() => {
       sqsMock.reset();
-      consoleErrorMock = jest
-        .spyOn(global.console, "error")
-        .mockImplementation();
       sqsMock.on(SendMessageCommand).resolves({ MessageId: "MessageId" });
       dynamoMock.reset();
       dynamoMock.rejectsOnce("mock error");
       process.env.AWS_REGION = "AWS_REGION";
       process.env.TABLE_NAME = "TABLE_NAME";
-    });
-
-    afterEach(() => {
-      consoleErrorMock.mockRestore();
     });
 
     test("throws an error", async () => {

--- a/src/tests/delete-activity-log.test.ts
+++ b/src/tests/delete-activity-log.test.ts
@@ -130,7 +130,6 @@ describe("handler", () => {
       dynamoMock.reset();
       sqsMock.reset();
       process.env.TABLE_NAME = "TABLE_NAME";
-      process.env.DLQ_URL = "DLQ_URL";
       dynamoMock.on(QueryCommand).resolves({ Items: [activityLogEntry] });
     });
 
@@ -150,7 +149,6 @@ describe("handler", () => {
       dynamoMock.reset();
       sqsMock.reset();
       process.env.TABLE_NAME = "TABLE_NAME";
-      process.env.DLQ_URL = "DLQ_URL";
       dynamoMock.on(QueryCommand).resolves({ Items: [] });
     });
 
@@ -176,20 +174,21 @@ describe("handler", () => {
       dynamoMock.reset();
       dynamoMock.rejectsOnce("mock error");
       process.env.AWS_REGION = "AWS_REGION";
+      process.env.TABLE_NAME = "TABLE_NAME";
     });
 
     afterEach(() => {
       consoleErrorMock.mockRestore();
     });
 
-    test("logs the error message", async () => {
-      await handler(TEST_SNS_EVENT_WITH_TWO_RECORDS);
-      expect(consoleErrorMock).toHaveBeenCalledTimes(2);
-    });
-
-    test("sends the event to the dead letter queue", async () => {
-      await handler(TEST_SNS_EVENT_WITH_TWO_RECORDS);
-      expect(sqsMock.commandCalls(SendMessageCommand).length).toEqual(2);
+    test("throws an error", async () => {
+      let errorThrown = false;
+      try {
+        await handler(TEST_SNS_EVENT_WITH_TWO_RECORDS);
+      } catch (error) {
+        errorThrown = true;
+      }
+      expect(errorThrown).toBeTruthy();
     });
   });
 });

--- a/src/tests/delete-email-subscriptions.test.ts
+++ b/src/tests/delete-email-subscriptions.test.ts
@@ -9,7 +9,6 @@ describe("handler", () => {
   beforeEach(() => {
     jest.restoreAllMocks();
     process.env.AWS_REGION = "AWS_REGION";
-    process.env.DLQ_URL = "DLQ_URL";
   });
 
   afterEach(() => {

--- a/src/tests/send-suspicious-activity.test.ts
+++ b/src/tests/send-suspicious-activity.test.ts
@@ -291,17 +291,13 @@ describe("handler", () => {
 });
 
 describe("handler error handling", () => {
-  let consoleErrorMock: jest.SpyInstance;
   beforeEach(() => {
     sqsMock.reset();
     process.env.EVENT_NAME = "ANOTHER_EVENT_NAME";
-    process.env.DLQ_URL = "DLQ_URL";
-    consoleErrorMock = jest.spyOn(global.console, "error").mockImplementation();
     sqsMock.on(SendMessageCommand).resolves({ MessageId: "MessageId" });
   });
 
   afterEach(() => {
-    consoleErrorMock.mockRestore();
     jest.clearAllMocks();
   });
 
@@ -330,12 +326,16 @@ describe("handler error handling", () => {
       notify_message_id: "12345678",
     };
     let errorThrown = false;
+    let errorMessage = "";
     try {
       await handler(input);
     } catch (error) {
       errorThrown = true;
+      errorMessage = (error as Error).message;
     }
     expect(errorThrown).toBeTruthy();
-    expect(consoleErrorMock).toHaveBeenCalledTimes(1);
+    expect(errorMessage).toContain(
+      'Error occurred sending event to TxMA: Received Event: {"event_id":"522c5ab4-7e66-4b2a-8f5c-4d31dc4e93e6","event_type":"HOME_REPORT_SUSPICIOUS_ACTIVITY","persistent_session_id":"persistent_session_id","session_id":"session_id","email_address":"email","component_id":"https://home.account.gov.uk","timestamp":1708971886,"event_timestamp_ms":1708971886515,"event_timestamp_ms_formatted":"2024-02-26T18:24:46.515Z","timestamp_formatted":"2024-02-26T18:24:46.515Z","suspicious_activity":{"event_type":"TXMA_EVENT","session_id":"123456789","user_id":"qwerty","timestamp":123456789,"client_id":"gov-uk","event_id":"ab12345a-a12b-3ced-ef12-12a3b4cd5678","reported_suspicious":true},"zendesk_ticket_id":"12345677","notify_message_id":"12345678"'
+    );
   });
 });

--- a/src/tests/trigger-rsa-step.test.ts
+++ b/src/tests/trigger-rsa-step.test.ts
@@ -13,13 +13,10 @@ jest.mock("../common/call-async-step-function.ts");
 const sqsMock = mockClient(SQSClient);
 
 describe("handler", () => {
-  let consoleErrorMock: jest.SpyInstance;
   beforeEach(() => {
     jest.resetModules();
     process.env.STATE_MACHINE_ARN = "ReportSuspiciousActivityStepFunction";
-    process.env.DLQ_URL = "DLQ_URL";
     process.env.AWS_REGION = "AWS_REGION";
-    consoleErrorMock = jest.spyOn(global.console, "error").mockImplementation();
     (callAsyncStepFunction as jest.Mock).mockImplementation(() => {
       return {
         executionArn: "dummy-executionArn",
@@ -30,26 +27,23 @@ describe("handler", () => {
   });
 
   afterEach(() => {
-    consoleErrorMock.mockRestore();
     jest.clearAllMocks();
   });
 
   test("the handler triggers the report suspicious activity step function successfully", async () => {
     await handler(createSnsEvent(testSuspiciousActivity));
-    expect(consoleErrorMock).not.toHaveBeenCalled();
     expect(sqsMock.commandCalls(SendMessageCommand).length).toEqual(0);
   });
 
   test("the handler log and send message to SQS when error occurs", async () => {
-    await handler(createSnsEvent({}));
-    expect(consoleErrorMock).toHaveBeenCalledTimes(2);
-    expect(consoleErrorMock.mock.calls[0][0]).toContain(
-      "[Error occurred], trigger report suspicious activity step function:, Validation Failed - Required input to trigger report suspicious activity steps are not provided"
+    let errorMessage;
+    try {
+      await handler(createSnsEvent({}));
+    } catch (error) {
+      errorMessage = (error as Error).message;
+    }
+    expect(errorMessage).toContain(
+      "Unable to trigger rsa step for message with ID: MessageId, Validation Failed - Required input to trigger report suspicious activity steps are not provided"
     );
-    expect(sqsMock.commandCalls(SendMessageCommand).length).toEqual(1);
-    expect(sqsMock).toHaveReceivedNthCommandWith(1, SendMessageCommand, {
-      QueueUrl: "DLQ_URL",
-      MessageBody: JSON.stringify({}),
-    });
   });
 });

--- a/src/tests/write-user-services.test.ts
+++ b/src/tests/write-user-services.test.ts
@@ -26,7 +26,6 @@ describe("writeUserServices", () => {
     dynamoMock.reset();
 
     process.env.TABLE_NAME = "TABLE_NAME";
-    process.env.DLQ_URL = "DLQ_URL";
   });
 
   afterEach(() => {
@@ -44,7 +43,6 @@ describe("lambdaHandler", () => {
     dynamoMock.reset();
     sqsMock.reset();
     process.env.TABLE_NAME = "TABLE_NAME";
-    process.env.DLQ_URL = "DLQ_URL";
     process.env.AWS_REGION = "AWS_REGION";
   });
 
@@ -58,29 +56,22 @@ describe("lambdaHandler", () => {
   });
 
   describe("error handling", () => {
-    let consoleErrorMock: jest.SpyInstance;
-
     beforeEach(() => {
       sqsMock.reset();
       sqsMock.on(SendMessageCommand).resolves({ MessageId: "MessageId" });
-      consoleErrorMock = jest
-        .spyOn(global.console, "error")
-        .mockImplementation();
       dynamoMock.rejectsOnce("mock error");
     });
 
-    afterEach(() => {
-      consoleErrorMock.mockRestore();
-    });
-
     test("logs the error message", async () => {
-      await handler(TEST_SQS_EVENT_WITH_USER_SERVICES);
-      expect(consoleErrorMock).toHaveBeenCalledTimes(2);
-    });
-
-    test("sends the event to the dead letter queue", async () => {
-      await handler(TEST_SQS_EVENT_WITH_USER_SERVICES);
-      expect(sqsMock.commandCalls(SendMessageCommand).length).toEqual(1);
+      let errorMessage;
+      try {
+        await handler(TEST_SQS_EVENT_WITH_USER_SERVICES);
+      } catch (error) {
+        errorMessage = (error as Error).message;
+      }
+      expect(errorMessage).toContain(
+        "Unable to write user sercjces for message with ID: 19dd0b57-b21e-4ac1-bd88-01bbb068cb78, mock error"
+      );
     });
   });
 });

--- a/template.yaml
+++ b/template.yaml
@@ -767,7 +767,6 @@ Resources:
       Environment:
         Variables:
           TABLE_NAME: !Ref RawEventsStoreTableName
-          DLQ_URL: !Ref SaveRawEventsDeadLetterQueue
           NODE_OPTIONS: --enable-source-maps
       DeploymentPreference:
         Alarms:
@@ -998,7 +997,6 @@ Resources:
       Environment:
         Variables:
           TABLE_NAME: !Ref UserServicesStoreTableName
-          DLQ_URL: !Ref QueryUserServicesDeadLetterQueue
           OUTPUT_QUEUE_URL: !Ref UserServicesToFormatQueue
           NODE_OPTIONS: --enable-source-maps
       DeploymentPreference:
@@ -1256,7 +1254,6 @@ Resources:
       Role: !GetAtt FormatUserServicesRole.Arn
       Environment:
         Variables:
-          DLQ_URL: !Ref FormatUserServicesDeadLetterQueue
           OUTPUT_QUEUE_URL: !Ref UserServicesToWriteQueue
           NODE_OPTIONS: --enable-source-maps
       DeploymentPreference:
@@ -1497,7 +1494,6 @@ Resources:
       Environment:
         Variables:
           TABLE_NAME: !Ref UserServicesStoreTableName
-          DLQ_URL: !Ref WriteUserServicesDeadLetterQueue
           NODE_OPTIONS: --enable-source-maps
       DeploymentPreference:
         Alarms:
@@ -1820,7 +1816,6 @@ Resources:
       Environment:
         Variables:
           TABLE_NAME: !Ref UserServicesStoreTableName
-          DLQ_URL: !Ref DeleteUserServicesDeadLetterQueue
           NODE_OPTIONS: --enable-source-maps
       DeploymentPreference:
         Alarms:
@@ -2147,7 +2142,6 @@ Resources:
         TargetArn: !GetAtt DeleteEmailSubscriptionsDeadLetterQueue.Arn
       Environment:
         Variables:
-          DLQ_URL: !Ref DeleteEmailSubscriptionsDeadLetterQueue
           GOV_ACCOUNTS_PUBLISHING_API_TOKEN: !Sub "{{resolve:secretsmanager:/${AccountManagementFrontendStackName}/Config/Publishing/API/Key}}"
           GOV_ACCOUNTS_PUBLISHING_API_URL:
             !FindInMap [
@@ -2390,7 +2384,6 @@ Resources:
       Environment:
         Variables:
           TABLE_NAME: !Ref ActivityLogsStoreTableName
-          DLQ_URL: !Ref WriteActivityLogDeadLetterQueue
           GENERATOR_KEY_ARN: !GetAtt GeneratorKey.Arn
           WRAPPING_KEY_ARN: !GetAtt WrapperKey.Arn
           BACKUP_WRAPPING_KEY_ARN: !Sub "{{resolve:ssm:/${AWS::StackName}/${Environment}/Backup/KMS/WrappingKey/ARN}}"
@@ -2634,7 +2627,6 @@ Resources:
       Role: !GetAtt FormatActivityLogRole.Arn
       Environment:
         Variables:
-          DLQ_URL: !Ref FormatActivityLogDeadLetterQueue
           OUTPUT_QUEUE_URL: !Ref ActivityLogToWriteQueue
           ENVIRONMENT: !Ref Environment
           ACCOUNT_ID: !Sub "${AWS::AccountId}"
@@ -3924,7 +3916,6 @@ Resources:
         Variables:
           STATE_MACHINE_ARN: !Ref ReportSuspiciousActivityStepFunction
           STEP_FUNCTION_ALIAS: "latest"
-          DLQ_URL: !Ref TriggerSuspiciousActivityStepDeadLetterQueue
           NODE_OPTIONS: --enable-source-maps
       DeploymentPreference:
         Alarms:

--- a/template.yaml
+++ b/template.yaml
@@ -2957,7 +2957,6 @@ Resources:
       Environment:
         Variables:
           TABLE_NAME: !Ref ActivityLogsStoreTableName
-          DLQ_URL: !Ref DeleteActivityLogDeadLetterQueue
           NODE_OPTIONS: --enable-source-maps
       DeploymentPreference:
         Alarms:


### PR DESCRIPTION
## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->

[OLH-2025]: Reconfigure the backend lambda's so that they all throw error's in the event of failures

### What changed
<!-- Describe the changes in detail - the "what"-->
Within the handler of each lambda there is a try catch that explicitly throws an error.
Removed manual SQS queue push. 
NOTE: We recognise that this could cause batch processes to be duplicated.

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->
Missing errors from our lamba's as they didn't throw errors. 
This change works well with canary deployments which will allow for automatic roll backs by tracking the success rate alarms.

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

## Testing

<!-- Provide a summary of any manual testing you've done, for example deploying the branch to dev -->
Error raised in test
<img width="1612" alt="image" src="https://github.com/user-attachments/assets/bf302a6c-f854-4951-ad8c-2754f995856a">

Proof of two retries:
<img width="1427" alt="image" src="https://github.com/user-attachments/assets/c534802a-719e-41b8-af9b-d5f5f5a54b41">

Proof message was received by DLQ:
<img width="1615" alt="image" src="https://github.com/user-attachments/assets/3e389bb8-c4b4-48d2-8e77-a3493343dfa4">



## How to review
<!-- Describe any non-standard steps to review this work, or highlight any areas that you'd like the reviewer's opinion on -->


[OLH-2025]: https://govukverify.atlassian.net/browse/OLH-2025?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ