### PR TITLE
OLH-2292-rectify-metric-assigned-to-backend-lambda-write-activity-log-function-success-rate

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -2570,7 +2570,7 @@ Resources:
               MetricName: Errors
               Dimensions:
                 - Name: FunctionName
-                  Value: !Ref DeleteEmailSubscriptionsFunction
+                  Value: !Ref WriteActivityLogFunction
             Period: 300
             Stat: Sum
           ReturnData: false
@@ -2581,7 +2581,7 @@ Resources:
               MetricName: Invocations
               Dimensions:
                 - Name: FunctionName
-                  Value: !Ref DeleteEmailSubscriptionsFunction
+                  Value: !Ref WriteActivityLogFunction
             Period: 300
             Stat: Sum
           ReturnData: false


### PR DESCRIPTION
## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->
[OLH-2292] Rectify metric assigned to Write Activity Log Success Rate Alarm 

### What changed

<!-- Describe the changes in detail - the "what"-->
Alarm uses Write Activity Log function Metric's instead of another lambda's.

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->
Alarm was using another Lambda's metric's which meant it was going into an alarm state when it shouldn't have.

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

## Testing

<!-- Provide a summary of any manual testing you've done, for example deploying the branch to dev -->
Deployed to Dev

[OLH-2292]: https://govukverify.atlassian.net/browse/OLH-2292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ