### PR TITLE
Bau refactor hmrc data delete script

### DIFF
--- a/src/remove-hmrc-events.ts
+++ b/src/remove-hmrc-events.ts
@@ -23,6 +23,7 @@ export const handler = async (): Promise<unknown> => {
           ":urn": "urn:",
         },
         ExclusiveStartKey: lastEvaluatedKey,
+        ProjectionExpression: "user_id, event_id",
       };
 
       const scanResults = await docClient.send(new ScanCommand(scanParams));
@@ -37,7 +38,8 @@ export const handler = async (): Promise<unknown> => {
             .map((item) => ({
               DeleteRequest: {
                 Key: {
-                  user_id: item["user_id"],
+                  user_id: item.user_id,
+                  event_id: item.event_id,
                 },
               },
             }));

--- a/src/remove-hmrc-events.ts
+++ b/src/remove-hmrc-events.ts
@@ -14,6 +14,16 @@ export const handler = async (): Promise<unknown> => {
   const TABLE_NAME = getEnvironmentVariable("TABLE_NAME");
   let lastEvaluatedKey: Record<string, unknown> | undefined = undefined;
 
+  const lastEvaluatedKeyEnvVar = getEnvironmentVariable("LAST_EVALUATED_KEY");
+
+  if (lastEvaluatedKeyEnvVar && lastEvaluatedKeyEnvVar != "undefined") {
+    const split = lastEvaluatedKeyEnvVar.split(",");
+    lastEvaluatedKey = {
+      event_id: split[0].trim(),
+      user_id: split[1].trim(),
+    } as Record<string, unknown>;
+  }
+
   try {
     do {
       const scanParams: ScanCommandInput = {
@@ -56,7 +66,7 @@ export const handler = async (): Promise<unknown> => {
           );
         }
       }
-
+      console.log(lastEvaluatedKey);
       lastEvaluatedKey = scanResults.LastEvaluatedKey;
     } while (lastEvaluatedKey);
 

--- a/src/tests/remove-hmrc-events.test.ts
+++ b/src/tests/remove-hmrc-events.test.ts
@@ -13,6 +13,8 @@ describe("handler", () => {
   beforeEach(() => {
     dynamoMock.reset();
     process.env.TABLE_NAME = "TABLE_NAME";
+    process.env.LAST_EVALUATED_KEY =
+      "5d100f41-66bc-48e8-a7f9-33b82dccffdd,user_id";
   });
 
   afterEach(() => {

--- a/template.yaml
+++ b/template.yaml
@@ -4295,6 +4295,7 @@ Resources:
       Environment:
         Variables:
           TABLE_NAME: !Ref ActivityLogsStoreTableName
+          LAST_EVALUATED_KEY: "undefined"
     Metadata:
       BuildMethod: esbuild
       BuildProperties:

--- a/template.yaml
+++ b/template.yaml
@@ -4289,12 +4289,12 @@ Resources:
       CodeUri: src
       PackageType: Zip
       MemorySize: 1024
-      Timeout: 600
+      Timeout: 900
       Handler: remove-hmrc-events.handler
       Role: !GetAtt RemoveHMRCEventsRole.Arn
       Environment:
         Variables:
-          TABLE_NAME: !Ref UserServicesStoreTableName
+          TABLE_NAME: !Ref ActivityLogsStoreTableName
     Metadata:
       BuildMethod: esbuild
       BuildProperties:


### PR DESCRIPTION
## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->
[BAU] Refactor HMRC data delete script to continue from the last evaluated key

### What changed
<!-- Describe the changes in detail - the "what"-->
enabled passing in the last evaluated key as a env var

### Why did it change
<!-- Describe the reason these changes were made - the "why" -->
In production there are too many records in the activity log table for it to be processed within the 15 min lambda limit. 
This change will allow us to continue from the last completed instead of iterating through all the records that have already been checked. 

## Testing

<!-- Provide a summary of any manual testing you've done, for example deploying the branch to dev -->
Deployed to dev and tested.