### PR TITLE
BAU: bump Sonar action version to address vulnerability

### DIFF
--- a/.github/workflows/sonarcloud.yaml
+++ b/.github/workflows/sonarcloud.yaml
@@ -25,7 +25,7 @@ jobs:
         run: yarn test:cov
 
       - name: SonarCloud Scan
-        uses: SonarSource/sonarqube-scan-action@0303d6b62e310685c0e34d0b9cde218036885c4d # pin@v5.0.0
+        uses: SonarSource/sonarqube-scan-action@1a6d90ebcb0e6a6b1d87e37ba693fe453195ae25 # pin@v5.3.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
Bump the Sonar GitHub Action version to address the vulnerability described at https://community.sonarsource.com/t/security-advisory-sonarqube-scanner-github-action/147696/15