### PR TITLE
BAU: Increase timeout of delete activity log lambda

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -2981,6 +2981,7 @@ Resources:
       FunctionName: !Sub ${Environment}-${AWS::StackName}-delete-activity-log
       CodeUri: src
       PackageType: Zip
+      Timeout: 10
       DeadLetterQueue:
         Type: SQS
         TargetArn: !GetAtt DeleteActivityLogDeadLetterQueue.Arn


### PR DESCRIPTION


## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->

### What changed

Double the timeout of the delete activity log lambda to 10s. 

### Why did it change

This lambda seems to timeout once every couple of weeks. When we retry the event it always succeeds. It does seem to sometimes take a long time to delete items from the table (users can have many entries) so increasing the timeout will hopefully stop our alarms going off.

## Checklists

<!-- Merging this PR deploys to production. Please answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed