### PR TITLE
Stopped HMRC Gateway Client ID's from being processed in our activity…

### DIFF
--- a/src/common/model.ts
+++ b/src/common/model.ts
@@ -217,3 +217,10 @@ export interface Personalisation {
   timeEn: string;
   timeCy: string;
 }
+
+export class DroppedEventError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "DroppedEventError";
+  }
+}

--- a/src/format-activity-log.ts
+++ b/src/format-activity-log.ts
@@ -1,20 +1,13 @@
 import { DynamoDBStreamEvent } from "aws-lambda";
 import { AttributeValue } from "@aws-sdk/client-dynamodb";
 import { unmarshall } from "@aws-sdk/util-dynamodb";
-import { ActivityLogEntry, TxmaEvent } from "./common/model";
+import { ActivityLogEntry, DroppedEventError, TxmaEvent } from "./common/model";
 import {
   allowedTxmaEvents,
   REPORT_SUSPICIOUS_ACTIVITY_DEFAULT,
 } from "./common/constants";
 import { sendSqsMessage } from "./common/sqs";
 import { getEnvironmentVariable } from "./common/utils";
-
-export class DroppedEventError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "DroppedEventError";
-  }
-}
 
 const createNewActivityLogEntryFromTxmaEvent = (
   txmaEvent: TxmaEvent

--- a/src/format-user-services.ts
+++ b/src/format-user-services.ts
@@ -1,19 +1,13 @@
 import { SQSEvent, SQSRecord } from "aws-lambda";
-import type {
-  UserData,
-  UserRecordEvent,
-  Service,
-  TxmaEvent,
+import {
+  type UserData,
+  type UserRecordEvent,
+  type Service,
+  type TxmaEvent,
+  DroppedEventError,
 } from "./common/model";
 import { sendSqsMessage } from "./common/sqs";
 import { getEnvironmentVariable } from "./common/utils";
-
-export class DroppedEventError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "DroppedEventError";
-  }
-}
 
 const validateUserService = (service: Service): void => {
   if (

--- a/src/tests/format-user-services.test.ts
+++ b/src/tests/format-user-services.test.ts
@@ -11,10 +11,9 @@ import {
   formatRecord,
   prettifyDate,
   handler,
-  DroppedEventError,
 } from "../format-user-services";
 
-import { Service, UserServices } from "../common/model";
+import { DroppedEventError, Service, UserServices } from "../common/model";
 import {
   makeServiceRecord,
   makeSQSInputFixture,

--- a/src/tests/testFixtures.ts
+++ b/src/tests/testFixtures.ts
@@ -185,6 +185,7 @@ export const MUTABLE_ACTIVITY_LOG_ENTRY: ActivityLogEntry = {
 
 // TODO: This would be better placed in testUtils but fails to be imported as a function when moved there.
 export const generateDynamoSteamRecord = (
+  customClientId?: string,
   txmaEventName = "AUTH_AUTH_CODE_ISSUED"
 ): DynamoDBRecord => ({
   eventID: "1234567",
@@ -207,7 +208,7 @@ export const generateDynamoSteamRecord = (
               session_id: { S: sessionId },
             },
           },
-          client_id: { S: clientId },
+          client_id: { S: customClientId ?? clientId },
           txma: { M: { configVersion: { S: "2.2.1" } } },
           timestamp: { N: `${timestamp}` },
         },
@@ -221,7 +222,7 @@ export const TEST_DYNAMO_STREAM_EVENT: DynamoDBStreamEvent = {
 };
 
 export const MUCKY_DYNAMODB_STREAM_EVENT: DynamoDBStreamEvent = {
-  Records: [generateDynamoSteamRecord(randomEventType)],
+  Records: [generateDynamoSteamRecord(undefined, randomEventType)],
 };
 
 export const ERROR_DYNAMODB_STREAM_EVENT: DynamoDBStreamEvent = {


### PR DESCRIPTION
## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->
[OLH] Stopped HMRC Gateway event's from populating Activity Log table
### What changed

<!-- Describe the changes in detail - the "what"-->
Stop HMRC Event's from populating our table

### Why did it change
<!-- Describe the reason these changes were made - the "why" -->
Don't need to store the hmrc user data
