### PR TITLE
BAU: Unpin cfn-lint

### DIFF
--- a/.github/workflows/lint-cloudformation.yaml
+++ b/.github/workflows/lint-cloudformation.yaml
@@ -28,7 +28,7 @@ jobs:
           python-version: "3.x"
 
       - name: Install cfn-lint
-        run: python -m pip install cfn-lint==1.29.1
+        run: python -m pip install cfn-lint
 
       - name: Run linter
         run: cfn-lint template.yaml -r "eu-west-2"


### PR DESCRIPTION
## Proposed changes

Unpin cfn-lint in the PR / post-merge Github actions.

### What changed

<!-- Describe the changes in detail - the "what"-->

### Why did it change

In #580 we pinned to an old version of cfn-lint to avoid a bug. That bug's been fixed (see https://github.com/aws-cloudformation/cfn-lint/pull/4041) so we can unpin and get the latest version.

I did consider leaving the pin in place to avoid these sorts of errors in the future, but it'd add another dependency upgrade that we'd have to look for, test and upgrade manually and I vaguely remember a conversation from a while back where we decided that that wasn't worth the tradeoff.

## Testing

You can install the latest version locally to verify it runs on our backend template with no errors:
```bash
pip install --upgrade cfn-lint # gets the new 1.32.0
cfn-lint -t template.yaml -r "eu-west-2" # Runs with no errors
```
