### PR TITLE
BAU: Pin cfn-lint to 1.29.1

### DIFF
--- a/.github/workflows/lint-cloudformation.yaml
+++ b/.github/workflows/lint-cloudformation.yaml
@@ -28,7 +28,7 @@ jobs:
           python-version: "3.x"
 
       - name: Install cfn-lint
-        run: python -m pip install cfn-lint
+        run: python -m pip install cfn-lint==1.29.1
 
       - name: Run linter
         run: cfn-lint template.yaml -r "eu-west-2"


### PR DESCRIPTION

## Proposed changes


### What changed

Pin cfn-lint to 1.29.1

### Why did it change

cfn-lint 1.30.0 introduced a new rule to check IAM permissions. Something in that new rule is causing false warnings when run against our template (see
https://github.com/aws-cloudformation/cfn-lint/issues/4035 for more details).

For now, pin to the latest working version. We'll be able to remove this pin again once we've figured out the issue.

### Testing

You can verify the behaviour by running cfn-lint locally:

```bash
pip install cfn-lint==1.30.0
cfn-lint -t template.yaml # gives the false warnings

pip install cfn-lint=1.29.1
cfn-lint -t template.yaml # no warnings
```