### PR TITLE
BAU: emit metric for unknown client_id

### DIFF
--- a/src/format-activity-log.ts
+++ b/src/format-activity-log.ts
@@ -10,8 +10,11 @@ import { sendSqsMessage } from "./common/sqs.js";
 import { getEnvironmentVariable } from "./common/utils.js";
 import { filterClients, getClientIDs } from "di-account-management-rp-registry";
 import { Logger } from "@aws-lambda-powertools/logger";
+import { MetricUnit } from "@aws-lambda-powertools/metrics";
+import { initMetrics } from "./common/metrics.js";
 
 const logger = new Logger();
+const metrics = initMetrics("format-activity-log");
 
 const createNewActivityLogEntryFromTxmaEvent = (
   txmaEvent: TxmaEvent
@@ -41,6 +44,8 @@ export const validateTxmaEventBody = (txmaEvent: TxmaEvent): void => {
   }
 
   if (txmaClientId && !getClientIDs(ENVIRONMENT).includes(txmaClientId)) {
+    metrics.addDimension("clientId", txmaClientId);
+    metrics.addMetric("unknownClientIdReceived", MetricUnit.Count, 1);
     logger.warn(`The client: "${txmaClientId}" is not in the RP registry.`);
   }
 
@@ -100,4 +105,5 @@ export const handler = async (
       }
     })
   );
+  metrics.publishStoredMetrics();
 };

--- a/src/format-user-services.ts
+++ b/src/format-user-services.ts
@@ -10,8 +10,11 @@ import { sendSqsMessage } from "./common/sqs.js";
 import { getEnvironmentVariable } from "./common/utils.js";
 import { filterClients, getClientIDs } from "di-account-management-rp-registry";
 import { Logger } from "@aws-lambda-powertools/logger";
+import { MetricUnit } from "@aws-lambda-powertools/metrics";
+import { initMetrics } from "./common/metrics.js";
 
 const logger = new Logger();
+const metrics = initMetrics("format-user-services");
 
 const validateUserService = (service: Service): void => {
   if (
@@ -66,6 +69,8 @@ const validateTxmaEvent = (txmaEvent: TxmaEvent): void => {
   }
 
   if (txmaClientId && !getClientIDs(ENVIRONMENT).includes(txmaClientId)) {
+    metrics.addDimension("clientId", txmaClientId);
+    metrics.addMetric("unknownClientIdReceived", MetricUnit.Count, 1);
     logger.warn(`The client: "${txmaClientId}" is not in the RP registry.`);
   }
 
@@ -169,4 +174,5 @@ export const handler = async (
       }
     })
   );
+  metrics.publishStoredMetrics();
 };

--- a/src/tests/format-activity-log.test.ts
+++ b/src/tests/format-activity-log.test.ts
@@ -24,6 +24,16 @@ import { DroppedEventError } from "../common/model.js";
 import { Context } from "aws-lambda";
 import { Logger } from "@aws-lambda-powertools/logger";
 
+const mockMetrics = vi.hoisted(() => ({
+  addDimension: vi.fn(),
+  addMetric: vi.fn(),
+  publishStoredMetrics: vi.fn(),
+}));
+const mockInitMetrics = vi.hoisted(() => vi.fn(() => mockMetrics));
+vi.mock("../common/metrics.js", () => ({
+  initMetrics: mockInitMetrics,
+}));
+
 const sqsMock = mockClient(SQSClient);
 
 describe("handler", () => {
@@ -86,6 +96,19 @@ describe("handler", () => {
     expect(Logger.prototype.warn).toHaveBeenCalledWith(
       'The client: "UNKNOWN" is not in the RP registry.'
     );
+    expect(mockMetrics.addDimension).toHaveBeenCalledWith("clientId", "UNKNOWN");
+    expect(mockMetrics.addMetric).toHaveBeenCalledWith("unknownClientIdReceived", "Count", 1);
+    expect(mockMetrics.publishStoredMetrics).toHaveBeenCalled();
+  });
+
+  test("does not emit metric when client_id is recognised", async () => {
+    const client_id = "EMGmY82k-92QSakDl_9keKDFmZY"; //home non prod ID
+
+    const TEST_EVENT: DynamoDBStreamEvent = {
+      Records: [generateDynamoSteamRecord(client_id)],
+    };
+    await handler(TEST_EVENT, {} as Context);
+    expect(mockMetrics.addMetric).not.toHaveBeenCalled();
   });
 
   describe("error handing ", () => {

--- a/src/tests/format-user-services.test.ts
+++ b/src/tests/format-user-services.test.ts
@@ -22,6 +22,16 @@ import {
 import { sendSqsMessage } from "../common/sqs.js";
 import { Logger } from "@aws-lambda-powertools/logger";
 
+const mockMetrics = vi.hoisted(() => ({
+  addDimension: vi.fn(),
+  addMetric: vi.fn(),
+  publishStoredMetrics: vi.fn(),
+}));
+const mockInitMetrics = vi.hoisted(() => vi.fn(() => mockMetrics));
+vi.mock("../common/metrics.js", () => ({
+  initMetrics: mockInitMetrics,
+}));
+
 const sqsMock = mockClient(SQSClient);
 
 describe("newServicePresenter", () => {
@@ -388,6 +398,23 @@ describe("handler", () => {
     expect(Logger.prototype.warn).toHaveBeenCalledWith(
       'The client: "UNKNOWN" is not in the RP registry.'
     );
+    expect(mockMetrics.addDimension).toHaveBeenCalledWith("clientId", "UNKNOWN");
+    expect(mockMetrics.addMetric).toHaveBeenCalledWith("unknownClientIdReceived", "Count", 1);
+    expect(mockMetrics.publishStoredMetrics).toHaveBeenCalled();
+  });
+
+  test("does not emit metric when client_id is recognised", async () => {
+    const emptyServiceList = [] as Service[];
+    const known_client_id = "EMGmY82k-92QSakDl_9keKDFmZY"; //home non prod ID
+    const inputSQSEvent = makeSQSInputFixture([
+      {
+        TxmaEvent: makeTxmaEvent(known_client_id, userId),
+        ServiceList: emptyServiceList,
+      },
+    ]);
+
+    await handler({ Records: inputSQSEvent }, {} as Context);
+    expect(mockMetrics.addMetric).not.toHaveBeenCalled();
   });
 });
 

--- a/template.yaml
+++ b/template.yaml
@@ -1593,7 +1593,7 @@ Resources:
       Statistic: Sum
       Period: 300
       EvaluationPeriods: 1
-      Threshold: 1
+      Threshold: 20
       ComparisonOperator: GreaterThanOrEqualToThreshold
       TreatMissingData: notBreaching
       ActionsEnabled: true
@@ -3036,7 +3036,7 @@ Resources:
       Statistic: Sum
       Period: 300
       EvaluationPeriods: 1
-      Threshold: 1
+      Threshold: 20
       ComparisonOperator: GreaterThanOrEqualToThreshold
       TreatMissingData: notBreaching
       ActionsEnabled: true


### PR DESCRIPTION
## Proposed changes

Emit a metric for unknown client_ids and raise alarm threshold.

### What changed

- Both `format-activity-log` and `format-user-services` now emit an `unknownClientIdReceived` CloudWatch metric with the `clientId` as a dimension when they encounter a client_id not in the RP registry.
- Raised the `FormatActivityLogConsoleWarningsAlarm` and `FormatUserServicesConsoleWarningsAlarm` thresholds from 1 to 20 per 5-minute period.

### Why did it change

The existing Slack alarms tell us unknown client_ids are being received but not which ones. The new metric can be dashboarded to give better observability of which client_ids are missing from the registry without digging through logs. The alarm threshold was raised to reduce notification fatigue from known noisy clients. Most of the time we get these its because we receive very low amounts of data from new clients where our RP registry needs updating.

The threshold raising to 20 will still help us be alerted to incidents with mass mis-alignment of known client IDs.

### Related links

None

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Permissions

- [ ] This PR adds or changes permissions

### Monitoring

- [ ] This PR includes changes that need to be monitored in production as the scope of the change could cause issues

## How to review

Review the implementation in `format-activity-log.ts` and `format-user-services.ts` — the pattern follows `notification-service` exactly. Check the threshold change in `template.yaml` is appropriate.