### PR TITLE
OLH-2293 Add parameter to enable skip canary deployment

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -69,6 +69,13 @@ Parameters:
     Description: Value for the System Tag
     Type: String
     Default: Accounts
+  LambdaDeploymentPreference:
+    Description: "Specifies the configuration to enable gradual Lambda deployments"
+    Type: String
+    Default: "Linear10PercentEvery1Minute"
+    AllowedValues:
+      - AllAtOnce
+      - Linear10PercentEvery1Minute
 
 Conditions:
   UseCodeSigning:
@@ -114,10 +121,6 @@ Conditions:
       - Fn::Equals:
           - !Ref TestRoleArn
           - "none"
-
-  UseCanaryDeployment: !Or
-    - !Equals [!Ref Environment, production]
-    - !Equals [!Ref Environment, integration]
 
 Globals:
   Function:
@@ -196,12 +199,7 @@ Globals:
             ]
     AutoPublishAlias: live
     DeploymentPreference:
-      Enabled: true
-      Type:
-        Fn::If:
-          - UseCanaryDeployment
-          - Linear10PercentEvery1Minute
-          - AllAtOnce
+      Type: !Ref LambdaDeploymentPreference
       Role: !GetAtt CodeDeployServiceRole.Arn
 
 Mappings:


### PR DESCRIPTION
## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->
[OLH-2293] Add parameter to enable skip canary deployment

### What changed

<!-- Describe the changes in detail - the "what"-->
Addition of LambdaDeploymentPreference parameter which is required for skip canary deployment.

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->
To allow canary deployments to be skipped

## Testing

<!-- Provide a summary of any manual testing you've done, for example deploying the branch to dev -->
Deployed to Dev

[OLH-2293]: https://govukverify.atlassian.net/browse/OLH-2293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ