### PR TITLE
[OLH-2296] Disable event source mapping for redrive lambda

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -2419,7 +2419,7 @@ Resources:
   RedriveDeleteEmailSubscriptionEventSourceMapping:
     Type: AWS::Lambda::EventSourceMapping
     Properties:
-      Enabled: true
+      Enabled: false
       BatchSize: 1
       EventSourceArn: !GetAtt DeleteEmailSubscriptionsDeadLetterQueue.Arn
       FunctionName: !Ref RedriveDeleteEmailSubscriptionsFunction


### PR DESCRIPTION
## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->
[OLH-2296] Disable event source mapping for redrive lambda

### What changed

<!-- Describe the changes in detail - the "what"-->
Disabled event source mapping

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->
There will be failures in the future that we need to identify and resolve. Leaving the event source mapping will cause the lambda to constantly retry failed events.


[OLH-2296]: https://govukverify.atlassian.net/browse/OLH-2296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ