### PR TITLE
OLH-2470: Remove eVCS access to delete topic

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -260,20 +260,6 @@ Mappings:
       GOVACCOUNTSPUBLISHINGAPIURL: "https://account-api.publishing.service.gov.uk"
       REPORTSUSPISCIOUSACTIVITYTEMPLATEID: "0674c6e3-219c-4e3a-b04c-3786bac7f228"
 
-  CredentialStoreAccounts:
-    demo:
-      AccountNumber: "013758878511"
-    dev:
-      AccountNumber: "013758878511"
-    build:
-      AccountNumber: "688341086169"
-    staging:
-      AccountNumber: "922902741880"
-    integration:
-      AccountNumber: "406416508755"
-    production:
-      AccountNumber: "499563136613"
-
   AccountInterventionsService:
     demo:
       AccountNumber: "484907510598"
@@ -1694,21 +1680,6 @@ Resources:
         - !Ref UserAccountDeletionTopic
       PolicyDocument:
         Statement:
-          - Sid: "Allow Credential store"
-            Effect: Allow
-            Principal:
-              AWS: !Join
-                - ""
-                - - "arn:aws:iam::"
-                  - !FindInMap [
-                      CredentialStoreAccounts,
-                      !Ref Environment,
-                      "AccountNumber",
-                    ]
-                  - ":root"
-            Action: sns:Subscribe
-            Resource:
-              - !Ref UserAccountDeletionTopic
           - Sid: "Allow Account Interventions Service"
             Effect: Allow
             Principal:
@@ -4590,23 +4561,6 @@ Resources:
             Action: kms:*
             Resource:
               - "*"
-          - !If
-            - "IsNotDevelopmentOrDemo"
-            - Effect: Allow
-              Principal:
-                AWS: !Join
-                  - ""
-                  - - "arn:aws:iam::"
-                    - !FindInMap [
-                        CredentialStoreAccounts,
-                        !Ref Environment,
-                        "AccountNumber",
-                      ]
-                    - ":root"
-              Action: kms:Decrypt
-              Resource:
-                - "*"
-            - !Ref AWS::NoValue
           - !If
             - "IsNotDevelopmentOrDemo"
             - Effect: Allow


### PR DESCRIPTION


## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->

### What changed

Remove eVCS access to delete topic.
### Why did it change

This service no longer needs access to our topic as it's switched over to consuming the `AUTH_DELETE_ACCOUNT` audit events.

### Related links

https://govukverify.atlassian.net/browse/OLH-2470

## Checklists

<!-- Merging this PR deploys to production. Please answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed


### Permissions

- [x] This PR adds or changes permissions
