### PR TITLE
OLH-2303 - Trigger Pre-merge test to validate as part of Github Merge

### DIFF
--- a/.github/workflows/lint-cloudformation.yaml
+++ b/.github/workflows/lint-cloudformation.yaml
@@ -10,6 +10,8 @@ on:
   pull_request:
     paths:
       - "template.yaml"
+  merge_group:
+    types: [checks_requested]
 
 jobs:
   lint_cloudformation:

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -1,9 +1,6 @@
 name: Pre Merge Check
 
 on:
-  push:
-    branches:
-      - main
   workflow_call:
     inputs:
       gitRef:
@@ -38,9 +35,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Verify skipPreMerge is not in the last 3 commit message
+      - name: Verify skipPreMerge is not in the last commit message
         id: verify_skip_merge
         run: |
+          echo "Github event action is ${{ github.event.action }}"
           WORD="skipPreMerge"
           echo "Checking the last commit messages for the word '${WORD}':"
           SKIP_FOUND="false"

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -42,9 +42,9 @@ jobs:
         id: verify_skip_merge
         run: |
           WORD="skipPreMerge"
-          echo "Checking the last 3 commit messages for the word '${WORD}':"
+          echo "Checking the last commit messages for the word '${WORD}':"
           SKIP_FOUND="false"
-          for COMMIT_MSG in $(git log -3 --pretty=format:"%s"); do
+          for COMMIT_MSG in $(git log -1 --pretty=format:"%s"); do
             if [[ "$COMMIT_MSG" == *"$WORD"* ]]; then
               echo "Found '${WORD}' in commit: $COMMIT_MSG"
               SKIP_FOUND="true"

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -3,20 +3,66 @@ name: Pre Merge Check
 on:
   push:
     branches:
-      - OLH-2228
+      - main
   workflow_call:
     inputs:
       gitRef:
         required: false
         type: string
         default: ${{ github.ref }}
+  pull_request:
+  merge_group:
+    types: [checks_requested]
   workflow_dispatch:
 
 permissions: read-all
 
 jobs:
+  check-if-skipping-pre-merge:
+    if: github.event_name != 'pull_request' || github.event.action == 'enqueued'
+    runs-on: ubuntu-latest
+    outputs:
+      skip_found: ${{ steps.verify_skip_merge.outputs.skip_found }}
+    defaults:
+      run:
+        shell: bash
+        working-directory: ./pre-merge-integration-tests
+    timeout-minutes: 60
+    name: "Check if pre-merge step should be skipped"
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # pin@v3
+        with:
+          fetch-depth: 0
+
+      - name: Verify skipPreMerge is not in the last 3 commit message
+        id: verify_skip_merge
+        run: |
+          WORD="skipPreMerge"
+          echo "Checking the last 3 commit messages for the word '${WORD}':"
+          SKIP_FOUND="false"
+          for COMMIT_MSG in $(git log -3 --pretty=format:"%s"); do
+            if [[ "$COMMIT_MSG" == *"$WORD"* ]]; then
+              echo "Found '${WORD}' in commit: $COMMIT_MSG"
+              SKIP_FOUND="true"
+              break
+            fi
+          done
+          echo "Skip found is '${SKIP_FOUND}'"
+          if [ "$SKIP_FOUND" == "true" ]; then 
+            echo "Skipping all steps because the commit message contains '${WORD}'."
+            echo "skip_found=$SKIP_FOUND" >> $GITHUB_OUTPUT
+          else
+            echo "No commit message with '${WORD}' found. Proceeding with workflow."
+            echo "skip_found=$SKIP_FOUND" >> $GITHUB_OUTPUT
+          fi
   deploy-to-demo:
     environment: Demo-test
+    needs: check-if-skipping-pre-merge
+    if: ${{ needs.check-if-skipping-pre-merge.outputs.skip_found == 'false' }}
     permissions:
       contents: read
       id-token: write
@@ -29,16 +75,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Verify merge queue source
-        run: |
-          echo "Commit message: ${{ github.event.head_commit.message }}"
-          if [[ "${{ github.event.head_commit.message }}" != *"Merge pull request"* ]]; then
-            echo "This was not a merge queue commit. Exiting."
-            exit 0
-          fi
-
       - name: Fill in backup wrapping key
-        run: .github/workflows/find-and-replace-backup-wrapping-key.sh
+        if: ${{ !contains(env.skip_found, 'true') }}
+        run: |
+          .github/workflows/find-and-replace-backup-wrapping-key.sh
         env:
           WRAPPING_KEY_ARN: ${{ secrets.WRAPPING_KEY_ARN }}
 
@@ -81,6 +121,7 @@ jobs:
           template-file: .aws-sam/build/template.yaml
 
   check-stack-ready:
+    if: ${{ needs.check-if-skipping-pre-merge.outputs.skip_found == 'false' }}
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -98,14 +139,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Verify merge queue source
-        run: |
-          echo "Commit message: ${{ github.event.head_commit.message }}"
-          if [[ "${{ github.event.head_commit.message }}" != *"Merge pull request"* ]]; then
-            echo "This was not a merge queue commit. Exiting."
-            exit 0
-          fi
-
       - name: Poll for deployment finished
         uses: govuk-one-login/github-actions/sam/check-stack-updated@b00f9eeccebbc72083d8ffca4f0a2448fb14bda5
         with:
@@ -113,6 +146,7 @@ jobs:
           gh-polling-role: ${{ secrets.DEMO_TESTING_ROLE_ARN }}
 
   test:
+    if: ${{ needs.check-if-skipping-pre-merge.outputs.skip_found == 'false' }}
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/README.md
+++ b/README.md
@@ -43,6 +43,24 @@ npm run lint
 npm run test
 ```
 
+### Pre-merge tests
+
+We run pre-merge regression tests before feature changes are merged to the main branch.
+
+This test will instrument environment setup and deployment to a test account `(di-account-test - 654654326096)` and
+then run a few tests to confirm critical functionalities are not broken as part of the code to be merged.
+
+This run takes approximately 20 minutes to complete as it has to create the artifacts,
+deploy to a new environment and run tests, as a result, we have introduced the ability to
+skip pre-merge regression testing where there is a requirement to push the change live ASAP.
+To do this, the keyword “skipPreMerge” has to be present in the last commit messages for the feature branch
+that is being merged to main.
+
+The configuration to ensure this test is configured in workflows and the branch config itself, where
+
+- We require a status check to pass before merging, in this case the status check is the Pre-Merge Test.
+- Merges are completed via merge queues and where the status check above fails, the merge attempt is removed from the merge queue.
+
 ### Post-deploy tests
 
 We run integration tests against the deployed application in our build environment as part of the pipeline.


### PR DESCRIPTION
## Proposed changes

OLH-2303 - Trigger Pre-merge test to validate as part of Github Merge
   
### What changed

 Make pre-merge a part of OLH release process by doing the following:
 
 Ensure merge to main is via a merge queue
As part of status check before merge, do a pre-merge test run. This process deploys the merge candidate to a test environment and carries out a series of end to end test, if all passes, proceeds with the merge
Define new trigger and filter to ensure only run in mere queue
Add ability to skip pre-merge test by including skipPreMerge in last 3 commits

### Why did it change

Make pre-merge testing a part of OLH release process. 

### Related links

## Checklists

### Environment variables or secrets

- [ ] No environment variables or secrets were added or changed

### Permissions

## Testing
Created a branch with similar configurations as the main branch, created a pr against that branch and demonstrated a successful pre-merge test run when skipPreMerge text is not in the last 3 commits messages and where it is, demonstrated that the pre-merge test is skipped.

## How to review



## Additional Steps prior to merging
Ensure main branch has the same config as below
 
<img width="284" alt="image" src="https://github.com/user-attachments/assets/c39ea7bb-4279-4f84-9151-df31585a6794" />

