### PR TITLE
Revert "OLH-2976: Use all 3 subnets in the new VPC"

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -35,7 +35,7 @@ Parameters:
       The name of the stack that defines the VPC in which this container will
       run.
     Type: String
-    Default: dev-platform-vpc
+    Default: vpc-enhanced
   CodeSigningConfigArn:
     Type: String
     Description: >
@@ -184,7 +184,6 @@ Globals:
       SubnetIds:
         - Fn::ImportValue: !Sub "${VpcStackName}-ProtectedSubnetIdA"
         - Fn::ImportValue: !Sub "${VpcStackName}-ProtectedSubnetIdB"
-        - Fn::ImportValue: !Sub "${VpcStackName}-ProtectedSubnetIdC"
       SecurityGroupIds:
         - Fn::ImportValue: !Sub ${VpcStackName}-AWSServicesEndpointSecurityGroupId
     CodeSigningConfigArn: !If


### PR DESCRIPTION
Reverts govuk-one-login/di-account-management-backend#742

The frontend is too complex to migrate at this time, so we're going to migrate the stubs and backend back to the old VPC stack until it's necessary (likely when transit gateway comes along).