### PR TITLE
OLH-2357: Increase lambda timeouts

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -947,6 +947,7 @@ Resources:
       CodeUri: src
       PackageType: Zip
       MemorySize: 250
+      Timeout: 10
       Events:
         DynamoStream:
           Type: DynamoDB
@@ -1494,6 +1495,7 @@ Resources:
       FunctionName: !Sub ${Environment}-${AWS::StackName}-write-user-services
       CodeUri: src
       PackageType: Zip
+      Timeout: 10
       MemorySize: 220
       Events:
         UserServicesToWriteQueue:


### PR DESCRIPTION
## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->
[OLH-2357] Increase Lambda Timeouts

### What changed
<!-- Describe the changes in detail - the "what"-->
Increased the query-user-services lambda timeout to 10s
Increased the write-user-services lambda timeout to 10s

### Why did it change
<!-- Describe the reason these changes were made - the "why" -->
These lambda's intermittently timeout due to down stream cold starts. They do make their way back to a DLQ and get retried. With this change it will allow for the existing Lambda process to execute. When the downstream cold starts are completed, we can still expect the lamdba to execute in less than 5s.

### Related links
<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->
https://govukverify.atlassian.net/browse/OLH-2357

[OLH-2357]: https://govukverify.atlassian.net/browse/OLH-2357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ