### PR TITLE
OLH-2522: Revoke IPV Core access to the deletion topic

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -223,20 +223,6 @@ Mappings:
       QueueArn: "arn:aws:sqs:eu-west-2:451773080033:self-production-EC-SQS-Output-Queue-accounts"
       KeyArn: "arn:aws:kms:eu-west-2:451773080033:key/e95d47b6-613d-4bea-93c9-d400cdfb31ee"
 
-  IPVCoreAccounts:
-    demo:
-      AccountNumber: ""
-    dev:
-      AccountNumber: ""
-    build:
-      AccountNumber: "457601271792"
-    staging:
-      AccountNumber: "335257547869"
-    integration:
-      AccountNumber: "991138514218"
-    production:
-      AccountNumber: "075701497069"
-
   OrchestrationAccounts:
     demo:
       AccountNumber: ""
@@ -1708,21 +1694,6 @@ Resources:
         - !Ref UserAccountDeletionTopic
       PolicyDocument:
         Statement:
-          - Sid: "Allow IPV Core"
-            Effect: Allow
-            Principal:
-              AWS: !Join
-                - ""
-                - - "arn:aws:iam::"
-                  - !FindInMap [
-                      IPVCoreAccounts,
-                      !Ref Environment,
-                      "AccountNumber",
-                    ]
-                  - ":root"
-            Action: sns:Subscribe
-            Resource:
-              - !Ref UserAccountDeletionTopic
           - Sid: "Allow Credential store"
             Effect: Allow
             Principal:
@@ -4645,23 +4616,6 @@ Resources:
                   - - "arn:aws:iam::"
                     - !FindInMap [
                         AccountInterventionsService,
-                        !Ref Environment,
-                        "AccountNumber",
-                      ]
-                    - ":root"
-              Action: kms:Decrypt
-              Resource:
-                - "*"
-            - !Ref AWS::NoValue
-          - !If
-            - "IsNotDevelopmentOrDemo"
-            - Effect: Allow
-              Principal:
-                AWS: !Join
-                  - ""
-                  - - "arn:aws:iam::"
-                    - !FindInMap [
-                        IPVCoreAccounts,
                         !Ref Environment,
                         "AccountNumber",
                       ]


### PR DESCRIPTION
## Proposed changes

### What changed

Revoke IPV Core access to the deletion topic. We can also clear up the respective mapping entries.

### Why did it change

The Core team have told us they're now listening for the account deleted audit events instead of messages on this topic, so we can safely revoke their access.

See https://gds.slack.com/archives/C012GEZBZM0/p1741863821328419
### Related links

[ADR 0189](https://github.com/govuk-one-login/architecture/blob/main/adr/0189-account-deletion-processing.md)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed
