### PR TITLE
BAU: pin transitive uuid dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -194,17 +194,6 @@
         "tslib": "^2.2.0"
       }
     },
-    "node_modules/@aws-crypto/material-management/node_modules/uuid": {
-      "version": "10.0.0",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/@aws-crypto/raw-aes-keyring-node": {
       "version": "5.0.0",
       "license": "Apache-2.0",
@@ -242,17 +231,6 @@
         "bn.js": "^5.2.3",
         "tslib": "^2.2.0",
         "uuid": "^10.0.0"
-      }
-    },
-    "node_modules/@aws-crypto/serialize/node_modules/uuid": {
-      "version": "10.0.0",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@aws-crypto/sha256-browser": {
@@ -6304,14 +6282,16 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "9.0.1",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/valibot": {

--- a/package.json
+++ b/package.json
@@ -71,5 +71,8 @@
     "**/*.{js,jsx,ts,tsx,json,css,scss,md,yaml}": [
       "npx prettier --write"
     ]
+  },
+  "overrides": {
+    "uuid": ">=11.1.1 <12"
   }
 }


### PR DESCRIPTION
Resolves [Dependabot alert #173](https://github.com/govuk-one-login/di-account-management-backend/security/dependabot/173).

Pins transitive `uuid` dependency to `>=11.1.1 <12` via npm overrides. Capped at `<12` as `uuid` `>=12` drops CommonJS support and is incompatible with `@aws-crypto`'s CJS imports.