### PR TITLE
Olh 2404 filter out internal RPs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6045,7 +6045,7 @@
     "node_modules/di-account-management-rp-registry": {
       "name": "di-account-management-client-registry",
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/govuk-one-login/di-account-management-rp-registry.git#e95395952f62ba21cf04764e037aba1634d5ffd4",
+      "resolved": "git+ssh://git@github.com/govuk-one-login/di-account-management-rp-registry.git#87441e715fc50fec8b0cc5ea31cd545658af0860",
       "license": "ISC"
     },
     "node_modules/diff": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6045,8 +6045,7 @@
     "node_modules/di-account-management-rp-registry": {
       "name": "di-account-management-client-registry",
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/govuk-one-login/di-account-management-rp-registry.git#32c38e9e9c69b867ef16ae5dbcd24d1de7553d38",
-      "integrity": "sha512-ngKrHbmyrjlnVt/R0hsHn5vbp5GcNSLX3BcIZYUJdK2R6bwRVjDkjfGACYBetcF+kVGTdBgMZjMKE9eEovJSiQ==",
+      "resolved": "git+ssh://git@github.com/govuk-one-login/di-account-management-rp-registry.git#e95395952f62ba21cf04764e037aba1634d5ffd4",
       "license": "ISC"
     },
     "node_modules/diff": {

--- a/src/format-user-services.ts
+++ b/src/format-user-services.ts
@@ -8,7 +8,7 @@ import {
 } from "./common/model";
 import { sendSqsMessage } from "./common/sqs";
 import { getEnvironmentVariable } from "./common/utils";
-import { getClientIDs } from "di-account-management-rp-registry";
+import { filterClients, getClientIDs } from "di-account-management-rp-registry";
 
 const validateUserService = (service: Service): void => {
   if (
@@ -46,16 +46,17 @@ const validateUser = (user: UserData): void => {
   }
 };
 
-const HMRC_CLIENT_ID = "7y-bchtHDfucVR5kcAe8KaM80wg";
-
 const validateTxmaEvent = (txmaEvent: TxmaEvent): void => {
   const txmaClientId = txmaEvent.client_id;
-
-  if (txmaClientId === HMRC_CLIENT_ID) {
-    throw new DroppedEventError(`Event dropped due to non-OLH login via HMRC.`);
-  }
-
   const ENVIRONMENT = getEnvironmentVariable("ENVIRONMENT");
+
+  if (
+    filterClients(ENVIRONMENT, { clientType: "internal" }).some(
+      (client) => client.clientId === txmaClientId
+    )
+  ) {
+    throw new DroppedEventError(`Event dropped due to internal RP.`);
+  }
 
   if (txmaClientId && !getClientIDs(ENVIRONMENT).includes(txmaClientId)) {
     console.warn(`The client: "${txmaClientId}" is not in the RP registry.`);

--- a/src/tests/format-activity-log.test.ts
+++ b/src/tests/format-activity-log.test.ts
@@ -110,7 +110,7 @@ describe("handler", () => {
     });
 
     test("drops hmrc events", async () => {
-      const hmrc_client_id = "7y-bchtHDfucVR5kcAe8KaM80wg";
+      const hmrc_client_id = "hmrcGovernmentGateway";
 
       const TEST_HMRC_EVENT: DynamoDBStreamEvent = {
         Records: [

--- a/src/tests/format-user-services.test.ts
+++ b/src/tests/format-user-services.test.ts
@@ -265,6 +265,7 @@ describe("handler", () => {
     process.env.OUTPUT_SQS_NAME = sqsQueueName;
     process.env.OUTPUT_QUEUE_URL = queueURL;
     process.env.AWS_REGION = "AwsRegion";
+    process.env.ENVIRONMENT = "test";
     sqsMock.on(SendMessageCommand).resolves({ MessageId: messageID });
   });
 
@@ -341,7 +342,7 @@ describe("handler", () => {
 
   test("drops hmrc events", async () => {
     const emptyServiceList = [] as Service[];
-    const hmrc_client_id = "7y-bchtHDfucVR5kcAe8KaM80wg";
+    const hmrc_client_id = "hmrcGovernmentGateway";
     const inputSQSEvent = makeSQSInputFixture([
       {
         TxmaEvent: makeTxmaEvent(hmrc_client_id, userId),

--- a/template.yaml
+++ b/template.yaml
@@ -122,6 +122,8 @@ Conditions:
           - !Ref TestRoleArn
           - "none"
 
+  IsProduction: !Equals [!Ref Environment, production]
+
 Globals:
   Function:
     Environment:
@@ -1456,6 +1458,7 @@ Resources:
 
   FormatUserServicesConsoleWarningsAlarm:
     Type: AWS::CloudWatch::Alarm
+    Condition: IsProduction
     Properties:
       AlarmName:
         !Join [
@@ -2880,6 +2883,7 @@ Resources:
 
   FormatActivityLogConsoleWarningsAlarm:
     Type: AWS::CloudWatch::Alarm
+    Condition: IsProduction
     Properties:
       AlarmName:
         !Join [


### PR DESCRIPTION
## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->
[OLH-2404] Filter out internal RPs in Backend Lambda's

### What changed

<!-- Describe the changes in detail - the "what"-->
Following the implementation of the internal category in the RP registry, we are now about to filter out data that doesn't need to to enter out database.

### Why did it change
<!-- Describe the reason these changes were made - the "why" -->
Orgnaise known RPs.



[OLH-2404]: https://govukverify.atlassian.net/browse/OLH-2404?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ