### PR TITLE
OLH-1321 - Performance testing: Throttling in several Lambda function

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -755,6 +755,7 @@ Resources:
         TargetArn: !GetAtt SaveRawEventsDeadLetterQueue.Arn
       Handler: save-raw-events.handler
       Role: !GetAtt SaveRawEventsRole.Arn
+      ReservedConcurrentExecutions: !Ref ProvisionedConcurrency
       ProvisionedConcurrencyConfig:
         ProvisionedConcurrentExecutions: !Ref ProvisionedConcurrency
       Environment:
@@ -2378,6 +2379,7 @@ Resources:
         TargetArn: !GetAtt WriteActivityLogDeadLetterQueue.Arn
       Handler: write-activity-log.handler
       Role: !GetAtt WriteActivityRecordRole.Arn
+      ReservedConcurrentExecutions: !Ref ProvisionedConcurrency
       ProvisionedConcurrencyConfig:
         ProvisionedConcurrentExecutions: !Ref ProvisionedConcurrency
       Environment:
@@ -2625,6 +2627,7 @@ Resources:
         TargetArn: !GetAtt FormatActivityLogDeadLetterQueue.Arn
       Handler: format-activity-log.handler
       Role: !GetAtt FormatActivityLogRole.Arn
+      ReservedConcurrentExecutions: !Ref ProvisionedConcurrency
       ProvisionedConcurrencyConfig:
         ProvisionedConcurrentExecutions: !Ref ProvisionedConcurrency
       Environment:

--- a/template.yaml
+++ b/template.yaml
@@ -69,6 +69,12 @@ Parameters:
     Description: Value for the System Tag
     Type: String
     Default: Accounts
+  ProvisionedConcurrency:
+    Type: Number
+    Default: 20
+    Description: "The number of provisioned concurrent executions for the Lambda function"
+    MinValue: 1
+    MaxValue: 100
 
 Conditions:
   UseCodeSigning:
@@ -749,6 +755,8 @@ Resources:
         TargetArn: !GetAtt SaveRawEventsDeadLetterQueue.Arn
       Handler: save-raw-events.handler
       Role: !GetAtt SaveRawEventsRole.Arn
+      ProvisionedConcurrencyConfig:
+        ProvisionedConcurrentExecutions: !Ref ProvisionedConcurrency
       Environment:
         Variables:
           TABLE_NAME: !Ref RawEventsStoreTableName
@@ -2370,6 +2378,8 @@ Resources:
         TargetArn: !GetAtt WriteActivityLogDeadLetterQueue.Arn
       Handler: write-activity-log.handler
       Role: !GetAtt WriteActivityRecordRole.Arn
+      ProvisionedConcurrencyConfig:
+        ProvisionedConcurrentExecutions: !Ref ProvisionedConcurrency
       Environment:
         Variables:
           TABLE_NAME: !Ref ActivityLogsStoreTableName
@@ -2615,6 +2625,8 @@ Resources:
         TargetArn: !GetAtt FormatActivityLogDeadLetterQueue.Arn
       Handler: format-activity-log.handler
       Role: !GetAtt FormatActivityLogRole.Arn
+      ProvisionedConcurrencyConfig:
+        ProvisionedConcurrentExecutions: !Ref ProvisionedConcurrency
       Environment:
         Variables:
           OUTPUT_QUEUE_URL: !Ref ActivityLogToWriteQueue


### PR DESCRIPTION
OLH-1321 - Performance testing: Throttling in several Lambda function during load tests

## Proposed changes
Add ProvisionedConcurrency to the identified Lambda so that a number of pre-initialized execution environments are allocated to the function. Reduces cold start latency and should stop the throttling.

### What changed

Update cloudformation template to configure provisioned concurrency

### Why did it change

So that cold start are reduced and consequently stops throttling in lamnbdas when under load.

### Related links


## Checklists

### Environment variables or secrets
- [ ] No environment variables or secrets were added or changed

### Permissions

## Testing

Deploy to dev environment
Run performance test
Check Cloudwatch metrics and confirm no throttling is happening under load.

## How to review
