### PR TITLE
OLH-2976: Use all 3 subnets in the new VPC

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -184,6 +184,7 @@ Globals:
       SubnetIds:
         - Fn::ImportValue: !Sub "${VpcStackName}-ProtectedSubnetIdA"
         - Fn::ImportValue: !Sub "${VpcStackName}-ProtectedSubnetIdB"
+        - Fn::ImportValue: !Sub "${VpcStackName}-ProtectedSubnetIdC"
       SecurityGroupIds:
         - Fn::ImportValue: !Sub ${VpcStackName}-AWSServicesEndpointSecurityGroupId
     CodeSigningConfigArn: !If

--- a/template.yaml
+++ b/template.yaml
@@ -35,7 +35,7 @@ Parameters:
       The name of the stack that defines the VPC in which this container will
       run.
     Type: String
-    Default: vpc-enhanced
+    Default: dev-platform-vpc
   CodeSigningConfigArn:
     Type: String
     Description: >


### PR DESCRIPTION
## Proposed changes

### What changed

Update the global configuration for our lambdas to use all 3 availability zones, now the new VPC has subnets in all of them. I will keep an eye on this as it rolls out.

I've deployed the branch to dev and it all looks ok there.

### Why did it change

This will cover us in a disaster situation where 2 of the 3 AZs go down.

### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists

<!-- Merging this PR deploys to production. Please answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Monitoring

- [x] This PR includes changes that need to be monitored in production as the scope of the change could cause issues
