### PR TITLE
OLH-2228 - Write a pre-merge test for a real use case of OLH

### DIFF
--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -1,6 +1,9 @@
-name: pre-merge check
+name: Pre Merge Check
 
 on:
+  push:
+    branches:
+      - OLH-2228
   workflow_call:
     inputs:
       gitRef:
@@ -8,36 +11,106 @@ on:
         type: string
         default: ${{ github.ref }}
   workflow_dispatch:
-  pull_request:
-    types: [opened, synchronize, reopened]
-  push:
-    branches:
-      - main
 
 permissions: read-all
 
 jobs:
-  deploy:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash
-        working-directory: pre-merge-integration-tests
-    timeout-minutes: 7
+  deploy-to-demo:
+    environment: Demo-test
     permissions:
-      id-token: write
       contents: read
+      id-token: write
+    name: "Deploy to Demo"
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Checkout repo
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # pin@v3
         with:
           fetch-depth: 0
 
+      - name: Verify merge queue source
+        run: |
+          echo "Commit message: ${{ github.event.head_commit.message }}"
+          if [[ "${{ github.event.head_commit.message }}" != *"Merge pull request"* ]]; then
+            echo "This was not a merge queue commit. Exiting."
+            exit 0
+          fi
+
+      - name: Fill in backup wrapping key
+        run: .github/workflows/find-and-replace-backup-wrapping-key.sh
+        env:
+          WRAPPING_KEY_ARN: ${{ secrets.WRAPPING_KEY_ARN }}
+
+      - name: Install Node.js
+        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # pin@v3
+        with:
+          node-version-file: ".nvmrc"
+
+      - name: Install ESbuild
+        run: npm install -g esbuild@0.23
+
+      - name: Set up Python 3.9
+        uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435 # pin@v4
+        with:
+          python-version: "3.9"
+
+      - name: Set up SAM cli
+        uses: aws-actions/setup-sam@b42eb7a54dac4039080975e32860b1b30935c9af # pin@v2
+
+      - name: sam fix https://github.com/aws/aws-sam-cli/issues/4527
+        run: $(dirname $(readlink $(which sam)))/pip install --force-reinstall "cryptography==38.0.4"
+
       - name: Set up AWS creds
         uses: aws-actions/configure-aws-credentials@e1e17a757e536f70e52b5a12b2e8d1d1c60e04ef # pin@v1-node16
         with:
-          role-to-assume: ${{ secrets.CloudFormationStackTestingGitHubActionsRole }}
+          role-to-assume: ${{ secrets.DEMO_GH_ACTIONS_ROLE_ARN }}
           aws-region: eu-west-2
+
+      - name: SAM validate
+        run: sam validate
+
+      - name: SAM build
+        run: sam build --manifest package.json
+
+      - name: Deploy SAM app
+        uses: govuk-one-login/devplatform-upload-action@dc8158079d3976d613515180e543930cdbe73f5f # pin@v3
+        with:
+          artifact-bucket-name: ${{ secrets.DEMO_ARTIFACT_BUCKET_NAME }}
+          signing-profile-name: ${{ secrets.DEMO_SIGNING_PROFILE_NAME }}
+          template-file: .aws-sam/build/template.yaml
+
+  check-stack-ready:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+        working-directory: ./pre-merge-integration-tests
+    timeout-minutes: 60
+    name: "Check stack is ready for pre-merge test"
+    permissions:
+      id-token: write
+      contents: read
+    needs: deploy-to-demo
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # pin@v3
+        with:
+          fetch-depth: 0
+
+      - name: Verify merge queue source
+        run: |
+          echo "Commit message: ${{ github.event.head_commit.message }}"
+          if [[ "${{ github.event.head_commit.message }}" != *"Merge pull request"* ]]; then
+            echo "This was not a merge queue commit. Exiting."
+            exit 0
+          fi
+
+      - name: Poll for deployment finished
+        uses: govuk-one-login/github-actions/sam/check-stack-updated@b00f9eeccebbc72083d8ffca4f0a2448fb14bda5
+        with:
+          stack-name: home-backend
+          gh-polling-role: ${{ secrets.DEMO_TESTING_ROLE_ARN }}
 
   test:
     runs-on: ubuntu-latest
@@ -46,10 +119,11 @@ jobs:
         shell: bash
         working-directory: ./pre-merge-integration-tests
     timeout-minutes: 60
+    name: "Run Pre Merge Test"
     permissions:
       id-token: write
       contents: read
-    needs: deploy
+    needs: check-stack-ready
     steps:
       - name: Checkout repo
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # pin@v3
@@ -66,8 +140,8 @@ jobs:
       - name: Set up AWS creds
         uses: aws-actions/configure-aws-credentials@e1e17a757e536f70e52b5a12b2e8d1d1c60e04ef # pin@v1-node16
         with:
-          role-to-assume: ${{ secrets.CloudFormationStackTestingGitHubActionsRole }}
+          role-to-assume: ${{ secrets.DEMO_TESTING_ROLE_ARN }}
           aws-region: eu-west-2
 
       - name: Run testing script
-        run: python3 $GITHUB_WORKSPACE/pre-merge-integration-tests/api_call.py
+        run: SQS_QUEUE_ARN=${{ secrets.RawEventsQueue }} python3 $GITHUB_WORKSPACE/pre-merge-integration-tests/api_call.py

--- a/.github/workflows/publish-to-demo.yaml
+++ b/.github/workflows/publish-to-demo.yaml
@@ -48,13 +48,6 @@ jobs:
     with:
       gitRef: ${{ inputs.gitRef }}
 
-  run_pre_merge:
-    name: Pre-merge Check
-    uses: ./.github/workflows/pre-merge.yaml
-    secrets: inherit
-    with:
-      gitRef: ${{ inputs.gitRef }}
-
   deploy_to_demo:
     environment: Demo-test
     permissions:

--- a/pre-merge-integration-tests/template.yaml
+++ b/pre-merge-integration-tests/template.yaml
@@ -14,7 +14,7 @@ Parameters:
       numbers and hyphens
 
 Outputs:
-  GitHubActionRoleArn:
+  GitHubActionTestingRoleArn:
     Description: "The resource used by GitHub Actions for testing cloudformation stack."
     Value: !Ref CloudFormationStackTestingGitHubActionsRole
     Export:
@@ -112,12 +112,23 @@ Resources:
       PolicyDocument:
         Version: "2012-10-17"
         Statement:
-          - Sid: "TestStackAPI"
-            Effect: "Allow"
+          - Sid: "TestStackSQSandDynamoDB"
+            Effect: Allow
             Action:
-              - "cloudformation:DescribeStackEvents"
+              - sqs:SendMessage
+              - dynamodb:Query
+              - dynamodb:GetItem
+              - dynamodb:DeleteItem
+              - dynamodb:PutItem
+              - cloudformation:DescribeStackEvents
+              - kms:Decrypt
+              - kms:GenerateDataKey*
+              - kms:ReEncrypt*
             Resource:
-              - !Sub 'arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/*'
+              - !Sub "arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:*"
+              - !Sub "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/*"
+              - !Sub "arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/*"
+              - !Sub "arn:${AWS::Partition}:kms:${AWS::Region}:${AWS::AccountId}:key/*"
 
   CloudFormationStackTestingGitHubActionsRole:
     Type: AWS::IAM::Role

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,6 +5,6 @@ sonar.projectVersion=1.0
 sonar.sources=.
 sonar.sourceEncoding=UTF-8
 
-sonar.exclusions=src/tests/*,scripts/*
+sonar.exclusions=src/tests/*,scripts/*,pre-merge-integration-tests/*
 
 sonar.javascript.lcov.reportPaths=./coverage/lcov.info

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,6 +5,6 @@ sonar.projectVersion=1.0
 sonar.sources=.
 sonar.sourceEncoding=UTF-8
 
-sonar.exclusions=src/tests/*,scripts/*,pre-merge-integration-tests/*
+sonar.exclusions=src/tests/*,scripts/*,pre-merge-integration-tests/api_call.py
 
 sonar.javascript.lcov.reportPaths=./coverage/lcov.info


### PR DESCRIPTION
## Proposed changes

OLH-2228 - Write a pre-merge test for a real use case of OLH

### What changed

Update Python script to include test for the writing an activity log and checking the activity log is recorded in dynamo.

### Why did it change

So that we get pre-merge testing to do real regression test against the one login home service

### Related links



## Checklists

### Environment variables or secrets
- [x] Added parameters to Cloudformation template
- [x] Added new secret or systems manager parameter
- [x] Added new environment variable

### Permissions

- [x] This PR adds or changes permissions

## Testing

Deploy to demo environment, trigger pre-merge testing and confirm it runs successfully

## How to review
