### PR TITLE
OLH-2644: add commit message linting

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -1,0 +1,20 @@
+[general]
+verbosity=3
+ignore=body-is-missing
+ignore-fixup-commits=false
+ignore-fixup-amend-commits=false
+ignore-squash-commits=false
+regex-style-search=true
+staged=true
+
+[title-max-length]
+line-length=72
+
+[title-min-length]
+min-length=10
+
+[title-match-regex]
+regex=^(BAU|OLH-[0-9]{1,4})[: ]+\w
+
+[author-valid-email]
+regex=[\w\.\+_-]+@(digital.cabinet-office.gov.uk|dsit.gov.uk|users.noreply.github.com)

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,1 @@
+cat $1 | gitlint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,0 @@
-repos:
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.1.0
-    hooks:
-      - id: prettier
-        additional_dependencies:
-          - prettier@3.2.5

--- a/README.md
+++ b/README.md
@@ -20,14 +20,14 @@ We transpile and package the Lambda functions using `sam build`. This needs `esb
 npm install -g esbuild
 ```
 
-### Pre-commit
+### Gitlint
 
-This repository uses [pre-commit](https://pre-commit.com/) to run linting on all staged files before they're committed.
-Install & setup pre-commit by running:
+This repository uses [Gitlint](https://jorisroovers.com/gitlint/latest/) to lint git commit messages.
+
+Install Gitlint by running:
 
 ```bash
-pip install pre-commit
-pre-commit install
+pip install gitlint # or `brew install gitlint` if using the brew package manager
 ```
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This repository uses [Gitlint](https://jorisroovers.com/gitlint/latest/) to lint
 Install Gitlint by running:
 
 ```bash
-pip install gitlint # or `brew install gitlint` if using the brew package manager
+pip install gitlint # or `brew install gitlint` if using the Homebrew package manager
 ```
 
 ## Testing


### PR DESCRIPTION
### What changed

- Removed `pre-commit` config and README instructions as it is no longer used as Husky is used for Git hooks instead
- Added Gitlint config
- Added Gitlint instructions to README
- Added `commit-msg` Git hook using Husky which pipes the commit message to Gitlint

### Why did it change

To ensure commit messages are consistently formatted, including the Jira ticket number

### Related links

https://govukverify.atlassian.net/browse/OLH-2644

## Checklists

<!-- Merging this PR deploys to production. Please answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Permissions

- [ ] This PR adds or changes permissions
