### PR TITLE
OLH-2737: Update GOV UK App to be unique client type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8381,7 +8381,7 @@
     "node_modules/di-account-management-rp-registry": {
       "name": "di-account-management-client-registry",
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/govuk-one-login/di-account-management-rp-registry.git#3ac9a93b1eefe2f07961b68f9a303bf2a69acc9d",
+      "resolved": "git+ssh://git@github.com/govuk-one-login/di-account-management-rp-registry.git#676a3b02e4eb71e14374b421725878e84a737b95",
       "license": "ISC"
     },
     "node_modules/diff": {


### PR DESCRIPTION
## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->
[OLH-2737] Change Gov UK App to a unique client ID

### What changed
<!-- Describe the changes in detail - the "what"-->
Added Gov UK App to it's own unique client ID as it doesn't follow other client type behaviours.

### Why did it change
<!-- Describe the reason these changes were made - the "why" -->
To make GOV UK App show in activity log but not elsewhere


[OLH-2737]: https://govukverify.atlassian.net/browse/OLH-2737?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ