### PR TITLE
BAU: restrict post-merge workflow to main branch only

### DIFF
--- a/.github/workflows/checkov.yml
+++ b/.github/workflows/checkov.yml
@@ -20,7 +20,7 @@ jobs:
           # (https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default-allow-root-enable-iam)
           # X-Ray actions also do not support resource-level restrictions.
           # CKV_AWS_116: Lambda DLQ configuration - created jira ticket OLH-4090
-          # CKV_GHA_7, CKV_DOCKER_3, CKV_DOCKER_2: Temporary skips - created jira ticket OLH-4089
+          # CKV_DOCKER_3, CKV_DOCKER_2: Temporary skips - created jira ticket OLH-4089
           # CKV_OPENAPI_4, CKV_OPENAPI_5: OIDC stub spec - created jira ticket OLH-4091
           # CKV2_GHA_1: Permissions are explicitly set at the job level in each workflow rather than at the top level
-          skip_check: CKV_AWS_111,CKV_AWS_116,CKV_GHA_7,CKV_DOCKER_3,CKV_DOCKER_2,CKV_OPENAPI_4,CKV_OPENAPI_5,CKV2_GHA_1
+          skip_check: CKV_AWS_111,CKV_AWS_116,CKV_DOCKER_3,CKV_DOCKER_2,CKV_OPENAPI_4,CKV_OPENAPI_5,CKV2_GHA_1

--- a/.github/workflows/publish-to-demo.yaml
+++ b/.github/workflows/publish-to-demo.yaml
@@ -1,5 +1,7 @@
 name: "Verify & Publish to Demo"
 
+# This pipeline deploys work-in-progress branches for demos
+# checkov:skip=CKV_GHA_7:workflow_dispatch inputs are required to select the branch/tag to deploy
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/publish-to-dev.yaml
+++ b/.github/workflows/publish-to-dev.yaml
@@ -1,5 +1,7 @@
 name: "Verify & Publish to Dev"
 
+# This pipeline deploys work-in-progress branches for dev work
+# checkov:skip=CKV_GHA_7:workflow_dispatch inputs are required to select the branch/tag to deploy
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/sam-app-post-merge-actions.yaml
+++ b/.github/workflows/sam-app-post-merge-actions.yaml
@@ -1,7 +1,6 @@
 name: SAM app test and build and deploy
 
 on:
-  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
Remove workflow_dispatch trigger from sam-app-post-merge-actions to prevent manual runs from arbitrary branches. Remove CKV_GHA_7 from global checkov skip list and add inline skips to the dev and demo publish workflows where workflow_dispatch inputs are needed.