### PR TITLE
Olh 2296 create a re drive lambda to process events in delete email subscription dlq rename lambda [skip canary]

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -2252,6 +2252,47 @@ Resources:
       FilterPattern: ""
       LogGroupName: !Ref DeleteEmailSubscriptionsFunctionLogGroup
 
+  RedriveDeleteEmailSubscriptionsFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Sub ${Environment}-${AWS::StackName}-redrive-delete-email-subscriptions
+      CodeUri: src
+      PackageType: Zip
+      Handler: redrive-delete-email-subscriptions.handler
+      Timeout: 30
+      Policies:
+        LambdaInvokePolicy:
+          FunctionName: !Ref DeleteEmailSubscriptionsFunction.Alias
+        SQSPollerPolicy:
+          QueueName: !GetAtt DeleteEmailSubscriptionsDeadLetterQueue.QueueName
+        KMSDecryptPolicy:
+          KeyId: !Ref QueueKmsKey
+      Environment:
+        Variables:
+          DELETE_EMAIL_SUBSCRIPTIONS_LAMBDA_ALIAS: !Ref DeleteEmailSubscriptionsFunction.Alias
+          NODE_OPTIONS: --enable-source-maps
+    Metadata:
+      BuildMethod: esbuild
+      BuildProperties:
+        Minify: true
+        Format: "esm"
+        OutExtension:
+          - .js=.mjs
+        Target: "es2020"
+        Sourcemap: true
+        EntryPoints:
+          - delete-email-subscriptions.ts
+        Banner:
+          - js=import { createRequire } from 'module'; const require = createRequire(import.meta.url);
+
+  RedriveDeleteEmailSubscriptionEventSourceMapping:
+    Type: AWS::Lambda::EventSourceMapping
+    Properties:
+      Enabled: true
+      BatchSize: 1
+      EventSourceArn: !GetAtt DeleteEmailSubscriptionsDeadLetterQueue.Arn
+      FunctionName: !Ref RedriveDeleteEmailSubscriptionsFunction
+
   ActivityLogToFormatQueue:
     Type: AWS::SQS::Queue
     Properties:

--- a/template.yaml
+++ b/template.yaml
@@ -2252,47 +2252,6 @@ Resources:
       FilterPattern: ""
       LogGroupName: !Ref DeleteEmailSubscriptionsFunctionLogGroup
 
-  RedriveDeleteEmailSubscriptionsFunction:
-    Type: AWS::Serverless::Function
-    Properties:
-      FunctionName: !Sub ${Environment}-${AWS::StackName}-redrive-delete-email-subscriptions
-      CodeUri: src
-      PackageType: Zip
-      Handler: redrive-delete-email-subscriptions.handler
-      Timeout: 30
-      Policies:
-        LambdaInvokePolicy:
-          FunctionName: !Ref DeleteEmailSubscriptionsFunction.Alias
-        SQSPollerPolicy:
-          QueueName: !GetAtt DeleteEmailSubscriptionsDeadLetterQueue.QueueName
-        KMSDecryptPolicy:
-          KeyId: !Ref QueueKmsKey
-      Environment:
-        Variables:
-          DELETE_EMAIL_SUBSCRIPTIONS_LAMBDA_ALIAS: !Ref DeleteEmailSubscriptionsFunction.Alias
-          NODE_OPTIONS: --enable-source-maps
-    Metadata:
-      BuildMethod: esbuild
-      BuildProperties:
-        Minify: true
-        Format: "esm"
-        OutExtension:
-          - .js=.mjs
-        Target: "es2020"
-        Sourcemap: true
-        EntryPoints:
-          - delete-email-subscriptions.ts
-        Banner:
-          - js=import { createRequire } from 'module'; const require = createRequire(import.meta.url);
-
-  RedriveDeleteEmailSubscriptionEventSourceMapping:
-    Type: AWS::Lambda::EventSourceMapping
-    Properties:
-      Enabled: true
-      BatchSize: 1
-      EventSourceArn: !GetAtt DeleteEmailSubscriptionsDeadLetterQueue.Arn
-      FunctionName: !Ref RedriveDeleteEmailSubscriptionsFunction
-
   ActivityLogToFormatQueue:
     Type: AWS::SQS::Queue
     Properties:

--- a/template.yaml
+++ b/template.yaml
@@ -2386,7 +2386,7 @@ Resources:
   RedriveDeleteEmailSubscriptionsFunction:
     Type: AWS::Serverless::Function
     Properties:
-      FunctionName: !Sub ${Environment}-${AWS::StackName}-redrive-delete-email-subscriptions
+      FunctionName: !Sub ${Environment}-${AWS::StackName}-redrive-delete-email-sub
       CodeUri: src
       PackageType: Zip
       Handler: redrive-delete-email-subscriptions.handler


### PR DESCRIPTION
## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->
[OLH-2296] Shorten name of lambda to meet AWS requirements of less than 64 characters

### What changed

<!-- Describe the changes in detail - the "what"-->
Changed name of lambda to be shorter

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->
AWS has a limit of 64 characters for function names. When deployed to production, it exceeds the character limit.


[OLH-2296]: https://govukverify.atlassian.net/browse/OLH-2296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ