### PR TITLE
Olh 2404 delete data from user services table that shouldnt be there

### DIFF
--- a/src/remove-hmrc-events.ts
+++ b/src/remove-hmrc-events.ts
@@ -22,10 +22,12 @@ export const handler = async (): Promise<unknown> => {
         ExpressionAttributeValues: {
           ":urn": "urn:",
         },
-        ExclusiveStartKey: lastEvaluatedKey, // Start from the last key
+        ExclusiveStartKey: lastEvaluatedKey,
       };
 
       const scanResults = await docClient.send(new ScanCommand(scanParams));
+      console.log("Scan complete");
+
       const itemsToDelete = scanResults.Items || [];
 
       if (itemsToDelete.length > 0) {

--- a/template.yaml
+++ b/template.yaml
@@ -4356,7 +4356,8 @@ Resources:
       FunctionName: !Sub ${Environment}-${AWS::StackName}-remove-hmrc-events
       CodeUri: src
       PackageType: Zip
-      MemorySize: 128
+      MemorySize: 1024
+      Timeout: 600
       Handler: remove-hmrc-events.handler
       Role: !GetAtt RemoveHMRCEventsRole.Arn
       Environment:

--- a/template.yaml
+++ b/template.yaml
@@ -4416,6 +4416,17 @@ Resources:
                 - Arn: !GetAtt UserServicesStore.Arn
           - Effect: Allow
             Action:
+              - dynamodb:Query
+              - dynamodb:GetItem
+              - dynamodb:Scan
+              - dynamodb:BatchWriteItem
+            Resource:
+              - !GetAtt UserActivityLogsStore.Arn
+              - !Sub
+                - "${Arn}/*"
+                - Arn: !GetAtt UserActivityLogsStore.Arn
+          - Effect: Allow
+            Action:
               - kms:Decrypt
               - kms:GenerateDataKey*
               - kms:ReEncrypt*


### PR DESCRIPTION
## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->

### What changed
Supported scan pagination and batch deletions.

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->
there was too much to delete in production so need to break up the scan command and batch write command. Batch write has a limit of 25 and scan supports pagination.
