### PR TITLE
BAU: Don't alarm on delete email deploy errors

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -2177,9 +2177,6 @@ Resources:
               GOVACCOUNTSPUBLISHINGAPIURL,
             ]
           NODE_OPTIONS: --enable-source-maps
-      DeploymentPreference:
-        Alarms:
-          - !Ref DeleteEmailSubscriptionsFunctionSuccessRate
     Metadata:
       BuildMethod: esbuild
       BuildProperties:


### PR DESCRIPTION
## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->

### What changed

Temporarily remove this alarm as it's causing every integration deployment to fail at the canary check stage.

I've deployed this to dev to check Cloudformation is happy with the empty list.

### Why did it change

I think there's something not working in the Lambda, so doing this will allow us to make deployments again while we investigate and fix whatever's broken.

### Related links

https://gds.slack.com/archives/C011Y5SAY3U/p1759139968080249

## Checklists

<!-- Merging this PR deploys to production. Please answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

