### PR TITLE
OLH-2775: Remove start and finish processing logs

### DIFF
--- a/src/create-support-ticket.ts
+++ b/src/create-support-ticket.ts
@@ -123,7 +123,6 @@ export const handler = async (
       "ZENDESK_TICKET_FORM_ID"
     );
     const ACTIVITY_LOG_TABLE = getEnvironmentVariable("ACTIVITY_LOG_TABLE");
-    logger.info(`started processing event with ID: ${eventIdentifier}`);
     validateSuspiciousActivity(input);
     const zendeskUserName = await getSecret(ZENDESK_API_USER_KEY, {
       maxAge: 900,
@@ -191,7 +190,6 @@ export const handler = async (
         );
       }
     }
-    logger.info(`finished processing event with ID: ${eventIdentifier}`);
     return input;
   } catch (error) {
     throw new Error(

--- a/src/format-user-services.ts
+++ b/src/format-user-services.ts
@@ -150,17 +150,11 @@ export const handler = async (
   await Promise.all(
     Records.map(async (record) => {
       try {
-        logger.info(`started processing message with ID: ${record.messageId}`);
         const formattedRecord = formatRecord(validateAndParseSQSRecord(record));
-        const { MessageId: messageId } = await sendSqsMessage(
-          JSON.stringify(formattedRecord),
-          OUTPUT_QUEUE_URL
-        );
-        logger.info(`[Message sent to QUEUE] with message id = ${messageId}`);
-        logger.info(`finished processing message with ID: ${record.messageId}`);
+        await sendSqsMessage(JSON.stringify(formattedRecord), OUTPUT_QUEUE_URL);
       } catch (error) {
         if (error instanceof DroppedEventError) {
-          logger.info("Dropped Event encountered and ignored.");
+          logger.info(error.message);
         } else {
           throw new Error(
             `Unable to format user services for message with ID: ${record.messageId}, ${

--- a/src/mark-activity-reported.ts
+++ b/src/mark-activity-reported.ts
@@ -92,7 +92,6 @@ export const handler = async (
   context: Context
 ): Promise<ReportSuspiciousActivityEvent> => {
   logger.addContext(context);
-  logger.info(`started processing event with ID: ${input.event_id}`);
   const activityLog = await queryActivityLog(input.user_id, input.event_id);
   const event_id = `${crypto.randomUUID()}`;
   const timestamps = getCurrentTimestamp();
@@ -150,6 +149,5 @@ export const handler = async (
   if (input.device_information) {
     reportedEvent.device_information = input.device_information;
   }
-  logger.info(`finished processing event with ID: ${input.event_id}`);
   return reportedEvent;
 };

--- a/src/save-raw-events.ts
+++ b/src/save-raw-events.ts
@@ -76,11 +76,9 @@ export const handler = async (
   await Promise.all(
     event.Records.map(async (record) => {
       try {
-        logger.info(`Started processing message with ID: ${record.messageId}`);
         const txmaEvent: TxmaEvent = JSON.parse(record.body);
         validateTxmaEventBody(txmaEvent);
         await writeRawTxmaEvent(txmaEvent);
-        logger.info(`Finished processing message with ID: ${record.messageId}`);
       } catch (error) {
         throw new Error(
           `Unable to save raw events for message with ID: ${record.messageId}, ${

--- a/src/send-conf-email.ts
+++ b/src/send-conf-email.ts
@@ -116,7 +116,6 @@ export const handler = async (
   const NOTIFY_API_KEY = getEnvironmentVariable("NOTIFY_API_KEY");
   const TEMPLATE_ID = getEnvironmentVariable("TEMPLATE_ID");
   try {
-    logger.info(`started processing event with ID: ${input.event_id}`);
     const notifyApiKey = await getSecret(NOTIFY_API_KEY, {
       maxAge: 900,
     });
@@ -129,7 +128,6 @@ export const handler = async (
     if (response?.data?.id) {
       input.notify_message_id = response.data.id;
     }
-    logger.info(`finished processing event with ID: ${input.event_id}`);
     return input;
   } catch (error) {
     logger.error(

--- a/src/send-suspicious-activity.ts
+++ b/src/send-suspicious-activity.ts
@@ -100,7 +100,6 @@ export const handler = async (
   const EVENT_NAME = getEnvironmentVariable("EVENT_NAME");
   const TXMA_QUEUE_URL = getEnvironmentVariable("TXMA_QUEUE_URL");
   try {
-    logger.info(`started processing event with ID: ${input.event_id}`);
     if (!validateObject(input, VALIDATOR_RULES_MAP.get(EVENT_NAME))) {
       throw new Error(
         `Received Event: ${JSON.stringify(input)} failed validation.`
@@ -122,7 +121,6 @@ export const handler = async (
       );
     }
     await sendAuditEvent(txMAEvent, TXMA_QUEUE_URL);
-    logger.info(`finished processing event with ID: ${input.event_id}`);
   } catch (err: unknown) {
     throw new Error(
       `Error occurred sending event to TxMA: ${(err as Error).message}`

--- a/src/tests/format-activity-log.test.ts
+++ b/src/tests/format-activity-log.test.ts
@@ -43,9 +43,9 @@ describe("handler", () => {
 
   test("Ignores any Non allowed event", async () => {
     await handler(MUCKY_DYNAMODB_STREAM_EVENT, {} as Context);
-    expect(loggerInfoMock).toHaveBeenCalledTimes(3);
+    expect(loggerInfoMock).toHaveBeenCalledTimes(1);
     expect(loggerInfoMock).toHaveBeenCalledWith(
-      `DB stream sent a ${randomEventType} event. Irrelevant for activity log so ignoring`
+      `DB stream sent a ${randomEventType} event. Ignoring.`
     );
   });
 
@@ -124,7 +124,7 @@ describe("handler", () => {
       await handler(TEST_HMRC_EVENT, {} as Context);
       expect(sqsMock.commandCalls(SendMessageCommand).length).toEqual(0);
       expect(Logger.prototype.info).toHaveBeenCalledWith(
-        "Dropped Event encountered and ignored."
+        "Event dropped due to internal RP."
       );
     });
   });

--- a/src/tests/format-user-services.test.ts
+++ b/src/tests/format-user-services.test.ts
@@ -354,7 +354,7 @@ describe("handler", () => {
     Logger.prototype.info = jest.fn();
     await handler({ Records: inputSQSEvent }, {} as Context);
     expect(Logger.prototype.info).toHaveBeenCalledWith(
-      "Dropped Event encountered and ignored."
+      "Event dropped due to internal RP."
     );
   });
 

--- a/src/tests/write-user-services.test.ts
+++ b/src/tests/write-user-services.test.ts
@@ -70,7 +70,7 @@ describe("lambdaHandler", () => {
         errorMessage = (error as Error).message;
       }
       expect(errorMessage).toContain(
-        "Unable to write user sercjces for message with ID: 19dd0b57-b21e-4ac1-bd88-01bbb068cb78, mock error"
+        "Unable to write user services for message with ID: 19dd0b57-b21e-4ac1-bd88-01bbb068cb78, mock error"
       );
     });
   });

--- a/src/write-activity-log.ts
+++ b/src/write-activity-log.ts
@@ -50,7 +50,6 @@ export const handler = async (
   await Promise.all(
     event.Records.map(async (record) => {
       try {
-        logger.info(`Started processing message with ID: ${record.messageId}`);
         const activityLogEntry: ActivityLogEntry = JSON.parse(record.body);
         validateActivityLogEntry(activityLogEntry);
         const encryptedActivityLog: EncryptedActivityLogEntry = {
@@ -66,7 +65,6 @@ export const handler = async (
           reported_suspicious: activityLogEntry.reported_suspicious,
         };
         await writeActivityLogEntry(encryptedActivityLog);
-        logger.info(`Finished processing message with ID: ${record.messageId}`);
       } catch (error) {
         throw new Error(
           `Unable to write activity log for message with ID: ${record.messageId}, ${

--- a/src/write-user-services.ts
+++ b/src/write-user-services.ts
@@ -7,12 +7,10 @@ import {
 } from "@aws-sdk/lib-dynamodb";
 import { Service, UserServices } from "./common/model";
 import { getEnvironmentVariable } from "./common/utils";
-import { Logger } from "@aws-lambda-powertools/logger";
 
 const dynamoDocClient = DynamoDBDocumentClient.from(new DynamoDBClient({}), {
   marshallOptions: { convertClassInstanceToMap: true },
 });
-const logger = new Logger();
 
 export const validateService = (service: Service): void => {
   const {
@@ -55,14 +53,12 @@ export const handler = async (event: SQSEvent): Promise<void> => {
   await Promise.all(
     event.Records.map(async (record) => {
       try {
-        logger.info(`Started processing message with ID: ${record.messageId}`);
         const userServices: UserServices = JSON.parse(record.body);
         validateUserServices(userServices);
         await writeUserServices(userServices);
-        logger.info(`Finished processing message with ID: ${record.messageId}`);
       } catch (error) {
         throw new Error(
-          `Unable to write user sercjces for message with ID: ${record.messageId}, ${
+          `Unable to write user services for message with ID: ${record.messageId}, ${
             (error as Error).message
           }`
         );


### PR DESCRIPTION
## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->

### What changed

Remove start and finish processing logs from all the Lambdas.

### Why did it change

We're getting close to breaching the GDS-wide Splunk data quota and teams have been asked to check their logging and reduce where possible.

Our backend emits about 10 million log events per day and these processing messages are the vast majority of that.

We initially added them to help with debugging or tracing a message through the system. In practice we've never used the message IDs in the ~3 years that these data pipelines have been running. Failed events are put on the DLQs anyway, so if we do need to see the IDs we can always pull the messages from the DLQ and see the IDs. The built in Lambda logs also contain a request ID to look at all logs in that execution.

I've left all the error messages in place so we're not losing any information when we do need to debug a problem.

### Related links

https://gds.slack.com/archives/C049ASDACJV/p1749715968265739

## Checklists

<!-- Merging this PR deploys to production. Please answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed
