### PR TITLE
OLH-3061: hardcode Dynatrace layer ARN

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -195,14 +195,7 @@ Globals:
       - !Ref PermissionsBoundary
       - !Ref AWS::NoValue
     Layers:
-      - !Sub
-        - "{{resolve:secretsmanager:${SecretArn}:SecretString:NODEJS_LAYER}}"
-        - SecretArn:
-            !FindInMap [
-              EnvironmentConfiguration,
-              !Ref Environment,
-              dynatraceSecretArn,
-            ]
+      - arn:aws:lambda:eu-west-2:216552277552:layer:Dynatrace_OneAgent_1_311_2_20250307-045250_with_collector_nodejs:1
     AutoPublishAlias: live
     DeploymentPreference:
       Type: !Ref LambdaDeploymentPreference


### PR DESCRIPTION
### What changed

Hardcodes the Dynatrace layer ARN. This is not the latest ARN which will come in a subsequent PR.

### Why did it change

There’s a bug in the `{{resolve:secretsmanager}}` syntax that prevents the current configuration from deploying the latest available Dynatrace layer. The fix is to just hardcode the layer ARN and manually keep it up to date.