### PR TITLE
OLH-3559: normalise timestamp format differences

### DIFF
--- a/src/analyse-activity-log/scan-segment.ts
+++ b/src/analyse-activity-log/scan-segment.ts
@@ -5,7 +5,7 @@ import {
   ScanCommandOutput,
 } from "@aws-sdk/client-dynamodb";
 import { Logger } from "@aws-lambda-powertools/logger";
-import { zeroedArray } from "../common/utils.js";
+import { zeroedArray, normaliseTimestamp } from "../common/utils.js";
 import {
   AgeThresholds,
   CounterIndex,
@@ -33,7 +33,7 @@ const processItem = (
   }
 ): typeof state => {
   const userId = item.user_id?.S;
-  const ts = Math.floor(Number(item.timestamp?.N) / 1000);
+  const ts = normaliseTimestamp(Number(item.timestamp?.N));
   if (!userId || Number.isNaN(ts)) return state;
 
   if (userId !== state.currentUserId) {

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -30,3 +30,21 @@ export function getEnvironmentVariable(name: string): string {
 
 export const zeroedArray = (length: number): number[] =>
   new Array(length).fill(0);
+
+const MILLISECOND_THRESHOLD = 1_000_000_000_000;
+
+/**
+ * Normalises a timestamp to seconds, handling both seconds and milliseconds formats.
+ *
+ * Values >= 1_000_000_000_000 are treated as milliseconds and divided by 1000.
+ * Values below this threshold are assumed to already be in seconds.
+ *
+ * @example
+ * normaliseTimestamp(1_700_000_000)     // seconds → 1_700_000_000
+ * normaliseTimestamp(1_700_000_000_000) // milliseconds → 1_700_000_000
+ *
+ * @param value - Epoch timestamp in either seconds or milliseconds
+ * @returns Epoch timestamp in seconds (floored)
+ */
+export const normaliseTimestamp = (value: number): number =>
+  value >= MILLISECOND_THRESHOLD ? Math.floor(value / 1000) : value;

--- a/src/tests/normalise-timestamp.test.ts
+++ b/src/tests/normalise-timestamp.test.ts
@@ -1,0 +1,22 @@
+import { describe, test, expect } from "vitest";
+import { normaliseTimestamp } from "../common/utils.js";
+
+describe("normaliseTimestamp", () => {
+  test("returns seconds unchanged when value is in seconds range", () => {
+    expect(normaliseTimestamp(1700000000)).toBe(1700000000);
+  });
+
+  test("converts milliseconds to seconds", () => {
+    expect(normaliseTimestamp(1700000000000)).toBe(1700000000);
+  });
+
+  test("handles boundary value at threshold", () => {
+    expect(normaliseTimestamp(9999999999)).toBe(9999999999);
+    expect(normaliseTimestamp(10000000000)).toBe(10000000000);
+    expect(normaliseTimestamp(10000000000000)).toBe(10000000000);
+  });
+
+  test("floors fractional seconds after conversion", () => {
+    expect(normaliseTimestamp(1700000000123)).toBe(1700000000);
+  });
+});


### PR DESCRIPTION
## Proposed changes

### What changed

Adds a `normaliseTimestamp` utility that detects whether a timestamp is in seconds or milliseconds (based on magnitude) and normalises to seconds. Updates `scan-segment.ts` to use it instead of the hardcoded `/ 1000`.

### Why did it change

For historical reasons, staging stores activity log timestamps in seconds while dev uses milliseconds. The previous code assumed milliseconds, which broke on staging.

### Related links

- OLH-3559

## Checklists

### Environment variables or secrets

- [ ] No environment variables or secrets were added or changed

### Permissions

- [ ] This PR adds or changes permissions

### Monitoring

- [ ] This PR includes changes that need to be monitored in production as the scope of the change could cause issues

## Testing

- Unit tests for `normaliseTimestamp` (seconds passthrough, milliseconds conversion, boundary, flooring)
- Integration test in `scan-segment.test.ts` for timestamps stored in seconds
- All existing tests still passing