### PR TITLE
OLH-3098: Remind us to monitor risky changes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -34,6 +34,10 @@
 
 - [ ] This PR adds or changes permissions
 
+### Monitoring
+
+- [ ] This PR includes changes that need to be monitored in production as the scope of the change could cause issues
+
 ## Testing
 
 <!-- Provide a summary of any manual testing you've done, for example deploying the branch to dev -->


### PR DESCRIPTION


## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->

### What changed

Add a checklist item in the PR template for extra risky PRs. I also formatted the template file with Prettier; it must be excluded from our normal linting checks.


### Why did it change

This is an action coming out of a recent retro. Hopefully having a checklist item in the PR template will remind us to flag any particularly risky changes at the review stage so we can
1. Review even more carefully
2. Be aware when we merge it and keep a close eye on the deployment

### Related links

https://github.com/govuk-one-login/di-account-management-frontend/pull/2459
