### PR TITLE
OLH-2538: Update Lambda runtime to Node 22

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -172,7 +172,7 @@ Globals:
     MemorySize: 128
     KmsKeyArn: !GetAtt LambdaKMSKey.Arn
     ReservedConcurrentExecutions: 10
-    Runtime: nodejs18.x
+    Runtime: nodejs22.x
     Timeout: 5
     VpcConfig:
       SubnetIds:


### PR DESCRIPTION


## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->

### What changed

Update Lambda runtime to Node 22 from Node 18 as that's about to be deprecated. Our policy[^1] says we should be on the most recent LTS runtime, so that's Node 22.

This is a safe upgrade as we already run our tests locally and in CI using Node 22

[^1]: https://team-manual.account.gov.uk/policies/#active-policies

### Why did it change

Node 18 will be deprecated in September. 

