### PR TITLE
BAU: no major update of ua-parser-js

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,9 @@ updates:
     ignore:
       - dependency-name: "node"
         versions: ["17.x", "18.x", "19.x"]
+      # Exclude major version updates - next major version has incompatible license
+      - dependency-name: "ua-parser-js"
+        update-types: ["version-update:semver-major"]
     commit-message:
       prefix: BAU
     groups:


### PR DESCRIPTION
Updates the dependabot config to exclude major versions of `ua-parser-js`. We can't go to the next major version of `ua-parser-js` due to licence incompatibility.