### PR TITLE
AUT-5588: Give Auth new AWS account access to publish SNS topic 

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -236,6 +236,20 @@ Mappings:
     production:
       AccountNumber: "172348255554"
 
+  AuthenticationAccounts:
+    demo:
+      AccountNumber: ""
+    dev:
+      AccountNumber: ""
+    build:
+      AccountNumber: ""
+    staging:
+      AccountNumber: "851725205974"
+    integration:
+      AccountNumber: "211125600642"
+    production:
+      AccountNumber: "211125303002"
+
   EnvironmentVariables:
     ### These environment variables are referenced further down the file.
     ### Please ensure that any variables defined for an environment are defined for _all_ environments.
@@ -1772,6 +1786,24 @@ Resources:
                   - - "arn:aws:iam::"
                     - !FindInMap [
                         OrchestrationAccounts,
+                        !Ref Environment,
+                        "AccountNumber",
+                      ]
+                    - ":root"
+              Action: sns:Publish
+              Resource:
+                - !Ref UserAccountDeletionTopic
+            - !Ref AWS::NoValue
+          - !If
+            - "UseExternalEvents"
+            - Sid: "Allow Authentication Accounts to publish"
+              Effect: Allow
+              Principal:
+                AWS: !Join
+                  - ""
+                  - - "arn:aws:iam::"
+                    - !FindInMap [
+                        AuthenticationAccounts,
                         !Ref Environment,
                         "AccountNumber",
                       ]
@@ -4558,6 +4590,27 @@ Resources:
                   - - "arn:aws:iam::"
                     - !FindInMap [
                         OrchestrationAccounts,
+                        !Ref Environment,
+                        "AccountNumber",
+                      ]
+                    - ":root"
+              Action:
+                - kms:Decrypt
+                - kms:Encrypt
+                - kms:ReEncrypt*
+                - kms:GenerateDataKey*
+              Resource:
+                - "*"
+            - !Ref AWS::NoValue
+          - !If
+            - "UseExternalEvents"
+            - Effect: Allow
+              Principal:
+                AWS: !Join
+                  - ""
+                  - - "arn:aws:iam::"
+                    - !FindInMap [
+                        AuthenticationAccounts,
                         !Ref Environment,
                         "AccountNumber",
                       ]


### PR DESCRIPTION

## Proposed changes

AUT-5588: 
1) Give Auth new AWS account access to publish to user account deletion SNS topic 
2) Allow new auth access to KMS attached to SNS opic 


### What changed

SNS and KMS key policy updated to give access to new Auth account 

### Why did it change

Auth manual Account deletion lambda is now Migrated to new Auth Account , hence new account need access to SNS and KMS 

### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists

<!-- Merging this PR deploys to production. Please answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

