### PR TITLE
OLH-3559: Activity log table analysis Lambda

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,6 +5,6 @@ sonar.projectVersion=1.0
 sonar.sources=.
 sonar.sourceEncoding=UTF-8
 
-sonar.exclusions=src/tests/*,scripts/*,pre-merge-integration-tests/api_call.py
+sonar.exclusions=src/tests/**,scripts/*,pre-merge-integration-tests/api_call.py
 
 sonar.javascript.lcov.reportPaths=./coverage/lcov.info

--- a/src/analyse-activity-log/age-thresholds.ts
+++ b/src/analyse-activity-log/age-thresholds.ts
@@ -1,0 +1,42 @@
+export type AgeThresholds = [number, number, number, number, number, number];
+
+const AGE_OFFSETS_MONTHS = [1, 3, 6, 12, 18, 24] as const;
+
+export const CounterIndex = {
+  TOTAL: 0,
+  OLDER_1M: 1,
+  OLDER_3M: 2,
+  OLDER_6M: 3,
+  OLDER_12M: 4,
+  OLDER_18M: 5,
+  OLDER_24M: 6,
+} as const;
+
+type CounterIndexValue = (typeof CounterIndex)[keyof typeof CounterIndex];
+
+export const ageThresholdsFromNow = (nowSeconds: number): AgeThresholds =>
+  AGE_OFFSETS_MONTHS.map(
+    (months) =>
+      nowSeconds - months * (30 * 24 * 60 * 60) /* seconds per month */
+  ) as unknown as AgeThresholds;
+
+export const getAgeCounterIndex = (
+  ts: number,
+  thresholds: AgeThresholds
+): CounterIndexValue => {
+  for (let i = thresholds.length - 1; i >= 0; i--) {
+    if (ts <= thresholds[i]) {
+      return (i + 1) as CounterIndexValue;
+    }
+  }
+  return CounterIndex.TOTAL;
+};
+
+export const incrementCounters = (
+  counters: number[],
+  upToAndIncludingAgeCounterIndex: number
+): void => {
+  for (let i = 0; i <= upToAndIncludingAgeCounterIndex; i++) {
+    counters[i]++;
+  }
+};

--- a/src/analyse-activity-log/compute-report.ts
+++ b/src/analyse-activity-log/compute-report.ts
@@ -1,0 +1,173 @@
+export interface PercentileResult {
+  mean: number;
+  median: number;
+  p75: number;
+  p90: number;
+  p95: number;
+  p99: number;
+  max: number;
+}
+
+export interface ConcentrationResult {
+  top_1_pct_users_own_pct_of_items: number;
+  top_5_pct_users_own_pct_of_items: number;
+  top_10_pct_users_own_pct_of_items: number;
+}
+
+const percentileAtRank = (sorted: number[], percentile: number): number => {
+  const index = Math.ceil((percentile / 100) * sorted.length) - 1;
+  return sorted[Math.max(0, index)];
+};
+
+export const computePercentiles = (
+  sortedCounts: number[]
+): PercentileResult => {
+  const sum = sortedCounts.reduce((a, b) => a + b, 0);
+  return {
+    mean: sum / sortedCounts.length,
+    median: percentileAtRank(sortedCounts, 50),
+    p75: percentileAtRank(sortedCounts, 75),
+    p90: percentileAtRank(sortedCounts, 90),
+    p95: percentileAtRank(sortedCounts, 95),
+    p99: percentileAtRank(sortedCounts, 99),
+    max: sortedCounts.at(-1)!,
+  };
+};
+
+const topNPercentOwnership = (
+  descendingCounts: number[],
+  percent: number,
+  totalItems: number
+): number => {
+  const n = Math.ceil((percent / 100) * descendingCounts.length);
+  const topSum = descendingCounts.slice(0, n).reduce((a, b) => a + b, 0);
+  return Math.round((topSum / totalItems) * 100);
+};
+
+export const computeConcentration = (
+  descendingCounts: number[],
+  totalItems: number
+): ConcentrationResult => ({
+  top_1_pct_users_own_pct_of_items: topNPercentOwnership(
+    descendingCounts,
+    1,
+    totalItems
+  ),
+  top_5_pct_users_own_pct_of_items: topNPercentOwnership(
+    descendingCounts,
+    5,
+    totalItems
+  ),
+  top_10_pct_users_own_pct_of_items: topNPercentOwnership(
+    descendingCounts,
+    10,
+    totalItems
+  ),
+});
+
+export interface UserBucket {
+  user_count: number;
+  total_items: number;
+}
+
+const USER_BUCKET_RANGES = [
+  { label: "1", min: 1, max: 1 },
+  { label: "2-5", min: 2, max: 5 },
+  { label: "6-10", min: 6, max: 10 },
+  { label: "11-25", min: 11, max: 25 },
+  { label: "26-50", min: 26, max: 50 },
+  { label: "51-100", min: 51, max: 100 },
+  { label: "101-500", min: 101, max: 500 },
+  { label: "501-1000", min: 501, max: 1000 },
+  { label: "1001-10000", min: 1001, max: 10000 },
+  { label: "10001-100000", min: 10001, max: 100000 },
+  { label: "100000+", min: 100001, max: Infinity },
+] as const;
+
+export const computeUserBuckets = (
+  totalCounts: number[]
+): Record<string, UserBucket> => {
+  const buckets: Record<string, UserBucket> = {};
+  for (const { label } of USER_BUCKET_RANGES) {
+    buckets[label] = { user_count: 0, total_items: 0 };
+  }
+  for (const count of totalCounts) {
+    const range = USER_BUCKET_RANGES.find(
+      (r) => count >= r.min && count <= r.max
+    );
+    if (range) {
+      buckets[range.label].user_count++;
+      buckets[range.label].total_items += count;
+    }
+  }
+  return buckets;
+};
+
+export const AGE_BUCKET_LABELS = [
+  "0-1_months",
+  "1-3_months",
+  "3-6_months",
+  "6-12_months",
+  "12-18_months",
+  "18-24_months",
+  "24+_months",
+] as const;
+
+export const computeItemsByAgeBucket = (
+  bucketCounts: number[]
+): Record<string, { count: number }> => {
+  if (bucketCounts.length !== AGE_BUCKET_LABELS.length) {
+    throw new Error(
+      `Expected ${AGE_BUCKET_LABELS.length} age buckets, got ${bucketCounts.length}`
+    );
+  }
+  const result: Record<string, { count: number }> = {};
+  for (let i = 0; i < AGE_BUCKET_LABELS.length; i++) {
+    result[AGE_BUCKET_LABELS[i]] = { count: bucketCounts[i] };
+  }
+  return result;
+};
+
+export interface TtlSimulationResult {
+  items_removed: number;
+  items_retained: number;
+  pct_items_removed: number;
+  users_with_all_data_removed: number;
+  users_with_data_retained: number;
+  items_per_user_after: PercentileResult;
+}
+
+export const computeTtlSimulation = (
+  perUserCounters: number[][],
+  thresholdIndex: number,
+  totalItems: number
+): TtlSimulationResult => {
+  let itemsRemoved = 0;
+  let usersWithAllDataRemoved = 0;
+  const retainedCounts: number[] = [];
+
+  for (const counters of perUserCounters) {
+    const removed = counters[thresholdIndex];
+    const retained = counters[0] - removed;
+    itemsRemoved += removed;
+    if (retained === 0) {
+      usersWithAllDataRemoved++;
+    } else {
+      retainedCounts.push(retained);
+    }
+  }
+
+  retainedCounts.sort((a, b) => a - b);
+
+  return {
+    items_removed: itemsRemoved,
+    items_retained: totalItems - itemsRemoved,
+    pct_items_removed: Math.round((itemsRemoved / totalItems) * 100),
+    users_with_all_data_removed: usersWithAllDataRemoved,
+    users_with_data_retained: perUserCounters.length - usersWithAllDataRemoved,
+    items_per_user_after:
+      retainedCounts.length > 0
+        ? computePercentiles(retainedCounts)
+        : { mean: 0, median: 0, p75: 0, p90: 0, p95: 0, p99: 0, max: 0 },
+  };
+};

--- a/src/analyse-activity-log/handler.ts
+++ b/src/analyse-activity-log/handler.ts
@@ -8,10 +8,12 @@ import {
   computeConcentration,
   computeUserBuckets,
   computeItemsByAgeBucket,
+  computeTtlSimulation,
   AGE_BUCKET_LABELS,
   PercentileResult,
   ConcentrationResult,
   UserBucket,
+  TtlSimulationResult,
 } from "./compute-report.js";
 import { getEnvironmentVariable, zeroedArray } from "../common/utils.js";
 
@@ -30,6 +32,7 @@ export interface ScanReport {
   concentration: ConcentrationResult;
   items_per_user_buckets: Record<string, UserBucket>;
   items_by_age_bucket: Record<string, { count: number }>;
+  ttl_impact_simulation: Record<string, TtlSimulationResult>;
 }
 
 export const handler = async (
@@ -99,6 +102,34 @@ export const handler = async (
   }
   const items_by_age_bucket = computeItemsByAgeBucket(ageBucketSums);
 
+  const ttl_impact_simulation: Record<string, TtlSimulationResult> = {
+    "3_months": computeTtlSimulation(
+      allCounters,
+      CounterIndex.OLDER_3M,
+      totalItems
+    ),
+    "6_months": computeTtlSimulation(
+      allCounters,
+      CounterIndex.OLDER_6M,
+      totalItems
+    ),
+    "12_months": computeTtlSimulation(
+      allCounters,
+      CounterIndex.OLDER_12M,
+      totalItems
+    ),
+    "18_months": computeTtlSimulation(
+      allCounters,
+      CounterIndex.OLDER_18M,
+      totalItems
+    ),
+    "24_months": computeTtlSimulation(
+      allCounters,
+      CounterIndex.OLDER_24M,
+      totalItems
+    ),
+  };
+
   const report: ScanReport = {
     total_items: totalItems,
     total_users: allCounters.length,
@@ -107,6 +138,7 @@ export const handler = async (
     concentration,
     items_per_user_buckets,
     items_by_age_bucket,
+    ttl_impact_simulation,
   };
 
   logger.info("Report complete", { ...report });

--- a/src/analyse-activity-log/handler.ts
+++ b/src/analyse-activity-log/handler.ts
@@ -25,6 +25,7 @@ export interface AnalyseActivityLogEvent {
 }
 
 export interface ScanReport {
+  scan_date: string;
   total_items: number;
   total_users: number;
   scan_duration_seconds: number;
@@ -131,6 +132,7 @@ export const handler = async (
   };
 
   const report: ScanReport = {
+    scan_date: new Date(startTime).toISOString(),
     total_items: totalItems,
     total_users: allCounters.length,
     scan_duration_seconds: scanDurationSeconds,

--- a/src/analyse-activity-log/handler.ts
+++ b/src/analyse-activity-log/handler.ts
@@ -3,6 +3,12 @@ import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { Context } from "aws-lambda";
 import { scanSegment } from "./scan-segment.js";
 import { ageThresholdsFromNow, CounterIndex } from "./age-thresholds.js";
+import {
+  computePercentiles,
+  computeConcentration,
+  PercentileResult,
+  ConcentrationResult,
+} from "./compute-report.js";
 import { getEnvironmentVariable } from "../common/utils.js";
 
 const logger = new Logger({ serviceName: "analyse-activity-log" });
@@ -16,6 +22,8 @@ export interface ScanReport {
   total_items: number;
   total_users: number;
   scan_duration_seconds: number;
+  items_per_user_distribution: PercentileResult;
+  concentration: ConcentrationResult;
 }
 
 export const handler = async (
@@ -51,26 +59,39 @@ export const handler = async (
     )
   );
 
-  const totalUsers = results.reduce(
-    (sum, r) => sum + r.perUserCounters.length,
-    0
-  );
-  const totalItems = results.reduce(
-    (sum, r) =>
-      sum + r.perUserCounters.reduce((s, t) => s + t[CounterIndex.TOTAL], 0),
-    0
-  );
   const scanDurationSeconds = Math.round((Date.now() - startTime) / 1000);
 
   logger.info("Compiling report");
 
-  const summary: ScanReport = {
+  const allCounters = results.flatMap((r) => r.perUserCounters);
+
+  if (allCounters.length === 0) {
+    throw new Error("Scan returned no items");
+  }
+
+  const totalCounts = new Array(allCounters.length);
+  let totalItems = 0;
+  for (let i = 0; i < allCounters.length; i++) {
+    const count = allCounters[i][CounterIndex.TOTAL];
+    totalCounts[i] = count;
+    totalItems += count;
+  }
+
+  totalCounts.sort((a, b) => a - b);
+  const items_per_user_distribution = computePercentiles(totalCounts);
+
+  totalCounts.reverse();
+  const concentration = computeConcentration(totalCounts, totalItems);
+
+  const report: ScanReport = {
     total_items: totalItems,
-    total_users: totalUsers,
+    total_users: allCounters.length,
     scan_duration_seconds: scanDurationSeconds,
+    items_per_user_distribution,
+    concentration,
   };
 
-  logger.info("Scan complete", { ...summary });
+  logger.info("Report complete", { ...report });
 
-  return summary;
+  return report;
 };

--- a/src/analyse-activity-log/handler.ts
+++ b/src/analyse-activity-log/handler.ts
@@ -1,0 +1,23 @@
+import { Logger } from "@aws-lambda-powertools/logger";
+import { Context } from "aws-lambda";
+
+const logger = new Logger({ serviceName: "analyse-activity-log" });
+
+export interface AnalyseActivityLogEvent {
+  totalSegments: number;
+}
+
+export const handler = async (
+  event: AnalyseActivityLogEvent,
+  context: Context
+): Promise<void> => {
+  logger.addContext(context);
+  if (
+    !event.totalSegments ||
+    !Number.isInteger(event.totalSegments) ||
+    event.totalSegments < 1
+  ) {
+    throw new Error("totalSegments must be a positive integer");
+  }
+  logger.info("Analysis started", { totalSegments: event.totalSegments });
+};

--- a/src/analyse-activity-log/handler.ts
+++ b/src/analyse-activity-log/handler.ts
@@ -62,6 +62,8 @@ export const handler = async (
   );
   const scanDurationSeconds = Math.round((Date.now() - startTime) / 1000);
 
+  logger.info("Compiling report");
+
   const summary: ScanReport = {
     total_items: totalItems,
     total_users: totalUsers,

--- a/src/analyse-activity-log/handler.ts
+++ b/src/analyse-activity-log/handler.ts
@@ -6,10 +6,14 @@ import { ageThresholdsFromNow, CounterIndex } from "./age-thresholds.js";
 import {
   computePercentiles,
   computeConcentration,
+  computeUserBuckets,
+  computeItemsByAgeBucket,
+  AGE_BUCKET_LABELS,
   PercentileResult,
   ConcentrationResult,
+  UserBucket,
 } from "./compute-report.js";
-import { getEnvironmentVariable } from "../common/utils.js";
+import { getEnvironmentVariable, zeroedArray } from "../common/utils.js";
 
 const logger = new Logger({ serviceName: "analyse-activity-log" });
 const client = new DynamoDBClient({});
@@ -24,6 +28,8 @@ export interface ScanReport {
   scan_duration_seconds: number;
   items_per_user_distribution: PercentileResult;
   concentration: ConcentrationResult;
+  items_per_user_buckets: Record<string, UserBucket>;
+  items_by_age_bucket: Record<string, { count: number }>;
 }
 
 export const handler = async (
@@ -83,12 +89,24 @@ export const handler = async (
   totalCounts.reverse();
   const concentration = computeConcentration(totalCounts, totalItems);
 
+  const items_per_user_buckets = computeUserBuckets(totalCounts);
+
+  const ageBucketSums = zeroedArray(AGE_BUCKET_LABELS.length);
+  for (const r of results) {
+    for (let i = 0; i < r.exclusiveAgeBuckets.length; i++) {
+      ageBucketSums[i] += r.exclusiveAgeBuckets[i];
+    }
+  }
+  const items_by_age_bucket = computeItemsByAgeBucket(ageBucketSums);
+
   const report: ScanReport = {
     total_items: totalItems,
     total_users: allCounters.length,
     scan_duration_seconds: scanDurationSeconds,
     items_per_user_distribution,
     concentration,
+    items_per_user_buckets,
+    items_by_age_bucket,
   };
 
   logger.info("Report complete", { ...report });

--- a/src/analyse-activity-log/handler.ts
+++ b/src/analyse-activity-log/handler.ts
@@ -1,17 +1,29 @@
 import { Logger } from "@aws-lambda-powertools/logger";
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { Context } from "aws-lambda";
+import { scanSegment } from "./scan-segment.js";
+import { ageThresholdsFromNow, CounterIndex } from "./age-thresholds.js";
+import { getEnvironmentVariable } from "../common/utils.js";
 
 const logger = new Logger({ serviceName: "analyse-activity-log" });
+const client = new DynamoDBClient({});
 
 export interface AnalyseActivityLogEvent {
   totalSegments: number;
 }
 
+export interface ScanReport {
+  total_items: number;
+  total_users: number;
+  scan_duration_seconds: number;
+}
+
 export const handler = async (
   event: AnalyseActivityLogEvent,
   context: Context
-): Promise<void> => {
+): Promise<ScanReport> => {
   logger.addContext(context);
+
   if (
     !event.totalSegments ||
     !Number.isInteger(event.totalSegments) ||
@@ -19,5 +31,44 @@ export const handler = async (
   ) {
     throw new Error("totalSegments must be a positive integer");
   }
+
   logger.info("Analysis started", { totalSegments: event.totalSegments });
+
+  const startTime = Date.now();
+  const ageThresholds = ageThresholdsFromNow(Math.floor(startTime / 1000));
+  const tableName = getEnvironmentVariable("TABLE_NAME");
+
+  const segments = [...new Array(event.totalSegments).keys()];
+  const results = await Promise.all(
+    segments.map((segment) =>
+      scanSegment(
+        client,
+        tableName,
+        segment,
+        event.totalSegments,
+        ageThresholds
+      )
+    )
+  );
+
+  const totalUsers = results.reduce(
+    (sum, r) => sum + r.perUserCounters.length,
+    0
+  );
+  const totalItems = results.reduce(
+    (sum, r) =>
+      sum + r.perUserCounters.reduce((s, t) => s + t[CounterIndex.TOTAL], 0),
+    0
+  );
+  const scanDurationSeconds = Math.round((Date.now() - startTime) / 1000);
+
+  const summary: ScanReport = {
+    total_items: totalItems,
+    total_users: totalUsers,
+    scan_duration_seconds: scanDurationSeconds,
+  };
+
+  logger.info("Scan complete", { ...summary });
+
+  return summary;
 };

--- a/src/analyse-activity-log/scan-segment.ts
+++ b/src/analyse-activity-log/scan-segment.ts
@@ -33,7 +33,7 @@ const processItem = (
   }
 ): typeof state => {
   const userId = item.user_id?.S;
-  const ts = Number(item.timestamp?.N);
+  const ts = Math.floor(Number(item.timestamp?.N) / 1000);
   if (!userId || Number.isNaN(ts)) return state;
 
   if (userId !== state.currentUserId) {

--- a/src/analyse-activity-log/scan-segment.ts
+++ b/src/analyse-activity-log/scan-segment.ts
@@ -1,0 +1,109 @@
+import {
+  AttributeValue,
+  DynamoDBClient,
+  ScanCommand,
+  ScanCommandOutput,
+} from "@aws-sdk/client-dynamodb";
+import { Logger } from "@aws-lambda-powertools/logger";
+import { zeroedArray } from "../common/utils.js";
+import {
+  AgeThresholds,
+  CounterIndex,
+  getAgeCounterIndex,
+  incrementCounters,
+} from "./age-thresholds.js";
+import { AGE_BUCKET_LABELS } from "./compute-report.js";
+
+export interface SegmentResult {
+  perUserCounters: number[][];
+  exclusiveAgeBuckets: number[];
+}
+
+const logger = new Logger({ serviceName: "analyse-activity-log" });
+
+const processItem = (
+  item: Record<string, AttributeValue>,
+  ageThresholds: AgeThresholds,
+  state: {
+    perUserCounters: number[][];
+    exclusiveAgeBuckets: number[];
+    currentUserId: string | null;
+    counters: number[];
+    totalItems: number;
+  }
+): typeof state => {
+  const userId = item.user_id?.S;
+  const ts = Number(item.timestamp?.N);
+  if (!userId || Number.isNaN(ts)) return state;
+
+  if (userId !== state.currentUserId) {
+    if (state.currentUserId !== null) {
+      state.perUserCounters.push(state.counters);
+    }
+    state.currentUserId = userId;
+    state.counters = zeroedArray(Object.keys(CounterIndex).length);
+  }
+
+  state.totalItems++;
+  const ageCounterIndex = getAgeCounterIndex(ts, ageThresholds);
+  incrementCounters(state.counters, ageCounterIndex);
+  state.exclusiveAgeBuckets[ageCounterIndex]++;
+
+  return state;
+};
+
+export const scanSegment = async (
+  client: DynamoDBClient,
+  tableName: string,
+  segment: number,
+  totalSegments: number,
+  ageThresholds: AgeThresholds
+): Promise<SegmentResult> => {
+  const state = {
+    perUserCounters: [] as number[][],
+    exclusiveAgeBuckets: zeroedArray(AGE_BUCKET_LABELS.length),
+    currentUserId: null as string | null,
+    counters: zeroedArray(Object.keys(CounterIndex).length),
+    totalItems: 0,
+  };
+
+  let lastEvaluatedKey: ScanCommandOutput["LastEvaluatedKey"];
+
+  do {
+    const response = await client.send(
+      new ScanCommand({
+        TableName: tableName,
+        ProjectionExpression: "user_id, #ts",
+        ExpressionAttributeNames: { "#ts": "timestamp" },
+        Segment: segment,
+        TotalSegments: totalSegments,
+        ExclusiveStartKey: lastEvaluatedKey,
+      })
+    );
+
+    for (const item of response.Items ?? []) {
+      processItem(item, ageThresholds, state);
+
+      if (state.totalItems % 10_000 === 0) {
+        logger.info("Segment progress", { segment, items: state.totalItems });
+      }
+    }
+
+    lastEvaluatedKey = response.LastEvaluatedKey;
+  } while (lastEvaluatedKey);
+
+  if (state.currentUserId !== null) {
+    state.perUserCounters.push(state.counters);
+  }
+
+  logger.info("Segment complete", {
+    segment,
+    users: state.perUserCounters.length,
+    items: state.totalItems,
+  });
+
+  return {
+    perUserCounters: state.perUserCounters,
+    exclusiveAgeBuckets: state.exclusiveAgeBuckets,
+  };
+};

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -27,3 +27,6 @@ export function getEnvironmentVariable(name: string): string {
   }
   return value;
 }
+
+export const zeroedArray = (length: number): number[] =>
+  new Array(length).fill(0);

--- a/src/tests/analyse-activity-log/age-thresholds.test.ts
+++ b/src/tests/analyse-activity-log/age-thresholds.test.ts
@@ -1,0 +1,79 @@
+import { describe, test, expect } from "vitest";
+import {
+  ageThresholdsFromNow,
+  getAgeCounterIndex,
+  incrementCounters,
+  CounterIndex,
+} from "../../analyse-activity-log/age-thresholds.js";
+
+const NOW_SECONDS = 1700000000;
+
+describe("ageThresholdsFromNow", () => {
+  test("returns 6 thresholds in descending order", () => {
+    const thresholds = ageThresholdsFromNow(NOW_SECONDS);
+    expect(thresholds).toHaveLength(6);
+    for (let i = 0; i < thresholds.length - 1; i++) {
+      expect(thresholds[i]).toBeGreaterThan(thresholds[i + 1]);
+    }
+  });
+
+  test("first threshold is 1 month before now", () => {
+    const thresholds = ageThresholdsFromNow(NOW_SECONDS);
+    expect(thresholds[0]).toBe(NOW_SECONDS - 30 * 24 * 60 * 60);
+  });
+
+  test("last threshold is 24 months before now", () => {
+    const thresholds = ageThresholdsFromNow(NOW_SECONDS);
+    expect(thresholds[5]).toBe(NOW_SECONDS - 24 * 30 * 24 * 60 * 60);
+  });
+});
+
+describe("getAgeCounterIndex", () => {
+  test("returns 0 for timestamp newer than all thresholds", () => {
+    const thresholds = ageThresholdsFromNow(NOW_SECONDS);
+    expect(getAgeCounterIndex(NOW_SECONDS, thresholds)).toBe(
+      CounterIndex.TOTAL
+    );
+  });
+
+  test("returns OLDER_1M for timestamp exactly at 1-month threshold", () => {
+    const thresholds = ageThresholdsFromNow(NOW_SECONDS);
+    expect(getAgeCounterIndex(thresholds[0], thresholds)).toBe(
+      CounterIndex.OLDER_1M
+    );
+  });
+
+  test("returns OLDER_6M for timestamp between 6 and 12 months", () => {
+    const thresholds = ageThresholdsFromNow(NOW_SECONDS);
+    expect(getAgeCounterIndex(thresholds[2] - 1, thresholds)).toBe(
+      CounterIndex.OLDER_6M
+    );
+  });
+
+  test("returns OLDER_24M for timestamp older than all thresholds", () => {
+    const thresholds = ageThresholdsFromNow(NOW_SECONDS);
+    expect(getAgeCounterIndex(thresholds[5] - 1, thresholds)).toBe(
+      CounterIndex.OLDER_24M
+    );
+  });
+});
+
+describe("incrementCounters", () => {
+  test("increments only index 0 for bucket 0", () => {
+    const counters = [0, 0, 0, 0, 0, 0, 0];
+    incrementCounters(counters, 0);
+    expect(counters).toEqual([1, 0, 0, 0, 0, 0, 0]);
+  });
+
+  test("increments indices 0 through bucket", () => {
+    const counters = [0, 0, 0, 0, 0, 0, 0];
+    incrementCounters(counters, 3);
+    expect(counters).toEqual([1, 1, 1, 1, 0, 0, 0]);
+  });
+
+  test("increments all for bucket 6", () => {
+    const counters = [0, 0, 0, 0, 0, 0, 0];
+    incrementCounters(counters, 6);
+    expect(counters).toEqual([1, 1, 1, 1, 1, 1, 1]);
+  });
+});

--- a/src/tests/analyse-activity-log/compute-report.test.ts
+++ b/src/tests/analyse-activity-log/compute-report.test.ts
@@ -1,0 +1,68 @@
+import { describe, test, expect } from "vitest";
+import {
+  computePercentiles,
+  computeConcentration,
+} from "../../analyse-activity-log/compute-report.js";
+
+describe("computePercentiles", () => {
+  test("all same values", () => {
+    const result = computePercentiles([1, 1, 1, 1, 1]);
+    expect(result.mean).toBe(1);
+    expect(result.median).toBe(1);
+    expect(result.p75).toBe(1);
+    expect(result.p90).toBe(1);
+    expect(result.p95).toBe(1);
+    expect(result.p99).toBe(1);
+    expect(result.max).toBe(1);
+  });
+
+  test("uniform distribution 1 to 100", () => {
+    const sorted = Array.from({ length: 100 }, (_, i) => i + 1);
+    const result = computePercentiles(sorted);
+    expect(result.mean).toBe(50.5);
+    expect(result.median).toBe(50);
+    expect(result.p75).toBe(75);
+    expect(result.p90).toBe(90);
+    expect(result.p95).toBe(95);
+    expect(result.p99).toBe(99);
+    expect(result.max).toBe(100);
+  });
+
+  test("outlier distribution", () => {
+    const result = computePercentiles([1, 1, 1, 1, 1000]);
+    expect(result.mean).toBe(200.8);
+    expect(result.median).toBe(1);
+    expect(result.p99).toBe(1000);
+    expect(result.max).toBe(1000);
+  });
+
+  test("single user", () => {
+    const result = computePercentiles([5]);
+    expect(result.mean).toBe(5);
+    expect(result.median).toBe(5);
+    expect(result.p75).toBe(5);
+    expect(result.p90).toBe(5);
+    expect(result.p95).toBe(5);
+    expect(result.p99).toBe(5);
+    expect(result.max).toBe(5);
+  });
+});
+
+describe("computeConcentration", () => {
+  test("top 1 user of 100 owns 50% of items", () => {
+    const counts = [50, ...new Array(99).fill(0.5)].sort(
+      (a, b) => b - a
+    ) as number[];
+    const totalItems = 50 + 99 * 0.5;
+    const result = computeConcentration(counts, totalItems);
+    expect(result.top_1_pct_users_own_pct_of_items).toBe(50);
+  });
+
+  test("uniform distribution", () => {
+    const counts = new Array(100).fill(10);
+    const result = computeConcentration(counts, 1000);
+    expect(result.top_1_pct_users_own_pct_of_items).toBe(1);
+    expect(result.top_5_pct_users_own_pct_of_items).toBe(5);
+    expect(result.top_10_pct_users_own_pct_of_items).toBe(10);
+  });
+});

--- a/src/tests/analyse-activity-log/compute-report.test.ts
+++ b/src/tests/analyse-activity-log/compute-report.test.ts
@@ -2,6 +2,8 @@ import { describe, test, expect } from "vitest";
 import {
   computePercentiles,
   computeConcentration,
+  computeUserBuckets,
+  computeItemsByAgeBucket,
 } from "../../analyse-activity-log/compute-report.js";
 
 describe("computePercentiles", () => {
@@ -64,5 +66,53 @@ describe("computeConcentration", () => {
     expect(result.top_1_pct_users_own_pct_of_items).toBe(1);
     expect(result.top_5_pct_users_own_pct_of_items).toBe(5);
     expect(result.top_10_pct_users_own_pct_of_items).toBe(10);
+  });
+});
+
+describe("computeUserBuckets", () => {
+  test("classifies boundary values correctly", () => {
+    const counts = [
+      1, 5, 6, 10, 11, 25, 26, 50, 51, 100, 101, 500, 501, 1000, 1001, 10000,
+      10001, 100000, 100001,
+    ];
+    const result = computeUserBuckets(counts);
+    expect(result["1"].user_count).toBe(1);
+    expect(result["2-5"].user_count).toBe(1);
+    expect(result["6-10"].user_count).toBe(2);
+    expect(result["11-25"].user_count).toBe(2);
+    expect(result["26-50"].user_count).toBe(2);
+    expect(result["51-100"].user_count).toBe(2);
+    expect(result["101-500"].user_count).toBe(2);
+    expect(result["501-1000"].user_count).toBe(2);
+    expect(result["1001-10000"].user_count).toBe(2);
+    expect(result["10001-100000"].user_count).toBe(2);
+    expect(result["100000+"].user_count).toBe(1);
+  });
+
+  test("sums total_items per bucket", () => {
+    const counts = [1, 3, 4];
+    const result = computeUserBuckets(counts);
+    expect(result["1"].total_items).toBe(1);
+    expect(result["2-5"].total_items).toBe(7);
+  });
+});
+
+describe("computeItemsByAgeBucket", () => {
+  test("labels match expected output keys", () => {
+    const buckets = [100, 200, 300, 400, 500, 600, 700];
+    const result = computeItemsByAgeBucket(buckets);
+    expect(result["0-1_months"].count).toBe(100);
+    expect(result["1-3_months"].count).toBe(200);
+    expect(result["3-6_months"].count).toBe(300);
+    expect(result["6-12_months"].count).toBe(400);
+    expect(result["12-18_months"].count).toBe(500);
+    expect(result["18-24_months"].count).toBe(600);
+    expect(result["24+_months"].count).toBe(700);
+  });
+
+  test("throws when bucket count does not match label count", () => {
+    expect(() => computeItemsByAgeBucket([1, 2, 3])).toThrow(
+      "Expected 7 age buckets, got 3"
+    );
   });
 });

--- a/src/tests/analyse-activity-log/compute-report.test.ts
+++ b/src/tests/analyse-activity-log/compute-report.test.ts
@@ -4,7 +4,9 @@ import {
   computeConcentration,
   computeUserBuckets,
   computeItemsByAgeBucket,
+  computeTtlSimulation,
 } from "../../analyse-activity-log/compute-report.js";
+import { CounterIndex } from "../../analyse-activity-log/age-thresholds.js";
 
 describe("computePercentiles", () => {
   test("all same values", () => {
@@ -114,5 +116,57 @@ describe("computeItemsByAgeBucket", () => {
     expect(() => computeItemsByAgeBucket([1, 2, 3])).toThrow(
       "Expected 7 age buckets, got 3"
     );
+  });
+});
+
+describe("computeTtlSimulation", () => {
+  test("user with all items older than 3m is fully removed", () => {
+    // [TOTAL, OLDER_1M, OLDER_3M, OLDER_6M, OLDER_12M, OLDER_18M, OLDER_24M]
+    const userCounters = [[5, 5, 5, 3, 0, 0, 0]];
+    const result = computeTtlSimulation(userCounters, CounterIndex.OLDER_3M, 5);
+    expect(result.items_removed).toBe(5);
+    expect(result.items_retained).toBe(0);
+    expect(result.pct_items_removed).toBe(100);
+    expect(result.users_with_all_data_removed).toBe(1);
+    expect(result.users_with_data_retained).toBe(0);
+  });
+
+  test("user with no items older than 3m has 0 removed", () => {
+    const userCounters = [[5, 2, 0, 0, 0, 0, 0]];
+    const result = computeTtlSimulation(userCounters, CounterIndex.OLDER_3M, 5);
+    expect(result.items_removed).toBe(0);
+    expect(result.items_retained).toBe(5);
+    expect(result.pct_items_removed).toBe(0);
+    expect(result.users_with_all_data_removed).toBe(0);
+    expect(result.users_with_data_retained).toBe(1);
+    expect(result.items_per_user_after.mean).toBe(5);
+  });
+
+  test("user with 5 total, 3 older than 6m", () => {
+    const userCounters = [[5, 5, 4, 3, 0, 0, 0]];
+    const result = computeTtlSimulation(userCounters, CounterIndex.OLDER_6M, 5);
+    expect(result.items_removed).toBe(3);
+    expect(result.items_retained).toBe(2);
+    expect(result.pct_items_removed).toBe(60);
+    expect(result.users_with_all_data_removed).toBe(0);
+    expect(result.users_with_data_retained).toBe(1);
+    expect(result.items_per_user_after.mean).toBe(2);
+  });
+
+  test("post-TTL percentiles exclude fully-removed users", () => {
+    const userCounters = [
+      [10, 10, 10, 0, 0, 0, 0], // fully removed at 3m
+      [5, 3, 0, 0, 0, 0, 0], // retains 5
+      [8, 6, 2, 0, 0, 0, 0], // retains 6
+    ];
+    const result = computeTtlSimulation(
+      userCounters,
+      CounterIndex.OLDER_3M,
+      23
+    );
+    expect(result.users_with_all_data_removed).toBe(1);
+    expect(result.users_with_data_retained).toBe(2);
+    expect(result.items_per_user_after.mean).toBe(5.5);
+    expect(result.items_per_user_after.max).toBe(6);
   });
 });

--- a/src/tests/analyse-activity-log/handler.test.ts
+++ b/src/tests/analyse-activity-log/handler.test.ts
@@ -1,37 +1,113 @@
-import { describe, test, expect } from "vitest";
-import { handler } from "../../analyse-activity-log/handler.js";
+import { vi, describe, test, expect, beforeEach } from "vitest";
 import { Context } from "aws-lambda";
 
+vi.mock(
+  "../../analyse-activity-log/scan-segment.js",
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import("../../analyse-activity-log/scan-segment.js")
+      >();
+    return {
+      ...actual,
+      scanSegment: vi.fn(),
+    };
+  }
+);
+
+import { handler } from "../../analyse-activity-log/handler.js";
+import { scanSegment } from "../../analyse-activity-log/scan-segment.js";
+
 const mockContext = {} as Context;
+const mockScanSegment = vi.mocked(scanSegment);
 
 describe("analyse-activity-log handler", () => {
-  test("throws when totalSegments is missing", async () => {
-    await expect(
-      handler({} as { totalSegments: number }, mockContext)
-    ).rejects.toThrow("totalSegments must be a positive integer");
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.TABLE_NAME = "activity_log";
   });
 
-  test("throws when totalSegments is 0", async () => {
-    await expect(handler({ totalSegments: 0 }, mockContext)).rejects.toThrow(
-      "totalSegments must be a positive integer"
-    );
+  describe("input validation", () => {
+    test("throws when totalSegments is missing", async () => {
+      await expect(
+        handler({} as { totalSegments: number }, mockContext)
+      ).rejects.toThrow("totalSegments must be a positive integer");
+    });
+
+    test("throws when totalSegments is 0", async () => {
+      await expect(handler({ totalSegments: 0 }, mockContext)).rejects.toThrow(
+        "totalSegments must be a positive integer"
+      );
+    });
+
+    test("throws when totalSegments is negative", async () => {
+      await expect(handler({ totalSegments: -1 }, mockContext)).rejects.toThrow(
+        "totalSegments must be a positive integer"
+      );
+    });
+
+    test("throws when totalSegments is not an integer", async () => {
+      await expect(
+        handler({ totalSegments: 1.5 }, mockContext)
+      ).rejects.toThrow("totalSegments must be a positive integer");
+    });
   });
 
-  test("throws when totalSegments is negative", async () => {
-    await expect(handler({ totalSegments: -1 }, mockContext)).rejects.toThrow(
-      "totalSegments must be a positive integer"
-    );
-  });
+  describe("scan orchestration", () => {
+    test("calls scanSegment once per segment", async () => {
+      mockScanSegment.mockResolvedValue({ perUserCounters: [] });
 
-  test("throws when totalSegments is not an integer", async () => {
-    await expect(handler({ totalSegments: 1.5 }, mockContext)).rejects.toThrow(
-      "totalSegments must be a positive integer"
-    );
-  });
+      await handler({ totalSegments: 3 }, mockContext);
 
-  test("does not throw with valid totalSegments", async () => {
-    await expect(
-      handler({ totalSegments: 5 }, mockContext)
-    ).resolves.not.toThrow();
+      expect(mockScanSegment).toHaveBeenCalledTimes(3);
+      expect(mockScanSegment).toHaveBeenCalledWith(
+        expect.anything(),
+        "activity_log",
+        0,
+        3,
+        expect.any(Array)
+      );
+      expect(mockScanSegment).toHaveBeenCalledWith(
+        expect.anything(),
+        "activity_log",
+        1,
+        3,
+        expect.any(Array)
+      );
+      expect(mockScanSegment).toHaveBeenCalledWith(
+        expect.anything(),
+        "activity_log",
+        2,
+        3,
+        expect.any(Array)
+      );
+    });
+
+    test("throws when TABLE_NAME is not set", async () => {
+      delete process.env.TABLE_NAME;
+
+      await expect(handler({ totalSegments: 1 }, mockContext)).rejects.toThrow(
+        'Environment variable "TABLE_NAME" is not set'
+      );
+    });
+
+    test("returns summed totals from all segments", async () => {
+      mockScanSegment
+        .mockResolvedValueOnce({
+          perUserCounters: [
+            [3, 1, 0, 0, 0, 0, 0],
+            [5, 2, 1, 0, 0, 0, 0],
+          ],
+        })
+        .mockResolvedValueOnce({
+          perUserCounters: [[2, 0, 0, 0, 0, 0, 0]],
+        });
+
+      const result = await handler({ totalSegments: 2 }, mockContext);
+
+      expect(result.total_users).toBe(3);
+      expect(result.total_items).toBe(10);
+      expect(result.scan_duration_seconds).toBeGreaterThanOrEqual(0);
+    });
   });
 });

--- a/src/tests/analyse-activity-log/handler.test.ts
+++ b/src/tests/analyse-activity-log/handler.test.ts
@@ -1,0 +1,37 @@
+import { describe, test, expect } from "vitest";
+import { handler } from "../../analyse-activity-log/handler.js";
+import { Context } from "aws-lambda";
+
+const mockContext = {} as Context;
+
+describe("analyse-activity-log handler", () => {
+  test("throws when totalSegments is missing", async () => {
+    await expect(
+      handler({} as { totalSegments: number }, mockContext)
+    ).rejects.toThrow("totalSegments must be a positive integer");
+  });
+
+  test("throws when totalSegments is 0", async () => {
+    await expect(handler({ totalSegments: 0 }, mockContext)).rejects.toThrow(
+      "totalSegments must be a positive integer"
+    );
+  });
+
+  test("throws when totalSegments is negative", async () => {
+    await expect(handler({ totalSegments: -1 }, mockContext)).rejects.toThrow(
+      "totalSegments must be a positive integer"
+    );
+  });
+
+  test("throws when totalSegments is not an integer", async () => {
+    await expect(handler({ totalSegments: 1.5 }, mockContext)).rejects.toThrow(
+      "totalSegments must be a positive integer"
+    );
+  });
+
+  test("does not throw with valid totalSegments", async () => {
+    await expect(
+      handler({ totalSegments: 5 }, mockContext)
+    ).resolves.not.toThrow();
+  });
+});

--- a/src/tests/analyse-activity-log/handler.test.ts
+++ b/src/tests/analyse-activity-log/handler.test.ts
@@ -157,6 +157,7 @@ describe("analyse-activity-log handler", () => {
 
       const result = await handler({ totalSegments: 2 }, mockContext);
 
+      expect(result.scan_date).toMatch(/^\d{4}-\d{2}-\d{2}T/);
       expect(result.total_users).toBe(8);
       expect(result.total_items).toBe(104);
       expect(result.items_per_user_distribution.mean).toBe(13);

--- a/src/tests/analyse-activity-log/handler.test.ts
+++ b/src/tests/analyse-activity-log/handler.test.ts
@@ -178,6 +178,65 @@ describe("analyse-activity-log handler", () => {
       expect(result.items_by_age_bucket["12-18_months"].count).toBe(17);
       expect(result.items_by_age_bucket["18-24_months"].count).toBe(12);
       expect(result.items_by_age_bucket["24+_months"].count).toBe(6);
+      expect(result.ttl_impact_simulation["3_months"]).toEqual({
+        items_removed: 68,
+        items_retained: 36,
+        pct_items_removed: 65,
+        users_with_all_data_removed: 0,
+        users_with_data_retained: 8,
+        items_per_user_after: expect.objectContaining({
+          mean: 4.5,
+          max: 10,
+        }),
+      });
+
+      expect(result.ttl_impact_simulation["6_months"]).toEqual({
+        items_removed: 47,
+        items_retained: 57,
+        pct_items_removed: 45,
+        users_with_all_data_removed: 0,
+        users_with_data_retained: 8,
+        items_per_user_after: expect.objectContaining({
+          mean: 7.125,
+          max: 20,
+        }),
+      });
+
+      expect(result.ttl_impact_simulation["12_months"]).toEqual({
+        items_removed: 27,
+        items_retained: 77,
+        pct_items_removed: 26,
+        users_with_all_data_removed: 0,
+        users_with_data_retained: 8,
+        items_per_user_after: expect.objectContaining({
+          mean: 9.625,
+          max: 30,
+        }),
+      });
+
+      expect(result.ttl_impact_simulation["18_months"]).toEqual({
+        items_removed: 12,
+        items_retained: 92,
+        pct_items_removed: 12,
+        users_with_all_data_removed: 0,
+        users_with_data_retained: 8,
+        items_per_user_after: expect.objectContaining({
+          mean: 11.5,
+          max: 40,
+        }),
+      });
+
+      expect(result.ttl_impact_simulation["24_months"]).toEqual({
+        items_removed: 5,
+        items_retained: 99,
+        pct_items_removed: 5,
+        users_with_all_data_removed: 0,
+        users_with_data_retained: 8,
+        items_per_user_after: expect.objectContaining({
+          mean: 12.375,
+          max: 45,
+        }),
+      });
     });
   });
 });

--- a/src/tests/analyse-activity-log/handler.test.ts
+++ b/src/tests/analyse-activity-log/handler.test.ts
@@ -55,7 +55,9 @@ describe("analyse-activity-log handler", () => {
 
   describe("scan orchestration", () => {
     test("calls scanSegment once per segment", async () => {
-      mockScanSegment.mockResolvedValue({ perUserCounters: [] });
+      mockScanSegment.mockResolvedValue({
+        perUserCounters: [[1, 0, 0, 0, 0, 0, 0]],
+      });
 
       await handler({ totalSegments: 3 }, mockContext);
 
@@ -91,6 +93,14 @@ describe("analyse-activity-log handler", () => {
       );
     });
 
+    test("throws when scan returns no items", async () => {
+      mockScanSegment.mockResolvedValue({ perUserCounters: [] });
+
+      await expect(handler({ totalSegments: 1 }, mockContext)).rejects.toThrow(
+        "Scan returned no items"
+      );
+    });
+
     test("returns summed totals from all segments", async () => {
       mockScanSegment
         .mockResolvedValueOnce({
@@ -108,6 +118,11 @@ describe("analyse-activity-log handler", () => {
       expect(result.total_users).toBe(3);
       expect(result.total_items).toBe(10);
       expect(result.scan_duration_seconds).toBeGreaterThanOrEqual(0);
+      expect(result.items_per_user_distribution.mean).toBeCloseTo(10 / 3);
+      expect(result.items_per_user_distribution.max).toBe(5);
+      expect(result.concentration).toHaveProperty(
+        "top_1_pct_users_own_pct_of_items"
+      );
     });
   });
 });

--- a/src/tests/analyse-activity-log/handler.test.ts
+++ b/src/tests/analyse-activity-log/handler.test.ts
@@ -57,6 +57,7 @@ describe("analyse-activity-log handler", () => {
     test("calls scanSegment once per segment", async () => {
       mockScanSegment.mockResolvedValue({
         perUserCounters: [[1, 0, 0, 0, 0, 0, 0]],
+        exclusiveAgeBuckets: [1, 0, 0, 0, 0, 0, 0],
       });
 
       await handler({ totalSegments: 3 }, mockContext);
@@ -94,7 +95,10 @@ describe("analyse-activity-log handler", () => {
     });
 
     test("throws when scan returns no items", async () => {
-      mockScanSegment.mockResolvedValue({ perUserCounters: [] });
+      mockScanSegment.mockResolvedValue({
+        perUserCounters: [],
+        exclusiveAgeBuckets: [0, 0, 0, 0, 0, 0, 0],
+      });
 
       await expect(handler({ totalSegments: 1 }, mockContext)).rejects.toThrow(
         "Scan returned no items"
@@ -108,9 +112,11 @@ describe("analyse-activity-log handler", () => {
             [3, 1, 0, 0, 0, 0, 0],
             [5, 2, 1, 0, 0, 0, 0],
           ],
+          exclusiveAgeBuckets: [5, 2, 1, 0, 0, 0, 0],
         })
         .mockResolvedValueOnce({
           perUserCounters: [[2, 0, 0, 0, 0, 0, 0]],
+          exclusiveAgeBuckets: [2, 0, 0, 0, 0, 0, 0],
         });
 
       const result = await handler({ totalSegments: 2 }, mockContext);
@@ -123,6 +129,55 @@ describe("analyse-activity-log handler", () => {
       expect(result.concentration).toHaveProperty(
         "top_1_pct_users_own_pct_of_items"
       );
+      expect(result.items_per_user_buckets["2-5"].user_count).toBe(3);
+      expect(result.items_by_age_bucket["0-1_months"].count).toBe(7);
+      expect(result.items_by_age_bucket["1-3_months"].count).toBe(2);
+    });
+
+    test("produces a complete report from realistic multi-segment data", async () => {
+      mockScanSegment
+        .mockResolvedValueOnce({
+          perUserCounters: [
+            [1, 0, 0, 0, 0, 0, 0],
+            [4, 2, 1, 0, 0, 0, 0],
+            [12, 10, 8, 5, 2, 0, 0],
+            [50, 45, 40, 30, 20, 10, 5],
+          ],
+          exclusiveAgeBuckets: [10, 12, 8, 10, 12, 10, 5],
+        })
+        .mockResolvedValueOnce({
+          perUserCounters: [
+            [1, 0, 0, 0, 0, 0, 0],
+            [3, 1, 0, 0, 0, 0, 0],
+            [8, 6, 4, 2, 0, 0, 0],
+            [25, 20, 15, 10, 5, 2, 0],
+          ],
+          exclusiveAgeBuckets: [8, 10, 6, 5, 5, 2, 1],
+        });
+
+      const result = await handler({ totalSegments: 2 }, mockContext);
+
+      expect(result.total_users).toBe(8);
+      expect(result.total_items).toBe(104);
+      expect(result.items_per_user_distribution.mean).toBe(13);
+      expect(result.items_per_user_distribution.median).toBe(4);
+      expect(result.items_per_user_distribution.max).toBe(50);
+      expect(result.items_per_user_distribution.p90).toBe(50);
+      expect(
+        result.concentration.top_10_pct_users_own_pct_of_items
+      ).toBeGreaterThan(0);
+      expect(result.items_per_user_buckets["1"].user_count).toBe(2);
+      expect(result.items_per_user_buckets["2-5"].user_count).toBe(2);
+      expect(result.items_per_user_buckets["6-10"].user_count).toBe(1);
+      expect(result.items_per_user_buckets["11-25"].user_count).toBe(2);
+      expect(result.items_per_user_buckets["26-50"].user_count).toBe(1);
+      expect(result.items_by_age_bucket["0-1_months"].count).toBe(18);
+      expect(result.items_by_age_bucket["1-3_months"].count).toBe(22);
+      expect(result.items_by_age_bucket["3-6_months"].count).toBe(14);
+      expect(result.items_by_age_bucket["6-12_months"].count).toBe(15);
+      expect(result.items_by_age_bucket["12-18_months"].count).toBe(17);
+      expect(result.items_by_age_bucket["18-24_months"].count).toBe(12);
+      expect(result.items_by_age_bucket["24+_months"].count).toBe(6);
     });
   });
 });

--- a/src/tests/analyse-activity-log/scan-segment.test.ts
+++ b/src/tests/analyse-activity-log/scan-segment.test.ts
@@ -14,9 +14,9 @@ const NOW_SECONDS = 1700000000;
 
 const thresholds: AgeThresholds = ageThresholdsFromNow(NOW_SECONDS);
 
-const makeItem = (userId: string, timestamp: number) => ({
+const makeItem = (userId: string, timestampSeconds: number) => ({
   user_id: { S: userId },
-  timestamp: { N: String(timestamp) },
+  timestamp: { N: String(timestampSeconds * 1000) },
 });
 
 describe("scanSegment", () => {

--- a/src/tests/analyse-activity-log/scan-segment.test.ts
+++ b/src/tests/analyse-activity-log/scan-segment.test.ts
@@ -126,5 +126,6 @@ describe("scanSegment", () => {
     expect(result.perUserCounters[0][CounterIndex.OLDER_12M]).toBe(3);
     expect(result.perUserCounters[0][CounterIndex.OLDER_18M]).toBe(2);
     expect(result.perUserCounters[0][CounterIndex.OLDER_24M]).toBe(1);
+    expect(result.exclusiveAgeBuckets).toEqual([1, 2, 1, 1, 1, 1, 1]);
   });
 });

--- a/src/tests/analyse-activity-log/scan-segment.test.ts
+++ b/src/tests/analyse-activity-log/scan-segment.test.ts
@@ -1,0 +1,130 @@
+import { describe, test, expect, beforeEach } from "vitest";
+import { DynamoDBClient, ScanCommand } from "@aws-sdk/client-dynamodb";
+import { mockClient } from "aws-sdk-client-mock";
+import { scanSegment } from "../../analyse-activity-log/scan-segment.js";
+import {
+  AgeThresholds,
+  ageThresholdsFromNow,
+  CounterIndex,
+} from "../../analyse-activity-log/age-thresholds.js";
+
+const dynamoMock = mockClient(DynamoDBClient);
+
+const NOW_SECONDS = 1700000000;
+
+const thresholds: AgeThresholds = ageThresholdsFromNow(NOW_SECONDS);
+
+const makeItem = (userId: string, timestamp: number) => ({
+  user_id: { S: userId },
+  timestamp: { N: String(timestamp) },
+});
+
+describe("scanSegment", () => {
+  beforeEach(() => {
+    dynamoMock.reset();
+  });
+
+  test("empty segment returns zero counts", async () => {
+    dynamoMock.on(ScanCommand).resolves({ Items: [] });
+
+    const result = await scanSegment(
+      dynamoMock as unknown as DynamoDBClient,
+      "table",
+      0,
+      1,
+      thresholds
+    );
+
+    expect(result.perUserCounters).toHaveLength(0);
+  });
+
+  test("single-item user", async () => {
+    dynamoMock.on(ScanCommand).resolves({
+      Items: [makeItem("user-a", NOW_SECONDS - 10)],
+    });
+
+    const result = await scanSegment(
+      dynamoMock as unknown as DynamoDBClient,
+      "table",
+      0,
+      1,
+      thresholds
+    );
+
+    expect(result.perUserCounters).toHaveLength(1);
+    expect(result.perUserCounters[0][CounterIndex.TOTAL]).toBe(1);
+  });
+
+  test("3 users across 2 pages with middle user spanning page boundary", async () => {
+    dynamoMock
+      .on(ScanCommand)
+      .resolvesOnce({
+        Items: [
+          makeItem("user-a", NOW_SECONDS - 10),
+          makeItem("user-a", NOW_SECONDS - 20),
+          makeItem("user-b", NOW_SECONDS - 10),
+        ],
+        LastEvaluatedKey: { user_id: { S: "user-b" } },
+      })
+      .resolvesOnce({
+        Items: [
+          makeItem("user-b", NOW_SECONDS - 30),
+          makeItem("user-c", NOW_SECONDS - 10),
+        ],
+      });
+
+    const result = await scanSegment(
+      dynamoMock as unknown as DynamoDBClient,
+      "table",
+      0,
+      1,
+      thresholds
+    );
+
+    expect(result.perUserCounters).toHaveLength(3);
+    expect(result.perUserCounters[0][CounterIndex.TOTAL]).toBe(2);
+    expect(result.perUserCounters[1][CounterIndex.TOTAL]).toBe(2);
+    expect(result.perUserCounters[2][CounterIndex.TOTAL]).toBe(1);
+  });
+
+  test("age bucket counting at threshold boundaries", async () => {
+    const fresh = NOW_SECONDS - 10;
+    const exactly1m = thresholds[0];
+    const between1and3m = thresholds[0] - 10;
+    const between3and6m = thresholds[1] - 10;
+    const between6and12m = thresholds[2] - 10;
+    const between12and18m = thresholds[3] - 10;
+    const between18and24m = thresholds[4] - 10;
+    const older24m = thresholds[5] - 10;
+
+    dynamoMock.on(ScanCommand).resolves({
+      Items: [
+        makeItem("user-a", fresh),
+        makeItem("user-a", exactly1m),
+        makeItem("user-a", between1and3m),
+        makeItem("user-a", between3and6m),
+        makeItem("user-a", between6and12m),
+        makeItem("user-a", between12and18m),
+        makeItem("user-a", between18and24m),
+        makeItem("user-a", older24m),
+      ],
+    });
+
+    const result = await scanSegment(
+      dynamoMock as unknown as DynamoDBClient,
+      "table",
+      0,
+      1,
+      thresholds
+    );
+
+    expect(result.perUserCounters).toHaveLength(1);
+    expect(result.perUserCounters[0][CounterIndex.TOTAL]).toBe(8);
+    expect(result.perUserCounters[0][CounterIndex.OLDER_1M]).toBe(7);
+    expect(result.perUserCounters[0][CounterIndex.OLDER_3M]).toBe(5);
+    expect(result.perUserCounters[0][CounterIndex.OLDER_6M]).toBe(4);
+    expect(result.perUserCounters[0][CounterIndex.OLDER_12M]).toBe(3);
+    expect(result.perUserCounters[0][CounterIndex.OLDER_18M]).toBe(2);
+    expect(result.perUserCounters[0][CounterIndex.OLDER_24M]).toBe(1);
+  });
+});

--- a/template.yaml
+++ b/template.yaml
@@ -5391,6 +5391,7 @@ Resources:
       Environment:
         Variables:
           NODE_OPTIONS: --enable-source-maps --max-old-space-size=5120
+          TABLE_NAME: !Ref ActivityLogsStoreTableName
     Metadata:
       BuildMethod: esbuild
       BuildProperties:
@@ -5415,6 +5416,7 @@ Resources:
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
         - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
+        - !Ref AnalyseActivityLogPolicy
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -5424,6 +5426,23 @@ Resources:
                 - lambda.amazonaws.com
             Action:
               - "sts:AssumeRole"
+
+  AnalyseActivityLogPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - dynamodb:Scan
+            Resource:
+              - !GetAtt UserActivityLogsStore.Arn
+          - Effect: Allow
+            Action:
+              - kms:Decrypt
+            Resource:
+              - !GetAtt DatabaseKmsKey.Arn
 
   AnalyseActivityLogFunctionLogGroup:
     Type: AWS::Logs::LogGroup

--- a/template.yaml
+++ b/template.yaml
@@ -5372,6 +5372,66 @@ Resources:
       AlarmActions:
         - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/LowAlertNotificationTopic/ARN}}"
 
+  #######################
+  # Analyse Activity Log
+  #######################
+
+  AnalyseActivityLogFunction:
+    Type: AWS::Serverless::Function
+    DependsOn:
+      - AnalyseActivityLogFunctionLogGroup
+    Properties:
+      FunctionName: !Sub ${Environment}-${AWS::StackName}-analyse-activity-log
+      CodeUri: src
+      PackageType: Zip
+      Timeout: 900
+      MemorySize: 6144
+      Handler: analyse-activity-log/handler.handler
+      Role: !GetAtt AnalyseActivityLogRole.Arn
+      Environment:
+        Variables:
+          NODE_OPTIONS: --enable-source-maps --max-old-space-size=5120
+    Metadata:
+      BuildMethod: esbuild
+      BuildProperties:
+        Minify: true
+        Format: "esm"
+        OutExtension:
+          - .js=.mjs
+        Target: "es2022"
+        Sourcemap: true
+        EntryPoints:
+          - analyse-activity-log/handler.ts
+        Banner:
+          - js=import { createRequire } from 'module'; const require = createRequire(import.meta.url);
+
+  AnalyseActivityLogRole:
+    Type: AWS::IAM::Role
+    Properties:
+      PermissionsBoundary: !If
+        - UsePermissionsBoundary
+        - !Ref PermissionsBoundary
+        - !Ref AWS::NoValue
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - "sts:AssumeRole"
+
+  AnalyseActivityLogFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/${Environment}-${AWS::StackName}-analyse-activity-log"
+      RetentionInDays: 30
+      KmsKeyId: !GetAtt LoggingKmsKey.Arn
+
 Outputs:
   GeneratorKey:
     Description: A generator key for generating a plaintext data key


### PR DESCRIPTION
## Proposed changes

### What changed

Adds a manually-invocable Lambda that scans the `activity_log` DynamoDB table using parallel segments and produces a JSON report with:
- Per-user item count distribution (mean, median, percentiles)
- Concentration metrics (top 1%/5%/10% of users' share of items)
- User bucketing by item count (1, 2-5, 6-10, ... 100000+)
- Items by age range (0-1 months through 24+ months)
- TTL impact simulation for 3/6/12/18/24 month thresholds

### Why did it change

The `activity_log` table has no TTL and grows unboundedly. We need data to assess retention strategies (time-based TTL vs segregation by value). This Lambda produces the analysis needed to make that decision.

### Example output

```json
{
  "scan_date": "2026-06-08T12:00:00.000Z",
  "total_items": 1843927,
  "total_users": 241000,
  "scan_duration_seconds": 47,
  "items_per_user_distribution": {
    "mean": 7.6,
    "median": 3,
    "p75": 8,
    "p90": 14,
    "p95": 22,
    "p99": 61,
    "max": 3870
  },
  "concentration": {
    "top_1_pct_users_own_pct_of_items": 31,
    "top_5_pct_users_own_pct_of_items": 55,
    "top_10_pct_users_own_pct_of_items": 71
  },
  "items_per_user_buckets": {
    "1": { "user_count": 58200, "total_items": 58200 },
    "2-5": { "user_count": 97400, "total_items": 312000 },
    "6-10": { "user_count": 43100, "total_items": 321000 },
    "11-25": { "user_count": 28600, "total_items": 412000 },
    "26-50": { "user_count": 9200, "total_items": 298000 },
    "51-100": { "user_count": 3100, "total_items": 214000 },
    "101-500": { "user_count": 1180, "total_items": 178000 },
    "501-1000": { "user_count": 142, "total_items": 89000 },
    "1001-10000": { "user_count": 38, "total_items": 62000 },
    "10001-100000": { "user_count": 0, "total_items": 0 },
    "100000+": { "user_count": 0, "total_items": 0 }
  },
  "items_by_age_bucket": {
    "0-1_months": { "count": 231000 },
    "1-3_months": { "count": 389000 },
    "3-6_months": { "count": 341000 },
    "6-12_months": { "count": 462000 },
    "12-18_months": { "count": 243000 },
    "18-24_months": { "count": 112000 },
    "24+_months": { "count": 65900 }
  },
  "ttl_impact_simulation": {
    "3_months": {
      "items_removed": 1223900,
      "items_retained": 620027,
      "pct_items_removed": 66,
      "users_with_all_data_removed": 34200,
      "users_with_data_retained": 206800,
      "items_per_user_after": {
        "mean": 3.0,
        "median": 2,
        "p75": 4,
        "p90": 6,
        "p95": 10,
        "p99": 29,
        "max": 1640
      }
    },
    "6_months": { "...": "same structure" },
    "12_months": { "...": "same structure" },
    "18_months": { "...": "same structure" },
    "24_months": { "...": "same structure" }
  }
}
```

## Checklists

### Environment variables or secrets

- [x] Added parameters to Cloudformation template

### Permissions

- [x] This PR adds or changes permissions

### Monitoring

- [ ] This PR includes changes that need to be monitored in production as the scope of the change could cause issues

## Testing

- Unit tests covering age classification, scan pagination, percentile calculations, TTL simulations, and end-to-end handler orchestration
- Stress tested report compilation at production scale (synthetic users) on local machine: completes in ~24s, peaks at ~2.8GB heap (within 5GB/6GB limits). Does not include DynamoDB I/O time.
- Tested in dev (see comment in PR)

## How to review

Review commit-by-commit. Each commit builds on the previous one incrementally.