### PR TITLE
OLH-2839: Tag persistent tables for backup

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -123,6 +123,11 @@ Conditions:
 
   IsProduction: !Equals [!Ref Environment, production]
 
+  BackupEnabled: !Or
+    - !Equals [!Ref Environment, staging]
+    - !Equals [!Ref Environment, integration]
+    - !Equals [!Ref Environment, production]
+
 Globals:
   Function:
     Environment:
@@ -471,6 +476,8 @@ Resources:
           Value: !Ref "Environment"
         - Key: Source
           Value: "https://github.com/alphagov/di-account-management-backend/blob/main/infrastructre/template.yaml"
+        - Key: BackupFrequency
+          Value: !If [BackupEnabled, "Bihourly", ""]
       PointInTimeRecoverySpecification:
         PointInTimeRecoveryEnabled: true
       SSESpecification:
@@ -519,6 +526,8 @@ Resources:
           Value: !Ref "Environment"
         - Key: Source
           Value: "https://github.com/alphagov/di-account-management-backend/blob/main/infrastructre/template.yaml"
+        - Key: BackupFrequency
+          Value: !If [BackupEnabled, "Bihourly", ""]
       PointInTimeRecoverySpecification:
         PointInTimeRecoveryEnabled: true
       SSESpecification:


### PR DESCRIPTION
## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->

### What changed

Tag persistent tables for backup in staging, integration and production.

Note I've used an empty string as the tag value when the `BackupEnabled` condition is false. Semantically it'd be nicer to use `AWS::NoValue` but that'll cause an error when we try to deploy to any environment when the condition is false. I couldn't get the linter to be happy when conditionally setting the tag, so this is the least bad solution.

### Why did it change

Adding these tags means the backup-as-a-service system will take snapshots of these two tables every 120 minutes.

See https://github.com/govuk-one-login/backup-as-a-service for more details.

## Checklists

<!-- Merging this PR deploys to production. Please answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

## How to review

Please check against the documentation in the backup-as-a-service README and check I've spelled `Bihourly` correctly.
