### PR TITLE
removed provisioned concurrency

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -761,8 +761,6 @@ Resources:
       Handler: save-raw-events.handler
       Role: !GetAtt SaveRawEventsRole.Arn
       ReservedConcurrentExecutions: 30
-      ProvisionedConcurrencyConfig:
-        ProvisionedConcurrentExecutions: 30
       Environment:
         Variables:
           TABLE_NAME: !Ref RawEventsStoreTableName
@@ -995,8 +993,6 @@ Resources:
       Handler: query-user-services.handler
       Role: !GetAtt QueryUserServicesRole.Arn
       ReservedConcurrentExecutions: 30
-      ProvisionedConcurrencyConfig:
-        ProvisionedConcurrentExecutions: 30
       Environment:
         Variables:
           TABLE_NAME: !Ref UserServicesStoreTableName
@@ -1257,8 +1253,6 @@ Resources:
       Handler: format-user-services.handler
       Role: !GetAtt FormatUserServicesRole.Arn
       ReservedConcurrentExecutions: 30
-      ProvisionedConcurrencyConfig:
-        ProvisionedConcurrentExecutions: 30
       Environment:
         Variables:
           OUTPUT_QUEUE_URL: !Ref UserServicesToWriteQueue
@@ -2449,8 +2443,6 @@ Resources:
       Handler: write-activity-log.handler
       Role: !GetAtt WriteActivityRecordRole.Arn
       ReservedConcurrentExecutions: 30
-      ProvisionedConcurrencyConfig:
-        ProvisionedConcurrentExecutions: 30
       Environment:
         Variables:
           TABLE_NAME: !Ref ActivityLogsStoreTableName
@@ -2697,8 +2689,6 @@ Resources:
       Handler: format-activity-log.handler
       Role: !GetAtt FormatActivityLogRole.Arn
       ReservedConcurrentExecutions: 30
-      ProvisionedConcurrencyConfig:
-        ProvisionedConcurrentExecutions: 30
       Environment:
         Variables:
           OUTPUT_QUEUE_URL: !Ref ActivityLogToWriteQueue


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX] PR Title` -->
BAU - Performance Optimisations

### What changed

<!-- Describe the changes in detail - the "what"-->
Previously provisioned concurrency was added to facilitate the NFR which had a high number of users per second. This NFR was set too high and did not take into account real world traffic. Whilst this NFR is being adjusted, we are reverting our configuration to save costs. Additionally, provisioned concurrency is not required for the backend as we are aiming for eventual consistency. This means lambda cold start times do not matter and the queues will ensure they are completed.

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->
Save costs ~$300 per month

### Testing

<!-- When working with feature flags, features that are flagged off should not be made available in production -->
<!-- Delete if changes do NOT include any feature flags -->
Deployed to Dev and ran a performance test against it
