### PR TITLE
Define new trigger and filter to ensure only run in merge queue

### DIFF
--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -10,12 +10,16 @@ on:
         required: false
         type: string
         default: ${{ github.ref }}
+  pull_request:
+  merge_group:
+    types: [checks_requested]
   workflow_dispatch:
 
 permissions: read-all
 
 jobs:
   deploy-to-demo:
+    if: github.event_name != 'pull_request' || github.event.action == 'enqueued'
     environment: Demo-test
     permissions:
       contents: read
@@ -81,6 +85,7 @@ jobs:
           template-file: .aws-sam/build/template.yaml
 
   check-stack-ready:
+    if: github.event_name != 'pull_request' || github.event.action == 'enqueued'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -113,6 +118,7 @@ jobs:
           gh-polling-role: ${{ secrets.DEMO_TESTING_ROLE_ARN }}
 
   test:
+    if: github.event_name != 'pull_request' || github.event.action == 'enqueued'
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
## Proposed changes

OLH-2303 - Trigger Pre-merge test to validate as part of Github Merge queue

### What changed

Define new trigger and filter to ensure only run in mere queue


### Why did it change
Attempting to make pre-merge a part of OLH release process

### Related links


## Checklists


### Environment variables or secrets

- [ ] No environment variables or secrets were added or changed



### Permissions

## Testing


## How to review

