### PR TITLE
Remove conditional from check pre-merge. skipPreMerge

### DIFF
--- a/.github/workflows/lint-cloudformation.yaml
+++ b/.github/workflows/lint-cloudformation.yaml
@@ -10,6 +10,8 @@ on:
   pull_request:
     paths:
       - "template.yaml"
+  merge_group:
+    types: [checks_requested]
 
 jobs:
   lint_cloudformation:

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -1,9 +1,6 @@
 name: Pre Merge Check
 
 on:
-  push:
-    branches:
-      - main
   workflow_call:
     inputs:
       gitRef:
@@ -38,13 +35,14 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Verify skipPreMerge is not in the last 3 commit message
+      - name: Verify skipPreMerge is not in the last commit message
         id: verify_skip_merge
         run: |
+          echo "Github event action is ${{ github.event.action }}"
           WORD="skipPreMerge"
-          echo "Checking the last 3 commit messages for the word '${WORD}':"
+          echo "Checking the last commit messages for the word '${WORD}':"
           SKIP_FOUND="false"
-          for COMMIT_MSG in $(git log -3 --pretty=format:"%s"); do
+          for COMMIT_MSG in $(git log -1 --pretty=format:"%s"); do
             if [[ "$COMMIT_MSG" == *"$WORD"* ]]; then
               echo "Found '${WORD}' in commit: $COMMIT_MSG"
               SKIP_FOUND="true"

--- a/README.md
+++ b/README.md
@@ -43,6 +43,24 @@ npm run lint
 npm run test
 ```
 
+### Pre-merge tests
+
+We run pre-merge regression tests before feature changes are merged to the main branch.
+
+This test will instrument environment setup and deployment to a test account `(di-account-test - 654654326096)` and
+then run a few tests to confirm critical functionalities are not broken as part of the code to be merged.
+
+This run takes approximately 20 minutes to complete as it has to create the artifacts,
+deploy to a new environment and run tests, as a result, we have introduced the ability to
+skip pre-merge regression testing where there is a requirement to push the change live ASAP.
+To do this, the keyword “skipPreMerge” has to be present in the last commit messages for the feature branch
+that is being merged to main.
+
+The configuration to ensure this test is configured in workflows and the branch config itself, where
+
+- We require a status check to pass before merging, in this case the status check is the Pre-Merge Test.
+- Merges are completed via merge queues and where the status check above fails, the merge attempt is removed from the merge queue.
+
 ### Post-deploy tests
 
 We run integration tests against the deployed application in our build environment as part of the pipeline.


### PR DESCRIPTION
## Proposed changes

Added pre-merge related doc to readme
Check for keyword in the last commit only
Ensured pre-merge check runs and its not skipped when merging to main
