### PR TITLE
Olh 2404 warn if unexpected txma client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8184,7 +8184,7 @@
     "node_modules/di-account-management-rp-registry": {
       "name": "di-account-management-client-registry",
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/govuk-one-login/di-account-management-rp-registry.git#19beeb5dd992640eb084812ff951f4745affb8c7",
+      "resolved": "git+ssh://git@github.com/govuk-one-login/di-account-management-rp-registry.git#e95395952f62ba21cf04764e037aba1634d5ffd4",
       "license": "ISC"
     },
     "node_modules/diff": {

--- a/src/format-user-services.ts
+++ b/src/format-user-services.ts
@@ -8,6 +8,7 @@ import {
 } from "./common/model";
 import { sendSqsMessage } from "./common/sqs";
 import { getEnvironmentVariable } from "./common/utils";
+import { getClientIDs } from "di-account-management-rp-registry";
 
 const validateUserService = (service: Service): void => {
   if (
@@ -48,8 +49,16 @@ const validateUser = (user: UserData): void => {
 const HMRC_CLIENT_ID = "7y-bchtHDfucVR5kcAe8KaM80wg";
 
 const validateTxmaEvent = (txmaEvent: TxmaEvent): void => {
-  if (txmaEvent.client_id === HMRC_CLIENT_ID) {
+  const txmaClientId = txmaEvent.client_id;
+
+  if (txmaClientId === HMRC_CLIENT_ID) {
     throw new DroppedEventError(`Event dropped due to non-OLH login via HMRC.`);
+  }
+
+  const ENVIRONMENT = getEnvironmentVariable("ENVIRONMENT");
+
+  if (txmaClientId && !getClientIDs(ENVIRONMENT).includes(txmaClientId)) {
+    console.warn(`The client: "${txmaClientId}" is not in the RP registry.`);
   }
 
   if (

--- a/src/tests/format-activity-log.test.ts
+++ b/src/tests/format-activity-log.test.ts
@@ -31,6 +31,7 @@ describe("handler", () => {
     process.env.TABLE_NAME = tableName;
     process.env.OUTPUT_QUEUE_URL = queueUrl;
     process.env.AWS_REGION = "AWS_REGION";
+    process.env.ENVIRONMENT = "test";
     consoleLogMock = jest.spyOn(global.console, "log").mockImplementation();
     sqsMock.on(SendMessageCommand).resolves({ MessageId: messageId });
   });
@@ -64,6 +65,7 @@ describe("handler", () => {
       sqsMock.reset();
       process.env.TABLE_NAME = tableName;
       process.env.OUTPUT_QUEUE_URL = queueUrl;
+      process.env.ENVIRONMENT = "test";
       sqsMock.on(SendMessageCommand).resolves({ MessageId: messageId });
     });
 

--- a/src/tests/format-activity-log.test.ts
+++ b/src/tests/format-activity-log.test.ts
@@ -60,6 +60,30 @@ describe("handler", () => {
     });
   });
 
+  test("checks rp registry and logs no warnings", async () => {
+    const client_id = "EMGmY82k-92QSakDl_9keKDFmZY"; //home non prod ID
+
+    const TEST_HMRC_EVENT: DynamoDBStreamEvent = {
+      Records: [generateDynamoSteamRecord(client_id)],
+    };
+    console.warn = jest.fn();
+    await handler(TEST_HMRC_EVENT);
+    expect(console.warn).toHaveLength(0);
+  });
+
+  test("warn if client_id doesn't match rp registry", async () => {
+    const client_id = "UNKNOWN";
+
+    const TEST_HMRC_EVENT: DynamoDBStreamEvent = {
+      Records: [generateDynamoSteamRecord(client_id)],
+    };
+    console.warn = jest.fn();
+    await handler(TEST_HMRC_EVENT);
+    expect(console.warn).toHaveBeenCalledWith(
+      'The client: "UNKNOWN" is not in the RP registry.'
+    );
+  });
+
   describe("error handing ", () => {
     beforeEach(() => {
       sqsMock.reset();

--- a/src/tests/format-user-services.test.ts
+++ b/src/tests/format-user-services.test.ts
@@ -355,6 +355,38 @@ describe("handler", () => {
       "Dropped Event encountered and ignored."
     );
   });
+
+  test("no warning message logged as client id is expected", async () => {
+    const emptyServiceList = [] as Service[];
+    const hmrc_client_id = "EMGmY82k-92QSakDl_9keKDFmZY"; //home non prod ID
+    const inputSQSEvent = makeSQSInputFixture([
+      {
+        TxmaEvent: makeTxmaEvent(hmrc_client_id, userId),
+        ServiceList: emptyServiceList,
+      },
+    ]);
+
+    console.warn = jest.fn();
+    await handler({ Records: inputSQSEvent });
+    expect(console.warn).toHaveLength(0);
+  });
+
+  test("logs a warning when client id doesn't match rp registry", async () => {
+    const emptyServiceList = [] as Service[];
+    const hmrc_client_id = "UNKNOWN";
+    const inputSQSEvent = makeSQSInputFixture([
+      {
+        TxmaEvent: makeTxmaEvent(hmrc_client_id, userId),
+        ServiceList: emptyServiceList,
+      },
+    ]);
+
+    console.warn = jest.fn();
+    await handler({ Records: inputSQSEvent });
+    expect(console.warn).toHaveBeenCalledWith(
+      'The client: "UNKNOWN" is not in the RP registry.'
+    );
+  });
 });
 
 describe("handler error handling ", () => {

--- a/src/tests/format-user-services.test.ts
+++ b/src/tests/format-user-services.test.ts
@@ -24,6 +24,15 @@ import { sendSqsMessage } from "../common/sqs";
 const sqsMock = mockClient(SQSClient);
 
 describe("newServicePresenter", () => {
+  beforeEach(() => {
+    process.env.AWS_REGION = "AWS_REGION";
+    process.env.ENVIRONMENT = "test";
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   const TXMA_EVENT = makeTxmaEvent("clientID1234", "userID1234");
 
   test("presents TxmaEvent data as a Service", () => {

--- a/template.yaml
+++ b/template.yaml
@@ -1446,7 +1446,7 @@ Resources:
   FormatUserServicesConsoleWarningsFilter:
     Type: AWS::Logs::MetricFilter
     Properties:
-      FilterPattern: "[w=WARN]"
+      FilterPattern: "WARN"
       LogGroupName: !Ref FormatUserServicesFunctionLogGroup
       MetricTransformations:
         - MetricName: FormatUserServicesWarningsCount
@@ -2915,7 +2915,7 @@ Resources:
   FormatActivityLogConsoleWarningsFilter:
     Type: AWS::Logs::MetricFilter
     Properties:
-      FilterPattern: "[w=WARN]"
+      FilterPattern: "WARN"
       LogGroupName: !Ref FormatActivityLogFunctionLogGroup
       MetricTransformations:
         - MetricName: FormatActivityLogWarningsCount

--- a/template.yaml
+++ b/template.yaml
@@ -1443,6 +1443,42 @@ Resources:
       AlarmActions:
         - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/LowAlertNotificationTopic/ARN}}"
 
+  FormatUserServicesConsoleWarningsFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      FilterPattern: "[w=WARN]"
+      LogGroupName: !Ref FormatUserServicesFunctionLogGroup
+      MetricTransformations:
+        - MetricName: FormatUserServicesWarningsCount
+          MetricNamespace: !Ref SystemTagValue
+          MetricValue: 1
+          Unit: Count
+
+  FormatUserServicesConsoleWarningsAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName:
+        !Join [
+          "-",
+          [
+            !Ref AWS::StackName,
+            !Ref Environment,
+            FormatUserServicesConsoleWarningsAlarm,
+          ],
+        ]
+      AlarmDescription: Triggers when the Lambda function logs console warnings.
+      MetricName: FormatUserServicesWarningsCount
+      Namespace: !Ref SystemTagValue
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+      ActionsEnabled: true
+      AlarmActions:
+        - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/LowAlertNotificationTopic/ARN}}"
+
   #########################
   # Write the User Services
   #########################
@@ -2873,6 +2909,42 @@ Resources:
       Threshold: 0.95
       ComparisonOperator: LessThanThreshold
       EvaluationPeriods: 1
+      AlarmActions:
+        - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/LowAlertNotificationTopic/ARN}}"
+
+  FormatActivityLogConsoleWarningsFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      FilterPattern: "[w=WARN]"
+      LogGroupName: !Ref FormatActivityLogFunctionLogGroup
+      MetricTransformations:
+        - MetricName: FormatActivityLogWarningsCount
+          MetricNamespace: !Ref SystemTagValue
+          MetricValue: 1
+          Unit: Count
+
+  FormatActivityLogConsoleWarningsAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName:
+        !Join [
+          "-",
+          [
+            !Ref AWS::StackName,
+            !Ref Environment,
+            FormatActivityLogConsoleWarningsAlarm,
+          ],
+        ]
+      AlarmDescription: Triggers when the Lambda function logs console warnings.
+      MetricName: FormatActivityLogWarningsCount
+      Namespace: !Ref SystemTagValue
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+      ActionsEnabled: true
       AlarmActions:
         - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/LowAlertNotificationTopic/ARN}}"
 

--- a/template.yaml
+++ b/template.yaml
@@ -1229,6 +1229,7 @@ Resources:
         Variables:
           OUTPUT_QUEUE_URL: !Ref UserServicesToWriteQueue
           NODE_OPTIONS: --enable-source-maps
+          ENVIRONMENT: !Ref Environment
       DeploymentPreference:
         Alarms:
           - !Ref FormatUserServicesFunctionSuccessRate


### PR DESCRIPTION
## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->
[OLH-2404] Trigger an Alarm if we receive a unexpected TXMA Event Client ID

### What changed
<!-- Describe the changes in detail - the "what"-->
Added a check against the rp registry for the txma client ID.
If the ID doesn't match any of the IDs in the client registry, it logs a warning.
This warning is picked up by a log filter and in turn raises an alarm. 
This will let us know if there is a unexpected txma client ID event and potentially allow us to quickly respond to bad data entering our databases.

### Why did it change
<!-- Describe the reason these changes were made - the "why" -->
Improve monitoring for unexpected client ids being processed to our databases.

## Testing
<!-- Provide a summary of any manual testing you've done, for example deploying the branch to dev -->
Deployed and tested in Dev.

[OLH-2404]: https://govukverify.atlassian.net/browse/OLH-2404?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ