### PR TITLE
BAU: fix pre-commit hook failures

### DIFF
--- a/.github/workflows/checkov.yml
+++ b/.github/workflows/checkov.yml
@@ -7,8 +7,12 @@ on:
 jobs:
   checkov:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # pragma: allowlist secret
+        with:
+          persist-credentials: false
 
       - name: Checkov GitHub Action
         uses: bridgecrewio/checkov-action@eec884fd62682f5f2b33e303e160d5e2fe8d89ec # pragma: allowlist secret

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -36,6 +36,7 @@
         "@typescript-eslint/eslint-plugin",
         "eslint-plugin-prettier",
         "lint-staged",
+        "aws-lambda"
       ],
     },
     "solutions/integration-tests": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "@aws-sdk/client-sqs": "^3.1056.0",
     "@aws-sdk/lib-dynamodb": "^3.1056.0",
     "@aws-sdk/util-dynamodb": "^3.985.0",
-    "@types/aws-lambda": "^8.10.161",
     "axios": "^1.16.1",
     "di-account-management-rp-registry": "github:govuk-one-login/di-account-management-rp-registry#main",
     "esbuild": "0.27.3",


### PR DESCRIPTION
## Summary

Fixes two pre-commit hook failures that were blocking all commits in this repo:

### zizmor (check-gh-actions hook)

- Add `persist-credentials: false` to checkout step in checkov.yml (resolves artipacked warning)
- Add explicit `permissions: contents: read` to job (resolves excessive-permissions warning)

### knip

- Remove duplicate `@types/aws-lambda` from `dependencies` (was in both dependencies and devDependencies — belongs only in devDependencies as it provides types, not runtime code)
- Add `aws-lambda` to `ignoreDependencies` in knip.jsonc (knip cannot resolve that import paths like `aws-lambda` are satisfied by the DefinitelyTyped package `@types/aws-lambda`)

## Testing

All pre-commit hooks pass locally.