### PR TITLE
Olh 2296 create a re drive lambda to process events in delete email subscription dlq

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@aws-crypto/client-node": "^4.0.2",
         "@aws-lambda-powertools/parameters": "^2.10.0",
         "@aws-sdk/client-dynamodb": "^3.682.0",
+        "@aws-sdk/client-lambda": "^3.696.0",
         "@aws-sdk/client-secrets-manager": "^3.682.0",
         "@aws-sdk/client-sfn": "^3.682.0",
         "@aws-sdk/client-sqs": "^3.682.0",
@@ -102,6 +103,20 @@
         "@aws-crypto/raw-aes-keyring-node": "^4.0.1",
         "@aws-crypto/raw-rsa-keyring-node": "^4.0.1",
         "tslib": "^2.2.0"
+      }
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-crypto/decrypt-node": {
@@ -938,6 +953,554 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda": {
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.696.0.tgz",
+      "integrity": "sha512-c2qeAtvh+xdawTABZcAx5zXU/nqXXa1h+5fD0hEYKVF3hW6i2C6lHL3qlwlMFENbcEaZ0YtU965GBiDGsunvSg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.696.0",
+        "@aws-sdk/client-sts": "3.696.0",
+        "@aws-sdk/core": "3.696.0",
+        "@aws-sdk/credential-provider-node": "3.696.0",
+        "@aws-sdk/middleware-host-header": "3.696.0",
+        "@aws-sdk/middleware-logger": "3.696.0",
+        "@aws-sdk/middleware-recursion-detection": "3.696.0",
+        "@aws-sdk/middleware-user-agent": "3.696.0",
+        "@aws-sdk/region-config-resolver": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@aws-sdk/util-endpoints": "3.696.0",
+        "@aws-sdk/util-user-agent-browser": "3.696.0",
+        "@aws-sdk/util-user-agent-node": "3.696.0",
+        "@smithy/config-resolver": "^3.0.12",
+        "@smithy/core": "^2.5.3",
+        "@smithy/eventstream-serde-browser": "^3.0.13",
+        "@smithy/eventstream-serde-config-resolver": "^3.0.10",
+        "@smithy/eventstream-serde-node": "^3.0.12",
+        "@smithy/fetch-http-handler": "^4.1.1",
+        "@smithy/hash-node": "^3.0.10",
+        "@smithy/invalid-dependency": "^3.0.10",
+        "@smithy/middleware-content-length": "^3.0.12",
+        "@smithy/middleware-endpoint": "^3.2.3",
+        "@smithy/middleware-retry": "^3.0.27",
+        "@smithy/middleware-serde": "^3.0.10",
+        "@smithy/middleware-stack": "^3.0.10",
+        "@smithy/node-config-provider": "^3.1.11",
+        "@smithy/node-http-handler": "^3.3.1",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/smithy-client": "^3.4.4",
+        "@smithy/types": "^3.7.1",
+        "@smithy/url-parser": "^3.0.10",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.27",
+        "@smithy/util-defaults-mode-node": "^3.0.27",
+        "@smithy/util-endpoints": "^2.1.6",
+        "@smithy/util-middleware": "^3.0.10",
+        "@smithy/util-retry": "^3.0.10",
+        "@smithy/util-stream": "^3.3.1",
+        "@smithy/util-utf8": "^3.0.0",
+        "@smithy/util-waiter": "^3.1.9",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/client-sso": {
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.696.0.tgz",
+      "integrity": "sha512-q5TTkd08JS0DOkHfUL853tuArf7NrPeqoS5UOvqJho8ibV9Ak/a/HO4kNvy9Nj3cib/toHYHsQIEtecUPSUUrQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.696.0",
+        "@aws-sdk/middleware-host-header": "3.696.0",
+        "@aws-sdk/middleware-logger": "3.696.0",
+        "@aws-sdk/middleware-recursion-detection": "3.696.0",
+        "@aws-sdk/middleware-user-agent": "3.696.0",
+        "@aws-sdk/region-config-resolver": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@aws-sdk/util-endpoints": "3.696.0",
+        "@aws-sdk/util-user-agent-browser": "3.696.0",
+        "@aws-sdk/util-user-agent-node": "3.696.0",
+        "@smithy/config-resolver": "^3.0.12",
+        "@smithy/core": "^2.5.3",
+        "@smithy/fetch-http-handler": "^4.1.1",
+        "@smithy/hash-node": "^3.0.10",
+        "@smithy/invalid-dependency": "^3.0.10",
+        "@smithy/middleware-content-length": "^3.0.12",
+        "@smithy/middleware-endpoint": "^3.2.3",
+        "@smithy/middleware-retry": "^3.0.27",
+        "@smithy/middleware-serde": "^3.0.10",
+        "@smithy/middleware-stack": "^3.0.10",
+        "@smithy/node-config-provider": "^3.1.11",
+        "@smithy/node-http-handler": "^3.3.1",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/smithy-client": "^3.4.4",
+        "@smithy/types": "^3.7.1",
+        "@smithy/url-parser": "^3.0.10",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.27",
+        "@smithy/util-defaults-mode-node": "^3.0.27",
+        "@smithy/util-endpoints": "^2.1.6",
+        "@smithy/util-middleware": "^3.0.10",
+        "@smithy/util-retry": "^3.0.10",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.696.0.tgz",
+      "integrity": "sha512-ikxQ3mo86d1mAq5zTaQAh8rLBERwL+I4MUYu/IVYW2hhl9J2SDsl0SgnKeXQG6S8zWuHcBO587zsZaRta1MQ/g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.696.0",
+        "@aws-sdk/credential-provider-node": "3.696.0",
+        "@aws-sdk/middleware-host-header": "3.696.0",
+        "@aws-sdk/middleware-logger": "3.696.0",
+        "@aws-sdk/middleware-recursion-detection": "3.696.0",
+        "@aws-sdk/middleware-user-agent": "3.696.0",
+        "@aws-sdk/region-config-resolver": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@aws-sdk/util-endpoints": "3.696.0",
+        "@aws-sdk/util-user-agent-browser": "3.696.0",
+        "@aws-sdk/util-user-agent-node": "3.696.0",
+        "@smithy/config-resolver": "^3.0.12",
+        "@smithy/core": "^2.5.3",
+        "@smithy/fetch-http-handler": "^4.1.1",
+        "@smithy/hash-node": "^3.0.10",
+        "@smithy/invalid-dependency": "^3.0.10",
+        "@smithy/middleware-content-length": "^3.0.12",
+        "@smithy/middleware-endpoint": "^3.2.3",
+        "@smithy/middleware-retry": "^3.0.27",
+        "@smithy/middleware-serde": "^3.0.10",
+        "@smithy/middleware-stack": "^3.0.10",
+        "@smithy/node-config-provider": "^3.1.11",
+        "@smithy/node-http-handler": "^3.3.1",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/smithy-client": "^3.4.4",
+        "@smithy/types": "^3.7.1",
+        "@smithy/url-parser": "^3.0.10",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.27",
+        "@smithy/util-defaults-mode-node": "^3.0.27",
+        "@smithy/util-endpoints": "^2.1.6",
+        "@smithy/util-middleware": "^3.0.10",
+        "@smithy/util-retry": "^3.0.10",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.696.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/client-sts": {
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.696.0.tgz",
+      "integrity": "sha512-eJOxR8/UyI7kGSRyE751Ea7MKEzllQs7eNveDJy9OP4t/jsN/P19HJ1YHeA1np40JRTUBfqa6WLAAiIXsk8rkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.696.0",
+        "@aws-sdk/core": "3.696.0",
+        "@aws-sdk/credential-provider-node": "3.696.0",
+        "@aws-sdk/middleware-host-header": "3.696.0",
+        "@aws-sdk/middleware-logger": "3.696.0",
+        "@aws-sdk/middleware-recursion-detection": "3.696.0",
+        "@aws-sdk/middleware-user-agent": "3.696.0",
+        "@aws-sdk/region-config-resolver": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@aws-sdk/util-endpoints": "3.696.0",
+        "@aws-sdk/util-user-agent-browser": "3.696.0",
+        "@aws-sdk/util-user-agent-node": "3.696.0",
+        "@smithy/config-resolver": "^3.0.12",
+        "@smithy/core": "^2.5.3",
+        "@smithy/fetch-http-handler": "^4.1.1",
+        "@smithy/hash-node": "^3.0.10",
+        "@smithy/invalid-dependency": "^3.0.10",
+        "@smithy/middleware-content-length": "^3.0.12",
+        "@smithy/middleware-endpoint": "^3.2.3",
+        "@smithy/middleware-retry": "^3.0.27",
+        "@smithy/middleware-serde": "^3.0.10",
+        "@smithy/middleware-stack": "^3.0.10",
+        "@smithy/node-config-provider": "^3.1.11",
+        "@smithy/node-http-handler": "^3.3.1",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/smithy-client": "^3.4.4",
+        "@smithy/types": "^3.7.1",
+        "@smithy/url-parser": "^3.0.10",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.27",
+        "@smithy/util-defaults-mode-node": "^3.0.27",
+        "@smithy/util-endpoints": "^2.1.6",
+        "@smithy/util-middleware": "^3.0.10",
+        "@smithy/util-retry": "^3.0.10",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/core": {
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.696.0.tgz",
+      "integrity": "sha512-3c9III1k03DgvRZWg8vhVmfIXPG6hAciN9MzQTzqGngzWAELZF/WONRTRQuDFixVtarQatmLHYVw/atGeA2Byw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/core": "^2.5.3",
+        "@smithy/node-config-provider": "^3.1.11",
+        "@smithy/property-provider": "^3.1.9",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/signature-v4": "^4.2.2",
+        "@smithy/smithy-client": "^3.4.4",
+        "@smithy/types": "^3.7.1",
+        "@smithy/util-middleware": "^3.0.10",
+        "fast-xml-parser": "4.4.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.696.0.tgz",
+      "integrity": "sha512-T9iMFnJL7YTlESLpVFT3fg1Lkb1lD+oiaIC8KMpepb01gDUBIpj9+Y+pA/cgRWW0yRxmkDXNazAE2qQTVFGJzA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/property-provider": "^3.1.9",
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.696.0.tgz",
+      "integrity": "sha512-GV6EbvPi2eq1+WgY/o2RFA3P7HGmnkIzCNmhwtALFlqMroLYWKE7PSeHw66Uh1dFQeVESn0/+hiUNhu1mB0emA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/fetch-http-handler": "^4.1.1",
+        "@smithy/node-http-handler": "^3.3.1",
+        "@smithy/property-provider": "^3.1.9",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/smithy-client": "^3.4.4",
+        "@smithy/types": "^3.7.1",
+        "@smithy/util-stream": "^3.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.696.0.tgz",
+      "integrity": "sha512-9WsZZofjPjNAAZhIh7c7FOhLK8CR3RnGgUm1tdZzV6ZSM1BuS2m6rdwIilRxAh3fxxKDkmW/r/aYmmCYwA+AYA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.696.0",
+        "@aws-sdk/credential-provider-env": "3.696.0",
+        "@aws-sdk/credential-provider-http": "3.696.0",
+        "@aws-sdk/credential-provider-process": "3.696.0",
+        "@aws-sdk/credential-provider-sso": "3.696.0",
+        "@aws-sdk/credential-provider-web-identity": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/credential-provider-imds": "^3.2.6",
+        "@smithy/property-provider": "^3.1.9",
+        "@smithy/shared-ini-file-loader": "^3.1.10",
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.696.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.696.0.tgz",
+      "integrity": "sha512-8F6y5FcfRuMJouC5s207Ko1mcVvOXReBOlJmhIwE4QH1CnO/CliIyepnAZrRQ659mo5wIuquz6gXnpYbitEVMg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.696.0",
+        "@aws-sdk/credential-provider-http": "3.696.0",
+        "@aws-sdk/credential-provider-ini": "3.696.0",
+        "@aws-sdk/credential-provider-process": "3.696.0",
+        "@aws-sdk/credential-provider-sso": "3.696.0",
+        "@aws-sdk/credential-provider-web-identity": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/credential-provider-imds": "^3.2.6",
+        "@smithy/property-provider": "^3.1.9",
+        "@smithy/shared-ini-file-loader": "^3.1.10",
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.696.0.tgz",
+      "integrity": "sha512-mL1RcFDe9sfmyU5K1nuFkO8UiJXXxLX4JO1gVaDIOvPqwStpUAwi3A1BoeZhWZZNQsiKI810RnYGo0E0WB/hUA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/property-provider": "^3.1.9",
+        "@smithy/shared-ini-file-loader": "^3.1.10",
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.696.0.tgz",
+      "integrity": "sha512-4SSZ9Nk08JSu4/rX1a+dEac/Ims1HCXfV7YLUe5LGdtRLSKRoQQUy+hkFaGYoSugP/p1UfUPl3BuTO9Vv8z1pA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.696.0",
+        "@aws-sdk/core": "3.696.0",
+        "@aws-sdk/token-providers": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/property-provider": "^3.1.9",
+        "@smithy/shared-ini-file-loader": "^3.1.10",
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.696.0.tgz",
+      "integrity": "sha512-XJ/CVlWChM0VCoc259vWguFUjJDn/QwDqHwbx+K9cg3v6yrqXfK5ai+p/6lx0nQpnk4JzPVeYYxWRpaTsGC9rg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/property-provider": "^3.1.9",
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.696.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.696.0.tgz",
+      "integrity": "sha512-zELJp9Ta2zkX7ELggMN9qMCgekqZhFC5V2rOr4hJDEb/Tte7gpfKSObAnw/3AYiVqt36sjHKfdkoTsuwGdEoDg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.696.0.tgz",
+      "integrity": "sha512-KhkHt+8AjCxcR/5Zp3++YPJPpFQzxpr+jmONiT/Jw2yqnSngZ0Yspm5wGoRx2hS1HJbyZNuaOWEGuJoxLeBKfA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.696.0.tgz",
+      "integrity": "sha512-si/maV3Z0hH7qa99f9ru2xpS5HlfSVcasRlNUXKSDm611i7jFMWwGNLUOXFAOLhXotPX5G3Z6BLwL34oDeBMug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.696.0.tgz",
+      "integrity": "sha512-Lvyj8CTyxrHI6GHd2YVZKIRI5Fmnugt3cpJo0VrKKEgK5zMySwEZ1n4dqPK6czYRWKd5+WnYHYAuU+Wdk6Jsjw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@aws-sdk/util-endpoints": "3.696.0",
+        "@smithy/core": "^2.5.3",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.696.0.tgz",
+      "integrity": "sha512-7EuH142lBXjI8yH6dVS/CZeiK/WZsmb/8zP6bQbVYpMrppSTgB3MzZZdxVZGzL5r8zPQOU10wLC4kIMy0qdBVQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/node-config-provider": "^3.1.11",
+        "@smithy/types": "^3.7.1",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.10",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/token-providers": {
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.696.0.tgz",
+      "integrity": "sha512-fvTcMADrkwRdNwVmJXi2pSPf1iizmUqczrR1KusH4XehI/KybS4U6ViskRT0v07vpxwL7x+iaD/8fR0PUu5L/g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/property-provider": "^3.1.9",
+        "@smithy/shared-ini-file-loader": "^3.1.10",
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sso-oidc": "^3.696.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/types": {
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.696.0.tgz",
+      "integrity": "sha512-9rTvUJIAj5d3//U5FDPWGJ1nFJLuWb30vugGOrWk7aNZ6y9tuA3PI7Cc9dP8WEXKVyK1vuuk8rSFP2iqXnlgrw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.696.0.tgz",
+      "integrity": "sha512-T5s0IlBVX+gkb9g/I6CLt4yAZVzMSiGnbUqWihWsHvQR1WOoIcndQy/Oz/IJXT9T2ipoy7a80gzV6a5mglrioA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/types": "^3.7.1",
+        "@smithy/util-endpoints": "^2.1.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.696.0.tgz",
+      "integrity": "sha512-Z5rVNDdmPOe6ELoM5AhF/ja5tSjbe6ctSctDPb0JdDf4dT0v2MfwhJKzXju2RzX8Es/77Glh7MlaXLE0kCB9+Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/types": "^3.7.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.696.0.tgz",
+      "integrity": "sha512-KhKqcfyXIB0SCCt+qsu4eJjsfiOrNzK5dCV7RAW2YIpp+msxGUUX0NdRE9rkzjiv+3EMktgJm3eEIS+yxtlVdQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/node-config-provider": "^3.1.11",
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@smithy/fetch-http-handler": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-4.1.1.tgz",
+      "integrity": "sha512-bH7QW0+JdX0bPBadXt8GwMof/jz0H28I84hU1Uet9ISpzUqXqRQ3fEZJ+ANPOhzSEczYvANNl3uDQDYArSFDtA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/querystring-builder": "^3.0.10",
+        "@smithy/types": "^3.7.1",
+        "@smithy/util-base64": "^3.0.0",
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager": {
@@ -5794,11 +6357,12 @@
       "dev": true
     },
     "node_modules/@smithy/abort-controller": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.5.tgz",
-      "integrity": "sha512-DhNPnqTqPoG8aZ5dWkFOgsuY+i0GQ3CI6hMmvCoduNsnU9gUZWZBwGfDQsTTB7NvFPkom1df7jMIJWU90kuXXg==",
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.8.tgz",
+      "integrity": "sha512-+3DOBcUn5/rVjlxGvUPKc416SExarAQ+Qe0bqk30YSUjbepwpS7QN0cyKUSifvLJhdMZ0WPzPP5ymut0oonrpQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.5.0",
+        "@smithy/types": "^3.7.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5806,14 +6370,15 @@
       }
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.9.tgz",
-      "integrity": "sha512-5d9oBf40qC7n2xUoHmntKLdqsyTMMo/r49+eqSIjJ73eDfEtljAxEhzIQ3bkgXJtR3xiv7YzMT/3FF3ORkjWdg==",
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.12.tgz",
+      "integrity": "sha512-YAJP9UJFZRZ8N+UruTeq78zkdjUHmzsY62J4qKWZ4SXB4QXJ/+680EfXXgkYA2xj77ooMqtUY9m406zGNqwivQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^3.1.8",
-        "@smithy/types": "^3.5.0",
+        "@smithy/node-config-provider": "^3.1.11",
+        "@smithy/types": "^3.7.1",
         "@smithy/util-config-provider": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.7",
+        "@smithy/util-middleware": "^3.0.10",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5821,18 +6386,17 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "2.4.8",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.4.8.tgz",
-      "integrity": "sha512-x4qWk7p/a4dcf7Vxb2MODIf4OIcqNbK182WxRvZ/3oKPrf/6Fdic5sSElhO1UtXpWKBazWfqg0ZEK9xN1DsuHA==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.5.3.tgz",
+      "integrity": "sha512-96uW8maifUSmehaeW7uydWn7wBc98NEeNI3zN8vqakGpyCQgzyJaA64Z4FCOUmAdCJkhppd/7SZ798Fo4Xx37g==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/middleware-endpoint": "^3.1.4",
-        "@smithy/middleware-retry": "^3.0.23",
-        "@smithy/middleware-serde": "^3.0.7",
-        "@smithy/protocol-http": "^4.1.4",
-        "@smithy/smithy-client": "^3.4.0",
-        "@smithy/types": "^3.5.0",
+        "@smithy/middleware-serde": "^3.0.10",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/types": "^3.7.1",
         "@smithy/util-body-length-browser": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.7",
+        "@smithy/util-middleware": "^3.0.10",
+        "@smithy/util-stream": "^3.3.1",
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       },
@@ -5841,14 +6405,82 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.2.4.tgz",
-      "integrity": "sha512-S9bb0EIokfYEuar4kEbLta+ivlKCWOCFsLZuilkNy9i0uEUEHSi47IFLPaxqqCl+0ftKmcOTHayY5nQhAuq7+w==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.2.7.tgz",
+      "integrity": "sha512-cEfbau+rrWF8ylkmmVAObOmjbTIzKyUC5TkBL58SbLywD0RCBC4JAUKbmtSm2w5KUJNRPGgpGFMvE2FKnuNlWQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^3.1.8",
-        "@smithy/property-provider": "^3.1.7",
-        "@smithy/types": "^3.5.0",
-        "@smithy/url-parser": "^3.0.7",
+        "@smithy/node-config-provider": "^3.1.11",
+        "@smithy/property-provider": "^3.1.10",
+        "@smithy/types": "^3.7.1",
+        "@smithy/url-parser": "^3.0.10",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-codec": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-3.1.9.tgz",
+      "integrity": "sha512-F574nX0hhlNOjBnP+noLtsPFqXnWh2L0+nZKCwcu7P7J8k+k+rdIDs+RMnrMwrzhUE4mwMgyN0cYnEn0G8yrnQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^3.7.1",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-browser": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-3.0.13.tgz",
+      "integrity": "sha512-Nee9m+97o9Qj6/XeLz2g2vANS2SZgAxV4rDBMKGHvFJHU/xz88x2RwCkwsvEwYjSX4BV1NG1JXmxEaDUzZTAtw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^3.0.12",
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-config-resolver": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.0.10.tgz",
+      "integrity": "sha512-K1M0x7P7qbBUKB0UWIL5KOcyi6zqV5mPJoL0/o01HPJr0CSq3A9FYuJC6e11EX6hR8QTIR++DBiGrYveOu6trw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-node": {
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-3.0.12.tgz",
+      "integrity": "sha512-kiZymxXvZ4tnuYsPSMUHe+MMfc4FTeFWJIc0Q5wygJoUQM4rVHNghvd48y7ppuulNMbuYt95ah71pYc2+o4JOA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^3.0.12",
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-universal": {
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-3.0.12.tgz",
+      "integrity": "sha512-1i8ifhLJrOZ+pEifTlF0EfZzMLUGQggYQ6WmZ4d5g77zEKf7oZ0kvh1yKWHPjofvOwqrkwRDVuxuYC8wVd662A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-codec": "^3.1.9",
+        "@smithy/types": "^3.7.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5868,11 +6500,12 @@
       }
     },
     "node_modules/@smithy/hash-node": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.7.tgz",
-      "integrity": "sha512-SAGHN+QkrwcHFjfWzs/czX94ZEjPJ0CrWJS3M43WswDXVEuP4AVy9gJ3+AF6JQHZD13bojmuf/Ap/ItDeZ+Qfw==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.10.tgz",
+      "integrity": "sha512-3zWGWCHI+FlJ5WJwx73Mw2llYR8aflVyZN5JhoqLxbdPZi6UyKSdCeXAWJw9ja22m6S6Tzz1KZ+kAaSwvydi0g==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.5.0",
+        "@smithy/types": "^3.7.1",
         "@smithy/util-buffer-from": "^3.0.0",
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
@@ -5882,11 +6515,12 @@
       }
     },
     "node_modules/@smithy/invalid-dependency": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.7.tgz",
-      "integrity": "sha512-Bq00GsAhHeYSuZX8Kpu4sbI9agH2BNYnqUmmbTGWOhki9NVsWn2jFr896vvoTMH8KAjNX/ErC/8t5QHuEXG+IA==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.10.tgz",
+      "integrity": "sha512-Lp2L65vFi+cj0vFMu2obpPW69DU+6O5g3086lmI4XcnRCG8PxvpWC7XyaVwJCxsZFzueHjXnrOH/E0pl0zikfA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.5.0",
+        "@smithy/types": "^3.7.1",
         "tslib": "^2.6.2"
       }
     },
@@ -5912,12 +6546,13 @@
       }
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.9.tgz",
-      "integrity": "sha512-t97PidoGElF9hTtLCrof32wfWMqC5g2SEJNxaVH3NjlatuNGsdxXRYO/t+RPnxA15RpYiS0f+zG7FuE2DeGgjA==",
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.12.tgz",
+      "integrity": "sha512-1mDEXqzM20yywaMDuf5o9ue8OkJ373lSPbaSjyEvkWdqELhFMyNNgKGWL/rCSf4KME8B+HlHKuR8u9kRj8HzEQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^4.1.4",
-        "@smithy/types": "^3.5.0",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/types": "^3.7.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5925,16 +6560,18 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.1.4.tgz",
-      "integrity": "sha512-/ChcVHekAyzUbyPRI8CzPPLj6y8QRAfJngWcLMgsWxKVzw/RzBV69mSOzJYDD3pRwushA1+5tHtPF8fjmzBnrQ==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.2.3.tgz",
+      "integrity": "sha512-Hdl9296i/EMptaX7agrSzJZDiz5Y8XPUeBbctTmMtnCguGpqfU3jVsTUan0VLaOhsnquqWLL8Bl5HrlbVGT1og==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/middleware-serde": "^3.0.7",
-        "@smithy/node-config-provider": "^3.1.8",
-        "@smithy/shared-ini-file-loader": "^3.1.8",
-        "@smithy/types": "^3.5.0",
-        "@smithy/url-parser": "^3.0.7",
-        "@smithy/util-middleware": "^3.0.7",
+        "@smithy/core": "^2.5.3",
+        "@smithy/middleware-serde": "^3.0.10",
+        "@smithy/node-config-provider": "^3.1.11",
+        "@smithy/shared-ini-file-loader": "^3.1.11",
+        "@smithy/types": "^3.7.1",
+        "@smithy/url-parser": "^3.0.10",
+        "@smithy/util-middleware": "^3.0.10",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5942,17 +6579,18 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "3.0.23",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.23.tgz",
-      "integrity": "sha512-x9PbGXxkcXIpm6L26qRSCC+eaYcHwybRmqU8LO/WM2RRlW0g8lz6FIiKbKgGvHuoK3dLZRiQVSQJveiCzwnA5A==",
+      "version": "3.0.27",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.27.tgz",
+      "integrity": "sha512-H3J/PjJpLL7Tt+fxDKiOD25sMc94YetlQhCnYeNmina2LZscAdu0ZEZPas/kwePHABaEtqp7hqa5S4UJgMs1Tg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^3.1.8",
-        "@smithy/protocol-http": "^4.1.4",
-        "@smithy/service-error-classification": "^3.0.7",
-        "@smithy/smithy-client": "^3.4.0",
-        "@smithy/types": "^3.5.0",
-        "@smithy/util-middleware": "^3.0.7",
-        "@smithy/util-retry": "^3.0.7",
+        "@smithy/node-config-provider": "^3.1.11",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/service-error-classification": "^3.0.10",
+        "@smithy/smithy-client": "^3.4.4",
+        "@smithy/types": "^3.7.1",
+        "@smithy/util-middleware": "^3.0.10",
+        "@smithy/util-retry": "^3.0.10",
         "tslib": "^2.6.2",
         "uuid": "^9.0.1"
       },
@@ -5961,11 +6599,12 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.7.tgz",
-      "integrity": "sha512-VytaagsQqtH2OugzVTq4qvjkLNbWehHfGcGr0JLJmlDRrNCeZoWkWsSOw1nhS/4hyUUWF/TLGGml4X/OnEep5g==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.10.tgz",
+      "integrity": "sha512-MnAuhh+dD14F428ubSJuRnmRsfOpxSzvRhaGVTvd/lrUDE3kxzCCmH8lnVTvoNQnV2BbJ4c15QwZ3UdQBtFNZA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.5.0",
+        "@smithy/types": "^3.7.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5973,11 +6612,12 @@
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.7.tgz",
-      "integrity": "sha512-EyTbMCdqS1DoeQsO4gI7z2Gzq1MoRFAeS8GkFYIwbedB7Lp5zlLHJdg+56tllIIG5Hnf9ZWX48YKSHlsKvugGA==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.10.tgz",
+      "integrity": "sha512-grCHyoiARDBBGPyw2BeicpjgpsDFWZZxptbVKb3CRd/ZA15F/T6rZjCCuBUjJwdck1nwUuIxYtsS4H9DDpbP5w==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.5.0",
+        "@smithy/types": "^3.7.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5985,13 +6625,14 @@
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.8.tgz",
-      "integrity": "sha512-E0rU0DglpeJn5ge64mk8wTGEXcQwmpUTY5Zr7IzTpDLmHKiIamINERNZYrPQjg58Ck236sEKSwRSHA4CwshU6Q==",
+      "version": "3.1.11",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.11.tgz",
+      "integrity": "sha512-URq3gT3RpDikh/8MBJUB+QGZzfS7Bm6TQTqoh4CqE8NBuyPkWa5eUXj0XFcFfeZVgg3WMh1u19iaXn8FvvXxZw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^3.1.7",
-        "@smithy/shared-ini-file-loader": "^3.1.8",
-        "@smithy/types": "^3.5.0",
+        "@smithy/property-provider": "^3.1.10",
+        "@smithy/shared-ini-file-loader": "^3.1.11",
+        "@smithy/types": "^3.7.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5999,14 +6640,15 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.2.4.tgz",
-      "integrity": "sha512-49reY3+JgLMFNm7uTAKBWiKCA6XSvkNp9FqhVmusm2jpVnHORYFeFZ704LShtqWfjZW/nhX+7Iexyb6zQfXYIQ==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.3.1.tgz",
+      "integrity": "sha512-fr+UAOMGWh6bn4YSEezBCpJn9Ukp9oR4D32sCjCo7U81evE11YePOQ58ogzyfgmjIO79YeOdfXXqr0jyhPQeMg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^3.1.5",
-        "@smithy/protocol-http": "^4.1.4",
-        "@smithy/querystring-builder": "^3.0.7",
-        "@smithy/types": "^3.5.0",
+        "@smithy/abort-controller": "^3.1.8",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/querystring-builder": "^3.0.10",
+        "@smithy/types": "^3.7.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6014,11 +6656,12 @@
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.7.tgz",
-      "integrity": "sha512-QfzLi1GPMisY7bAM5hOUqBdGYnY5S2JAlr201pghksrQv139f8iiiMalXtjczIP5f6owxFn3MINLNUNvUkgtPw==",
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.10.tgz",
+      "integrity": "sha512-n1MJZGTorTH2DvyTVj+3wXnd4CzjJxyXeOgnTlgNVFxaaMeT4OteEp4QrzF8p9ee2yg42nvyVK6R/awLCakjeQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.5.0",
+        "@smithy/types": "^3.7.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6026,11 +6669,12 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.4.tgz",
-      "integrity": "sha512-MlWK8eqj0JlpZBnWmjQLqmFp71Ug00P+m72/1xQB3YByXD4zZ+y9N4hYrR0EDmrUCZIkyATWHOXFgtavwGDTzQ==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.7.tgz",
+      "integrity": "sha512-FP2LepWD0eJeOTm0SjssPcgqAlDFzOmRXqXmGhfIM52G7Lrox/pcpQf6RP4F21k0+O12zaqQt5fCDOeBtqY6Cg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.5.0",
+        "@smithy/types": "^3.7.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6038,11 +6682,12 @@
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.7.tgz",
-      "integrity": "sha512-65RXGZZ20rzqqxTsChdqSpbhA6tdt5IFNgG6o7e1lnPVLCe6TNWQq4rTl4N87hTDD8mV4IxJJnvyE7brbnRkQw==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.10.tgz",
+      "integrity": "sha512-nT9CQF3EIJtIUepXQuBFb8dxJi3WVZS3XfuDksxSCSn+/CzZowRLdhDn+2acbBv8R6eaJqPupoI/aRFIImNVPQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.5.0",
+        "@smithy/types": "^3.7.1",
         "@smithy/util-uri-escape": "^3.0.0",
         "tslib": "^2.6.2"
       },
@@ -6051,11 +6696,12 @@
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.7.tgz",
-      "integrity": "sha512-Fouw4KJVWqqUVIu1gZW8BH2HakwLz6dvdrAhXeXfeymOBrZw+hcqaWs+cS1AZPVp4nlbeIujYrKA921ZW2WMPA==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.10.tgz",
+      "integrity": "sha512-Oa0XDcpo9SmjhiDD9ua2UyM3uU01ZTuIrNdZvzwUTykW1PM8o2yJvMh1Do1rY5sUQg4NDV70dMi0JhDx4GyxuQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.5.0",
+        "@smithy/types": "^3.7.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6063,22 +6709,24 @@
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.7.tgz",
-      "integrity": "sha512-91PRkTfiBf9hxkIchhRKJfl1rsplRDyBnmyFca3y0Z3x/q0JJN480S83LBd8R6sBCkm2bBbqw2FHp0Mbh+ecSA==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.10.tgz",
+      "integrity": "sha512-zHe642KCqDxXLuhs6xmHVgRwy078RfqxP2wRDpIyiF8EmsWXptMwnMwbVa50lw+WOGNrYm9zbaEg0oDe3PTtvQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.5.0"
+        "@smithy/types": "^3.7.1"
       },
       "engines": {
         "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.8.tgz",
-      "integrity": "sha512-0NHdQiSkeGl0ICQKcJQ2lCOKH23Nb0EaAa7RDRId6ZqwXkw4LJyIyZ0t3iusD4bnKYDPLGy2/5e2rfUhrt0Acw==",
+      "version": "3.1.11",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.11.tgz",
+      "integrity": "sha512-AUdrIZHFtUgmfSN4Gq9nHu3IkHMa1YDcN+s061Nfm+6pQ0mJy85YQDB0tZBCmls0Vuj22pLwDPmL92+Hvfwwlg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.5.0",
+        "@smithy/types": "^3.7.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6086,15 +6734,16 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.2.0.tgz",
-      "integrity": "sha512-LafbclHNKnsorMgUkKm7Tk7oJ7xizsZ1VwqhGKqoCIrXh4fqDDp73fK99HOEEgcsQbtemmeY/BPv0vTVYYUNEQ==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.2.3.tgz",
+      "integrity": "sha512-pPSQQ2v2vu9vc8iew7sszLd0O09I5TRc5zhY71KA+Ao0xYazIG+uLeHbTJfIWGO3BGVLiXjUr3EEeCcEQLjpWQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/is-array-buffer": "^3.0.0",
-        "@smithy/protocol-http": "^4.1.4",
-        "@smithy/types": "^3.5.0",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/types": "^3.7.1",
         "@smithy/util-hex-encoding": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.7",
+        "@smithy/util-middleware": "^3.0.10",
         "@smithy/util-uri-escape": "^3.0.0",
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
@@ -6104,15 +6753,17 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.4.0.tgz",
-      "integrity": "sha512-nOfJ1nVQsxiP6srKt43r2My0Gp5PLWCW2ASqUioxIiGmu6d32v4Nekidiv5qOmmtzIrmaD+ADX5SKHUuhReeBQ==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.4.4.tgz",
+      "integrity": "sha512-dPGoJuSZqvirBq+yROapBcHHvFjChoAQT8YPWJ820aPHHiowBlB3RL1Q4kPT1hx0qKgJuf+HhyzKi5Gbof4fNA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/middleware-endpoint": "^3.1.4",
-        "@smithy/middleware-stack": "^3.0.7",
-        "@smithy/protocol-http": "^4.1.4",
-        "@smithy/types": "^3.5.0",
-        "@smithy/util-stream": "^3.1.9",
+        "@smithy/core": "^2.5.3",
+        "@smithy/middleware-endpoint": "^3.2.3",
+        "@smithy/middleware-stack": "^3.0.10",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/types": "^3.7.1",
+        "@smithy/util-stream": "^3.3.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6120,9 +6771,10 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.5.0.tgz",
-      "integrity": "sha512-QN0twHNfe8mNJdH9unwsCK13GURU7oEAZqkBI+rsvpv1jrmserO+WnLE7jidR9W/1dxwZ0u/CB01mV2Gms/K2Q==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.7.1.tgz",
+      "integrity": "sha512-XKLcLXZY7sUQgvvWyeaL/qwNPp6V3dWcUjqrQKjSb+tzYiCy340R/c64LV5j+Tnb2GhmunEX0eou+L+m2hJNYA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -6131,12 +6783,13 @@
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.7.tgz",
-      "integrity": "sha512-70UbSSR8J97c1rHZOWhl+VKiZDqHWxs/iW8ZHrHp5fCCPLSBE7GcUlUvKSle3Ca+J9LLbYCj/A79BxztBvAfpA==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.10.tgz",
+      "integrity": "sha512-j90NUalTSBR2NaZTuruEgavSdh8MLirf58LoGSk4AtQfyIymogIhgnGUU2Mga2bkMkpSoC9gxb74xBXL5afKAQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/querystring-parser": "^3.0.7",
-        "@smithy/types": "^3.5.0",
+        "@smithy/querystring-parser": "^3.0.10",
+        "@smithy/types": "^3.7.1",
         "tslib": "^2.6.2"
       }
     },
@@ -6196,13 +6849,14 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "3.0.23",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.23.tgz",
-      "integrity": "sha512-Y07qslyRtXDP/C5aWKqxTPBl4YxplEELG3xRrz2dnAQ6Lq/FgNrcKWmV561nNaZmFH+EzeGOX3ZRMbU8p1T6Nw==",
+      "version": "3.0.27",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.27.tgz",
+      "integrity": "sha512-GV8NvPy1vAGp7u5iD/xNKUxCorE4nQzlyl057qRac+KwpH5zq8wVq6rE3lPPeuFLyQXofPN6JwxL1N9ojGapiQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^3.1.7",
-        "@smithy/smithy-client": "^3.4.0",
-        "@smithy/types": "^3.5.0",
+        "@smithy/property-provider": "^3.1.10",
+        "@smithy/smithy-client": "^3.4.4",
+        "@smithy/types": "^3.7.1",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
@@ -6211,16 +6865,17 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "3.0.23",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.23.tgz",
-      "integrity": "sha512-9Y4WH7f0vnDGuHUa4lGX9e2p+sMwODibsceSV6rfkZOvMC+BY3StB2LdO1NHafpsyHJLpwAgChxQ38tFyd6vkg==",
+      "version": "3.0.27",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.27.tgz",
+      "integrity": "sha512-7+4wjWfZqZxZVJvDutO+i1GvL6bgOajEkop4FuR6wudFlqBiqwxw3HoH6M9NgeCd37km8ga8NPp2JacQEtAMPg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/config-resolver": "^3.0.9",
-        "@smithy/credential-provider-imds": "^3.2.4",
-        "@smithy/node-config-provider": "^3.1.8",
-        "@smithy/property-provider": "^3.1.7",
-        "@smithy/smithy-client": "^3.4.0",
-        "@smithy/types": "^3.5.0",
+        "@smithy/config-resolver": "^3.0.12",
+        "@smithy/credential-provider-imds": "^3.2.7",
+        "@smithy/node-config-provider": "^3.1.11",
+        "@smithy/property-provider": "^3.1.10",
+        "@smithy/smithy-client": "^3.4.4",
+        "@smithy/types": "^3.7.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6228,12 +6883,13 @@
       }
     },
     "node_modules/@smithy/util-endpoints": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.1.3.tgz",
-      "integrity": "sha512-34eACeKov6jZdHqS5hxBMJ4KyWKztTMulhuQ2UdOoP6vVxMLrOKUqIXAwJe/wiWMhXhydLW664B02CNpQBQ4Aw==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.1.6.tgz",
+      "integrity": "sha512-mFV1t3ndBh0yZOJgWxO9J/4cHZVn5UG1D8DeCc6/echfNkeEJWu9LD7mgGH5fHrEdR7LDoWw7PQO6QiGpHXhgA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^3.1.8",
-        "@smithy/types": "^3.5.0",
+        "@smithy/node-config-provider": "^3.1.11",
+        "@smithy/types": "^3.7.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6252,11 +6908,12 @@
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.7.tgz",
-      "integrity": "sha512-OVA6fv/3o7TMJTpTgOi1H5OTwnuUa8hzRzhSFDtZyNxi6OZ70L/FHattSmhE212I7b6WSOJAAmbYnvcjTHOJCA==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.10.tgz",
+      "integrity": "sha512-eJO+/+RsrG2RpmY68jZdwQtnfsxjmPxzMlQpnHKjFPwrYqvlcT+fHdT+ZVwcjlWSrByOhGr9Ff2GG17efc192A==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.5.0",
+        "@smithy/types": "^3.7.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6264,12 +6921,13 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.7.tgz",
-      "integrity": "sha512-nh1ZO1vTeo2YX1plFPSe/OXaHkLAHza5jpokNiiKX2M5YpNUv6RxGJZhpfmiR4jSvVHCjIDmILjrxKmP+/Ghug==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.10.tgz",
+      "integrity": "sha512-1l4qatFp4PiU6j7UsbasUHL2VU023NRB/gfaa1M0rDqVrRN4g3mCArLRyH3OuktApA4ye+yjWQHjdziunw2eWA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/service-error-classification": "^3.0.7",
-        "@smithy/types": "^3.5.0",
+        "@smithy/service-error-classification": "^3.0.10",
+        "@smithy/types": "^3.7.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6277,13 +6935,14 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "3.1.9",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.1.9.tgz",
-      "integrity": "sha512-7YAR0Ub3MwTMjDfjnup4qa6W8gygZMxikBhFMPESi6ASsl/rZJhwLpF/0k9TuezScCojsM0FryGdz4LZtjKPPQ==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.3.1.tgz",
+      "integrity": "sha512-Ff68R5lJh2zj+AUTvbAU/4yx+6QPRzg7+pI7M1FbtQHcRIp7xvguxVsQBKyB3fwiOwhAKu0lnNyYBaQfSW6TNw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^3.2.9",
-        "@smithy/node-http-handler": "^3.2.4",
-        "@smithy/types": "^3.5.0",
+        "@smithy/fetch-http-handler": "^4.1.1",
+        "@smithy/node-http-handler": "^3.3.1",
+        "@smithy/types": "^3.7.1",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-buffer-from": "^3.0.0",
         "@smithy/util-hex-encoding": "^3.0.0",
@@ -6292,6 +6951,19 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream/node_modules/@smithy/fetch-http-handler": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-4.1.1.tgz",
+      "integrity": "sha512-bH7QW0+JdX0bPBadXt8GwMof/jz0H28I84hU1Uet9ISpzUqXqRQ3fEZJ+ANPOhzSEczYvANNl3uDQDYArSFDtA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/querystring-builder": "^3.0.10",
+        "@smithy/types": "^3.7.1",
+        "@smithy/util-base64": "^3.0.0",
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@smithy/util-uri-escape": {
@@ -6318,12 +6990,13 @@
       }
     },
     "node_modules/@smithy/util-waiter": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-3.1.6.tgz",
-      "integrity": "sha512-xs/KAwWOeCklq8aMlnpk25LgxEYHKOEodfjfKclDMLcBJEVEKzDLxZxBQyztcuPJ7F54213NJS8PxoiHNMdItQ==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-3.1.9.tgz",
+      "integrity": "sha512-/aMXPANhMOlMPjfPtSrDfPeVP8l56SJlz93xeiLmhLe5xvlXA5T3abZ2ilEsDEPeY9T/wnN/vNGn9wa1SbufWA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^3.1.5",
-        "@smithy/types": "^3.5.0",
+        "@smithy/abort-controller": "^3.1.8",
+        "@smithy/types": "^3.7.1",
         "tslib": "^2.6.2"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@aws-crypto/client-node": "^4.0.2",
     "@aws-lambda-powertools/parameters": "^2.10.0",
     "@aws-sdk/client-dynamodb": "^3.682.0",
+    "@aws-sdk/client-lambda": "^3.696.0",
     "@aws-sdk/client-secrets-manager": "^3.682.0",
     "@aws-sdk/client-sfn": "^3.682.0",
     "@aws-sdk/client-sqs": "^3.682.0",

--- a/src/redrive-delete-email-subscriptions.ts
+++ b/src/redrive-delete-email-subscriptions.ts
@@ -1,10 +1,22 @@
-import { SQSEvent } from "aws-lambda";
+import { SNSEvent, SQSEvent, SQSRecord } from "aws-lambda";
 import { InvokeCommand, LambdaClient } from "@aws-sdk/client-lambda";
+import { UserData } from "./common/model";
 
-const lambdaClient = new LambdaClient();
+export const lambdaClient = new LambdaClient();
+
+const logIdentifiers = (record: SQSRecord): void => {
+  const parsedBody: SNSEvent = JSON.parse(record.body);
+  for (const snsRecord of parsedBody.Records) {
+    const userData: UserData = JSON.parse(snsRecord.Sns.Message);
+    console.log(
+      `Redriving message with publicSubjectId: ${userData.public_subject_id}, legacySubjectId: ${userData.legacy_subject_id}`
+    );
+  }
+};
 
 export const handler = async (event: SQSEvent): Promise<void> => {
   for (const record of event.Records) {
+    logIdentifiers(record);
     const command = new InvokeCommand({
       FunctionName: process.env.DELETE_EMAIL_SUBSCRIPTIONS_LAMBDA_ALIAS,
       Payload: record.body,

--- a/src/redrive-delete-email-subscriptions.ts
+++ b/src/redrive-delete-email-subscriptions.ts
@@ -1,0 +1,20 @@
+import { SQSEvent } from "aws-lambda";
+import { InvokeCommand, LambdaClient } from "@aws-sdk/client-lambda";
+
+const lambdaClient = new LambdaClient();
+
+export const handler = async (event: SQSEvent): Promise<void> => {
+  for (const record of event.Records) {
+    const command = new InvokeCommand({
+      FunctionName: process.env.DELETE_EMAIL_SUBSCRIPTIONS_LAMBDA_ALIAS,
+      Payload: record.body,
+    });
+    const response = await lambdaClient.send(command);
+    if (
+      response.StatusCode &&
+      (response.StatusCode > 299 || response.StatusCode < 200)
+    ) {
+      throw new Error("Redrive failed");
+    }
+  }
+};

--- a/src/tests/redrive-delete-email-subscriptions.test.ts
+++ b/src/tests/redrive-delete-email-subscriptions.test.ts
@@ -1,0 +1,84 @@
+import { mockClient } from "aws-sdk-client-mock";
+import { handler, lambdaClient } from "../redrive-delete-email-subscriptions";
+import { SNSEvent, SQSMessageAttributes } from "aws-lambda";
+import { SQSRecordAttributes } from "aws-lambda/trigger/sqs";
+import { UserData } from "../common/model";
+import { InvokeCommand } from "@aws-sdk/client-lambda";
+import "aws-sdk-client-mock-jest";
+
+describe("handler", () => {
+  const mockLambdaClient = mockClient(lambdaClient);
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("that it successfully redrives the message", async () => {
+    mockLambdaClient.on(InvokeCommand).resolves({
+      StatusCode: 200,
+    });
+    const spyConsoleLog = jest.spyOn(global.console, "log");
+    const userData: UserData = {
+      user_id: "1",
+      public_subject_id: "public",
+      legacy_subject_id: "legacy",
+    };
+    const snsEvent = buildSnsEvent(userData);
+    const sqsInput = buildSqsEvent(snsEvent);
+    await handler(sqsInput);
+
+    expect(spyConsoleLog).toHaveBeenCalledWith(
+      "Redriving message with publicSubjectId: public, legacySubjectId: legacy"
+    );
+    expect(mockLambdaClient).toHaveReceivedCommandWith(InvokeCommand, {
+      Payload: JSON.stringify(snsEvent),
+    });
+  });
+});
+
+function buildSnsEvent(userData: UserData): SNSEvent {
+  return {
+    Records: [
+      {
+        EventSource: "aws:sns",
+        EventVersion: "1.0",
+        EventSubscriptionArn: "",
+        Sns: {
+          Type: "",
+          MessageId: "",
+          TopicArn: "",
+          Subject: "",
+          Message: JSON.stringify(userData),
+          Timestamp: "",
+          SignatureVersion: "1",
+          Signature: "",
+          SigningCertUrl: "",
+          UnsubscribeUrl: "",
+          MessageAttributes: {},
+        },
+      },
+    ],
+  };
+}
+
+function buildSqsEvent(snsEvent: SNSEvent) {
+  return {
+    Records: [
+      {
+        messageId: "1",
+        receiptHandle: "handle",
+        body: JSON.stringify(snsEvent),
+        attributes: {} as unknown as SQSRecordAttributes,
+        messageAttributes: {} as unknown as SQSMessageAttributes,
+        md5OfBody: "",
+        eventSource: "",
+        eventSourceARN: "",
+        awsRegion: "",
+      },
+    ],
+  };
+}

--- a/template.yaml
+++ b/template.yaml
@@ -2252,6 +2252,47 @@ Resources:
       FilterPattern: ""
       LogGroupName: !Ref DeleteEmailSubscriptionsFunctionLogGroup
 
+  RedriveDeleteEmailSubscriptionsFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Sub ${Environment}-${AWS::StackName}-redrive-delete-email-subscriptions
+      CodeUri: src
+      PackageType: Zip
+      Handler: redrive-delete-email-subscriptions.handler
+      Timeout: 30
+      Policies:
+        LambdaInvokePolicy:
+          FunctionName: !Ref DeleteEmailSubscriptionsFunction.Alias
+        SQSPollerPolicy:
+          QueueName: !GetAtt DeleteEmailSubscriptionsDeadLetterQueue.QueueName
+        KMSDecryptPolicy:
+          KeyId: !Ref QueueKmsKey
+      Environment:
+        Variables:
+          DELETE_EMAIL_SUBSCRIPTIONS_LAMBDA_ALIAS: !Ref DeleteEmailSubscriptionsFunction.Alias
+          NODE_OPTIONS: --enable-source-maps
+    Metadata:
+      BuildMethod: esbuild
+      BuildProperties:
+        Minify: true
+        Format: "esm"
+        OutExtension:
+          - .js=.mjs
+        Target: "es2020"
+        Sourcemap: true
+        EntryPoints:
+          - delete-email-subscriptions.ts
+        Banner:
+          - js=import { createRequire } from 'module'; const require = createRequire(import.meta.url);
+
+  RedriveDeleteEmailSubscriptionEventSourceMapping:
+    Type: AWS::Lambda::EventSourceMapping
+    Properties:
+      Enabled: true
+      BatchSize: 1
+      EventSourceArn: !GetAtt DeleteEmailSubscriptionsDeadLetterQueue.Arn
+      FunctionName: !Ref RedriveDeleteEmailSubscriptionsFunction
+
   ActivityLogToFormatQueue:
     Type: AWS::SQS::Queue
     Properties:

--- a/template.yaml
+++ b/template.yaml
@@ -2252,47 +2252,6 @@ Resources:
       FilterPattern: ""
       LogGroupName: !Ref DeleteEmailSubscriptionsFunctionLogGroup
 
-  RedriveDeleteEmailSubscriptionsFunction:
-    Type: AWS::Serverless::Function
-    Properties:
-      FunctionName: !Sub ${Environment}-${AWS::StackName}-redrive-delete-email-subscriptions
-      CodeUri: src
-      PackageType: Zip
-      Handler: redrive-delete-email-subscriptions.handler
-      Timeout: 30
-      Policies:
-        LambdaInvokePolicy:
-          FunctionName: !Ref DeleteEmailSubscriptionsFunction.Alias
-        SQSPollerPolicy:
-          QueueName: !GetAtt DeleteEmailSubscriptionsDeadLetterQueue.QueueName
-        KMSDecryptPolicy:
-          KeyId: !Ref QueueKmsKey
-      Environment:
-        Variables:
-          DELETE_EMAIL_SUBSCRIPTIONS_LAMBDA_ALIAS: !Ref DeleteEmailSubscriptionsFunction.Alias
-          NODE_OPTIONS: --enable-source-maps
-    Metadata:
-      BuildMethod: esbuild
-      BuildProperties:
-        Minify: true
-        Format: "esm"
-        OutExtension:
-          - .js=.mjs
-        Target: "es2020"
-        Sourcemap: true
-        EntryPoints:
-          - delete-email-subscriptions.ts
-        Banner:
-          - js=import { createRequire } from 'module'; const require = createRequire(import.meta.url);
-
-  RedriveDeleteEmailSubscriptionEventSourceMapping:
-    Type: AWS::Lambda::EventSourceMapping
-    Properties:
-      Enabled: true
-      BatchSize: 1
-      EventSourceArn: !GetAtt DeleteEmailSubscriptionsDeadLetterQueue.Arn
-      FunctionName: !Ref RedriveDeleteEmailSubscriptionsFunction
-
   ActivityLogToFormatQueue:
     Type: AWS::SQS::Queue
     Properties:
@@ -2419,6 +2378,51 @@ Resources:
       EvaluationPeriods: 1
       AlarmActions:
         - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/LowAlertNotificationTopic/ARN}}"
+
+  ###########################################
+  # Redrive Delete Email Subscriptions
+  ###########################################
+
+  RedriveDeleteEmailSubscriptionsFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Sub ${Environment}-${AWS::StackName}-redrive-delete-email-subscriptions
+      CodeUri: src
+      PackageType: Zip
+      Handler: redrive-delete-email-subscriptions.handler
+      Timeout: 30
+      Policies:
+        - LambdaInvokePolicy:
+            FunctionName: !Sub ${Environment}-${AWS::StackName}-delete-email-subscriptions:live
+        - SQSPollerPolicy:
+            QueueName: !GetAtt DeleteEmailSubscriptionsDeadLetterQueue.QueueName
+        - KMSDecryptPolicy:
+            KeyId: !Ref QueueKmsKey
+      Environment:
+        Variables:
+          DELETE_EMAIL_SUBSCRIPTIONS_LAMBDA_ALIAS: !Ref DeleteEmailSubscriptionsFunction.Alias
+          NODE_OPTIONS: --enable-source-maps
+    Metadata:
+      BuildMethod: esbuild
+      BuildProperties:
+        Minify: true
+        Format: "esm"
+        OutExtension:
+          - .js=.mjs
+        Target: "es2020"
+        Sourcemap: true
+        EntryPoints:
+          - redrive-delete-email-subscriptions.ts
+        Banner:
+          - js=import { createRequire } from 'module'; const require = createRequire(import.meta.url);
+
+  RedriveDeleteEmailSubscriptionEventSourceMapping:
+    Type: AWS::Lambda::EventSourceMapping
+    Properties:
+      Enabled: true
+      BatchSize: 1
+      EventSourceArn: !GetAtt DeleteEmailSubscriptionsDeadLetterQueue.Arn
+      FunctionName: !Ref RedriveDeleteEmailSubscriptionsFunction
 
   ###################
   # Write Activity Log


### PR DESCRIPTION
## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->
[OLH-2296] Implement a lambda to redrive event's in DLQ for the delete email subscription lambda

### What changed
<!-- Describe the changes in detail - the "what"-->
Implemented a lambda that takes SQS from the delete email subscription lambda DLQ and send's them as an SNS event to the delete email subscription lambda.

### Why did it change
<!-- Describe the reason these changes were made - the "why" -->
290 failed events are in the DLQ in production and cannot be processed through AWS.

## Checklists

<!-- Merging this PR deploys to production. Please answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Permissions

- [x] This PR adds or changes permissions

## Testing

<!-- Provide a summary of any manual testing you've done, for example deploying the branch to dev -->
Deployed to Dev and used SQS event from prod to validate successful completion of Lambda.

[OLH-2296]: https://govukverify.atlassian.net/browse/OLH-2296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ