### PR TITLE
Olh 2294 backend lambda event triggers are not pointing to live alias

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6045,8 +6045,7 @@
     "node_modules/di-account-management-rp-registry": {
       "name": "di-account-management-client-registry",
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/govuk-one-login/di-account-management-rp-registry.git#2acbd5dbbf3c6274e4bdbb2c6c5e7110e5d1c6a4",
-      "integrity": "sha512-SqtMkkPvdXb2OgcvJb1RF4kyJHNtlbp+lLt3FndOAmsnY6N/letbwhYkROey62e2UEFc4NVXBUiElaxjIK01pQ==",
+      "resolved": "git+ssh://git@github.com/govuk-one-login/di-account-management-rp-registry.git#e95395952f62ba21cf04764e037aba1634d5ffd4",
       "license": "ISC"
     },
     "node_modules/diff": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6045,7 +6045,7 @@
     "node_modules/di-account-management-rp-registry": {
       "name": "di-account-management-client-registry",
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/govuk-one-login/di-account-management-rp-registry.git#e95395952f62ba21cf04764e037aba1634d5ffd4",
+      "resolved": "git+ssh://git@github.com/govuk-one-login/di-account-management-rp-registry.git#87441e715fc50fec8b0cc5ea31cd545658af0860",
       "license": "ISC"
     },
     "node_modules/diff": {

--- a/template.yaml
+++ b/template.yaml
@@ -1769,7 +1769,7 @@ Resources:
   DeleteUserServicesSubscription:
     Type: AWS::SNS::Subscription
     Properties:
-      Endpoint: !GetAtt DeleteUserServicesFunction.Arn
+      Endpoint: !Join [":", [!GetAtt DeleteUserServicesFunction.Arn, live]]
       Protocol: lambda
       RedrivePolicy:
         deadLetterTargetArn: !GetAtt UserAccountDeletionTopicDeadLetterQueue.Arn
@@ -1782,7 +1782,7 @@ Resources:
       Principal: sns.amazonaws.com
       SourceArn:
         Ref: UserAccountDeletionTopic
-      FunctionName: !GetAtt DeleteUserServicesFunction.Arn
+      FunctionName: !Join [":", [!GetAtt DeleteUserServicesFunction.Arn, live]]
 
   DeleteUserServicesFunction:
     DependsOn:
@@ -2067,7 +2067,8 @@ Resources:
   DeleteEmailSubscriptionsSubscription:
     Type: AWS::SNS::Subscription
     Properties:
-      Endpoint: !GetAtt DeleteEmailSubscriptionsFunction.Arn
+      Endpoint:
+        !Join [":", [!GetAtt DeleteEmailSubscriptionsFunction.Arn, live]]
       Protocol: lambda
       RedrivePolicy:
         deadLetterTargetArn: !GetAtt UserAccountDeletionTopicSubscriptionDeleteEmailSubscriptionsDeadLetterQueue.Arn
@@ -2104,7 +2105,8 @@ Resources:
       Principal: sns.amazonaws.com
       SourceArn:
         Ref: UserAccountDeletionTopic
-      FunctionName: !GetAtt DeleteEmailSubscriptionsFunction.Arn
+      FunctionName:
+        !Join [":", [!GetAtt DeleteEmailSubscriptionsFunction.Arn, live]]
 
   DeleteEmailSubscriptionsFunction:
     Type: AWS::Serverless::Function
@@ -2914,7 +2916,7 @@ Resources:
   DeleteActivityLogSubscription:
     Type: AWS::SNS::Subscription
     Properties:
-      Endpoint: !GetAtt DeleteActivityLogFunction.Arn
+      Endpoint: !Join [":", [!GetAtt DeleteActivityLogFunction.Arn, live]]
       Protocol: lambda
       RedrivePolicy:
         deadLetterTargetArn: !GetAtt DeleteActivityLogSubscriptionDeadLetterQueue.Arn
@@ -3065,7 +3067,7 @@ Resources:
       Principal: sns.amazonaws.com
       SourceArn:
         Ref: UserAccountDeletionTopic
-      FunctionName: !GetAtt DeleteActivityLogFunction.Arn
+      FunctionName: !Join [":", [!GetAtt DeleteActivityLogFunction.Arn, live]]
 
   DeleteActivityLogFunctionLogGroup:
     Type: AWS::Logs::LogGroup
@@ -3320,7 +3322,8 @@ Resources:
       Principal: sns.amazonaws.com
       SourceArn:
         Ref: SuspiciousActivityTopic
-      FunctionName: !GetAtt MarkActivityReportedFunction.Arn
+      FunctionName:
+        !Join [":", [!GetAtt MarkActivityReportedFunction.Arn, live]]
 
   MarkActivityReportedLogGroup:
     Type: AWS::Logs::LogGroup
@@ -3459,7 +3462,8 @@ Resources:
       Principal: sns.amazonaws.com
       SourceArn:
         Ref: SuspiciousActivityTopic
-      FunctionName: !GetAtt SendSuspiciousActivityFunction.Arn
+      FunctionName:
+        !Join [":", [!GetAtt SendSuspiciousActivityFunction.Arn, live]]
 
   SendSuspiciousActivityFunctionLogGroup:
     Type: AWS::Logs::LogGroup
@@ -3612,7 +3616,7 @@ Resources:
       Principal: sns.amazonaws.com
       SourceArn:
         Ref: SuspiciousActivityTopic
-      FunctionName: !GetAtt SendConfEmailFunction.Arn
+      FunctionName: !Join [":", [!GetAtt SendConfEmailFunction.Arn, live]]
 
   SendConfEmailFunctionLogGroup:
     Type: AWS::Logs::LogGroup
@@ -3809,7 +3813,7 @@ Resources:
       Principal: sns.amazonaws.com
       SourceArn:
         Ref: SuspiciousActivityTopic
-      FunctionName: !GetAtt CreateSupportTicketFunction.Arn
+      FunctionName: !Join [":", [!GetAtt CreateSupportTicketFunction.Arn, live]]
 
   CreateSupportTicketFunctionLogGroup:
     Type: AWS::Logs::LogGroup
@@ -3878,7 +3882,8 @@ Resources:
   TriggerSuspiciousActivityStepSubscription:
     Type: AWS::SNS::Subscription
     Properties:
-      Endpoint: !GetAtt TriggerSuspiciousActivityStepFunction.Arn
+      Endpoint:
+        !Join [":", [!GetAtt TriggerSuspiciousActivityStepFunction.Arn, live]]
       Protocol: lambda
       RedrivePolicy:
         deadLetterTargetArn: !GetAtt TriggerSuspiciousActivityStepDeadLetterQueue.Arn
@@ -4023,7 +4028,8 @@ Resources:
       Principal: sns.amazonaws.com
       SourceArn:
         Ref: SuspiciousActivityTopic
-      FunctionName: !GetAtt TriggerSuspiciousActivityStepFunction.Arn
+      FunctionName:
+        !Join [":", [!GetAtt TriggerSuspiciousActivityStepFunction.Arn, live]]
 
   TriggerSuspiciousActivityStepFunctionLogGroup:
     Type: AWS::Logs::LogGroup
@@ -4342,7 +4348,7 @@ Resources:
     Type: AWS::Lambda::Permission
     Properties:
       Action: lambda:InvokeFunction
-      FunctionName: !Ref WriteActivityLogFunction
+      FunctionName: !Join [":", [!Ref WriteActivityLogFunction, live]]
       Principal: !Ref TestRoleArn
 
   DeleteActivityLogFunctionTestPolicy:
@@ -4350,7 +4356,7 @@ Resources:
     Type: AWS::Lambda::Permission
     Properties:
       Action: lambda:InvokeFunction
-      FunctionName: !Ref DeleteActivityLogFunction
+      FunctionName: !Join [":", [!Ref DeleteActivityLogFunction, live]]
       Principal: !Ref TestRoleArn
 
   #######################


### PR DESCRIPTION
## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->
[OLH-2294] Point SNS topics and Permissions to alias live version of backend Lambda's

### What changed

<!-- Describe the changes in detail - the "what"-->
Pointed SNS topics and permissions to live version of lambda's.

### Why did it change
<!-- Describe the reason these changes were made - the "why" -->
We introduced the live alias following the implementation of canary deployments. However, some of the event triggers were still pointing to the function instead of the live alias. This meant that during canary deployment, the wrong lambda versions were being tested for some lambda's.
### Permissions

- [ ] This PR adds or changes permissions

## Testing

<!-- Provide a summary of any manual testing you've done, for example deploying the branch to dev -->
Deployed to dev and validated.

[OLH-2294]: https://govukverify.atlassian.net/browse/OLH-2294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ