### PR TITLE
OLH-2399-stop-tx-ma-sending-us-the-wrong-data

### DIFF
--- a/src/format-user-services.ts
+++ b/src/format-user-services.ts
@@ -70,7 +70,7 @@ const validateTxmaEvent = (txmaEvent: TxmaEvent): void => {
 
 export const prettifyDate = (dateEpoch: number): string => {
   return new Intl.DateTimeFormat("en-GB", { dateStyle: "long" }).format(
-    new Date(dateEpoch)
+    new Date(dateEpoch * 1000)
   );
 };
 

--- a/src/format-user-services.ts
+++ b/src/format-user-services.ts
@@ -69,9 +69,11 @@ const validateTxmaEvent = (txmaEvent: TxmaEvent): void => {
 };
 
 export const prettifyDate = (dateEpoch: number): string => {
-  return new Intl.DateTimeFormat("en-GB", { dateStyle: "long" }).format(
-    new Date(dateEpoch * 1000)
-  );
+  const date =
+    dateEpoch <= Date.now() / 1000
+      ? new Date(dateEpoch * 1000)
+      : new Date(dateEpoch);
+  return new Intl.DateTimeFormat("en-GB", { dateStyle: "long" }).format(date);
 };
 
 export const validateAndParseSQSRecord = (

--- a/src/format-user-services.ts
+++ b/src/format-user-services.ts
@@ -8,7 +8,7 @@ import type {
 import { sendSqsMessage } from "./common/sqs";
 import { getEnvironmentVariable } from "./common/utils";
 
-class DroppedEventError extends Error {
+export class DroppedEventError extends Error {
   constructor(message: string) {
     super(message);
     this.name = "DroppedEventError";

--- a/src/format-user-services.ts
+++ b/src/format-user-services.ts
@@ -51,8 +51,10 @@ const validateUser = (user: UserData): void => {
   }
 };
 
+const HMRC_CLIENT_ID = "7y-bchtHDfucVR5kcAe8KaM80wg";
+
 const validateTxmaEvent = (txmaEvent: TxmaEvent): void => {
-  if (txmaEvent.client_id === "7y-bchtHDfucVR5kcAe8KaM80wg") {
+  if (txmaEvent.client_id === HMRC_CLIENT_ID) {
     throw new DroppedEventError(`Event dropped due to non-OLH login via HMRC.`);
   }
 

--- a/src/tests/format-user-services.test.ts
+++ b/src/tests/format-user-services.test.ts
@@ -30,7 +30,7 @@ describe("newServicePresenter", () => {
     expect(newServicePresenter(TXMA_EVENT)).toEqual({
       client_id: "clientID1234",
       count_successful_logins: 1,
-      last_accessed: 1670850655485,
+      last_accessed: 1670850655,
       last_accessed_pretty: "12 December 2022",
     });
   });
@@ -40,12 +40,12 @@ describe("existingServicePresenter", () => {
   const existingServiceRecord = makeServiceRecord(
     "clientID1234",
     4,
-    1670850655485
+    1670850655
   );
-  const lastAccessed = 1670850655485;
+  const lastAccessed = 1670850655;
   const formattedDate = new Intl.DateTimeFormat("en-GB", {
     dateStyle: "long",
-  }).format(new Date(lastAccessed));
+  }).format(new Date(lastAccessed * 1000));
 
   test("modifies existing Service record", () => {
     expect(
@@ -233,7 +233,8 @@ describe("sendSqsMessage", () => {
 describe("prettifyDate", () => {
   test("It takes a date Epoch as a number and returns a pretty formatted date", async () => {
     const date = new Date(2022, 0, 1);
-    expect(prettifyDate(date.valueOf())).toEqual("1 January 2022");
+    const epochTimestamp = date.getTime() / 1000;
+    expect(prettifyDate(epochTimestamp)).toEqual("1 January 2022");
   });
 });
 
@@ -266,7 +267,7 @@ describe("handler", () => {
     ]);
     const outputSQSEventMessageBodies: UserServices = {
       user_id: userId,
-      services: [makeServiceRecord(serviceClientID, 1, 1670850655485)],
+      services: [makeServiceRecord(serviceClientID, 1, 1670850655)],
     };
     await handler({ Records: inputSQSEvent });
     expect(sqsMock).toHaveReceivedCommandWith(SendMessageCommand, {
@@ -277,7 +278,7 @@ describe("handler", () => {
 
   test("it writes a formatted SQS event when TxMA event matched a stored user service", async () => {
     const serviceListWithExistingService = [
-      makeServiceRecord(serviceClientID, 10, 1670850655485),
+      makeServiceRecord(serviceClientID, 10, 1670850655),
     ] as Service[];
     const inputSQSEvent = makeSQSInputFixture([
       {
@@ -287,7 +288,7 @@ describe("handler", () => {
     ]);
     const outputSQSEventMessageBodies: UserServices = {
       user_id: userId,
-      services: [makeServiceRecord(serviceClientID, 11, 1670850655485)],
+      services: [makeServiceRecord(serviceClientID, 11, 1670850655)],
     };
     await handler({ Records: inputSQSEvent });
     expect(sqsMock).toHaveReceivedCommandWith(SendMessageCommand, {
@@ -312,7 +313,7 @@ describe("handler", () => {
     const outputSQSEventMessageBodies: UserServices = {
       user_id: userId,
       services: [
-        makeServiceRecord(serviceClientID, 1, 1670850655485),
+        makeServiceRecord(serviceClientID, 1, 1670850655),
         anotherService,
       ],
     };

--- a/src/tests/testUtils.ts
+++ b/src/tests/testUtils.ts
@@ -15,7 +15,7 @@ export const makeServiceRecord = (
   const fallbackDate = new Date(2022, 0, 1).valueOf();
   const formattedDate = new Intl.DateTimeFormat("en-GB", {
     dateStyle: "long",
-  }).format(new Date(date || fallbackDate));
+  }).format(new Date((date || fallbackDate) * 1000));
   return {
     client_id: clientId,
     count_successful_logins: count,
@@ -51,7 +51,7 @@ export const makeTxmaEvent = (
 ): TxmaEvent => ({
   event_name: eventName ?? "event_1",
   event_id: "event_id",
-  timestamp: date ?? 1670850655485,
+  timestamp: date ?? 1670850655,
   timestamp_formatted: "",
   client_id: localclientId ?? clientId,
   user: {


### PR DESCRIPTION
## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->
[OLH-2399] Drop HMRC events & Fix last seen pretty

### What changed
<!-- Describe the changes in detail - the "what"-->
Dropped HMRC event's as they are not OLH users.
Last seen pretty isn't meant to be used but is still available in the database. Updating to the correct value so the table will fix itself over time. 

### Why did it change
<!-- Describe the reason these changes were made - the "why" -->
HMRC are sending event's to be processed when they shouldn't be. This has filled up our user_services table with 5m records that shouldn't be there. 
Last seen pretty date was expected in milliseconds turned out to be seconds in production and was too late to fix.

## Checklists

<!-- Merging this PR deploys to production. Please answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

## Testing

<!-- Provide a summary of any manual testing you've done, for example deploying the branch to dev -->
## How to review

<!-- Describe any non-standard steps to review this work, or highlight any areas that you'd like the reviewer's opinion on -->
Deployed to Dev and validated that hmrc event's were not processed by pushing event's were different client_ids to the sns user_services format queue. 

[OLH-2399]: https://govukverify.atlassian.net/browse/OLH-2399?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ