### PR TITLE
OLH-3559: Self-invoking scan for large table analysis

### DIFF
--- a/src/analyse-activity-log/chunk-result.ts
+++ b/src/analyse-activity-log/chunk-result.ts
@@ -1,0 +1,108 @@
+import { CounterIndex } from "./age-thresholds.js";
+
+export interface ChunkResult {
+  totalCountFrequency: Record<number, number>;
+  ageBuckets: number[];
+  ttlRetainedFrequency: Record<string, Record<number, number>>;
+  usersFullyRemovedByTtl: Record<string, number>;
+}
+
+const TTL_THRESHOLDS = [
+  { key: "3_months", index: CounterIndex.OLDER_3M },
+  { key: "6_months", index: CounterIndex.OLDER_6M },
+  { key: "12_months", index: CounterIndex.OLDER_12M },
+  { key: "18_months", index: CounterIndex.OLDER_18M },
+  { key: "24_months", index: CounterIndex.OLDER_24M },
+] as const;
+
+export const buildChunkResult = (
+  perUserCounters: number[][],
+  exclusiveAgeBuckets: number[]
+): ChunkResult => {
+  const totalCountFrequency: Record<number, number> = {};
+  const ttlRetainedFrequency: Record<string, Record<number, number>> = {};
+  const usersFullyRemovedByTtl: Record<string, number> = {};
+
+  for (const { key } of TTL_THRESHOLDS) {
+    ttlRetainedFrequency[key] = {};
+    usersFullyRemovedByTtl[key] = 0;
+  }
+
+  for (const counters of perUserCounters) {
+    const total = counters[CounterIndex.TOTAL];
+    totalCountFrequency[total] = (totalCountFrequency[total] ?? 0) + 1;
+
+    for (const { key, index } of TTL_THRESHOLDS) {
+      const retained = total - counters[index];
+      if (retained === 0) {
+        usersFullyRemovedByTtl[key]++;
+      } else {
+        ttlRetainedFrequency[key][retained] =
+          (ttlRetainedFrequency[key][retained] ?? 0) + 1;
+      }
+    }
+  }
+
+  return {
+    totalCountFrequency,
+    ageBuckets: exclusiveAgeBuckets,
+    ttlRetainedFrequency,
+    usersFullyRemovedByTtl,
+  };
+};
+
+const mergeFrequencyMaps = (
+  a: Record<number, number>,
+  b: Record<number, number>
+): Record<number, number> => {
+  const result = { ...a };
+  for (const [key, value] of Object.entries(b)) {
+    const k = Number(key);
+    result[k] = (result[k] ?? 0) + value;
+  }
+  return result;
+};
+
+export const mergeChunkResults = (
+  a: ChunkResult,
+  b: ChunkResult
+): ChunkResult => {
+  const ageBuckets = a.ageBuckets.map((v, i) => v + b.ageBuckets[i]);
+
+  const ttlRetainedFrequency: Record<string, Record<number, number>> = {};
+  const usersFullyRemovedByTtl: Record<string, number> = {};
+
+  for (const { key } of TTL_THRESHOLDS) {
+    ttlRetainedFrequency[key] = mergeFrequencyMaps(
+      a.ttlRetainedFrequency[key],
+      b.ttlRetainedFrequency[key]
+    );
+    usersFullyRemovedByTtl[key] =
+      a.usersFullyRemovedByTtl[key] + b.usersFullyRemovedByTtl[key];
+  }
+
+  return {
+    totalCountFrequency: mergeFrequencyMaps(
+      a.totalCountFrequency,
+      b.totalCountFrequency
+    ),
+    ageBuckets,
+    ttlRetainedFrequency,
+    usersFullyRemovedByTtl,
+  };
+};
+
+export const emptyChunkResult = (numAgeBuckets: number): ChunkResult => {
+  const ttlRetainedFrequency: Record<string, Record<number, number>> = {};
+  const usersFullyRemovedByTtl: Record<string, number> = {};
+  for (const { key } of TTL_THRESHOLDS) {
+    ttlRetainedFrequency[key] = {};
+    usersFullyRemovedByTtl[key] = 0;
+  }
+  return {
+    totalCountFrequency: {},
+    ageBuckets: new Array(numAgeBuckets).fill(0),
+    ttlRetainedFrequency,
+    usersFullyRemovedByTtl,
+  };
+};

--- a/src/analyse-activity-log/compute-report.ts
+++ b/src/analyse-activity-log/compute-report.ts
@@ -14,57 +14,6 @@ export interface ConcentrationResult {
   top_10_pct_users_own_pct_of_items: number;
 }
 
-const percentileAtRank = (sorted: number[], percentile: number): number => {
-  const index = Math.ceil((percentile / 100) * sorted.length) - 1;
-  return sorted[Math.max(0, index)];
-};
-
-export const computePercentiles = (
-  sortedCounts: number[]
-): PercentileResult => {
-  const sum = sortedCounts.reduce((a, b) => a + b, 0);
-  return {
-    mean: sum / sortedCounts.length,
-    median: percentileAtRank(sortedCounts, 50),
-    p75: percentileAtRank(sortedCounts, 75),
-    p90: percentileAtRank(sortedCounts, 90),
-    p95: percentileAtRank(sortedCounts, 95),
-    p99: percentileAtRank(sortedCounts, 99),
-    max: sortedCounts.at(-1)!,
-  };
-};
-
-const topNPercentOwnership = (
-  descendingCounts: number[],
-  percent: number,
-  totalItems: number
-): number => {
-  const n = Math.ceil((percent / 100) * descendingCounts.length);
-  const topSum = descendingCounts.slice(0, n).reduce((a, b) => a + b, 0);
-  return Math.round((topSum / totalItems) * 100);
-};
-
-export const computeConcentration = (
-  descendingCounts: number[],
-  totalItems: number
-): ConcentrationResult => ({
-  top_1_pct_users_own_pct_of_items: topNPercentOwnership(
-    descendingCounts,
-    1,
-    totalItems
-  ),
-  top_5_pct_users_own_pct_of_items: topNPercentOwnership(
-    descendingCounts,
-    5,
-    totalItems
-  ),
-  top_10_pct_users_own_pct_of_items: topNPercentOwnership(
-    descendingCounts,
-    10,
-    totalItems
-  ),
-});
-
 export interface UserBucket {
   user_count: number;
   total_items: number;
@@ -83,25 +32,6 @@ const USER_BUCKET_RANGES = [
   { label: "10001-100000", min: 10001, max: 100000 },
   { label: "100000+", min: 100001, max: Infinity },
 ] as const;
-
-export const computeUserBuckets = (
-  totalCounts: number[]
-): Record<string, UserBucket> => {
-  const buckets: Record<string, UserBucket> = {};
-  for (const { label } of USER_BUCKET_RANGES) {
-    buckets[label] = { user_count: 0, total_items: 0 };
-  }
-  for (const count of totalCounts) {
-    const range = USER_BUCKET_RANGES.find(
-      (r) => count >= r.min && count <= r.max
-    );
-    if (range) {
-      buckets[range.label].user_count++;
-      buckets[range.label].total_items += count;
-    }
-  }
-  return buckets;
-};
 
 export const AGE_BUCKET_LABELS = [
   "0-1_months",
@@ -137,37 +67,117 @@ export interface TtlSimulationResult {
   items_per_user_after: PercentileResult;
 }
 
-export const computeTtlSimulation = (
-  perUserCounters: number[][],
-  thresholdIndex: number,
-  totalItems: number
-): TtlSimulationResult => {
-  let itemsRemoved = 0;
-  let usersWithAllDataRemoved = 0;
-  const retainedCounts: number[] = [];
+export const computePercentilesFromFrequency = (
+  frequency: Record<number, number>
+): PercentileResult => {
+  const entries = Object.entries(frequency)
+    .map(([k, v]) => [Number(k), v] as [number, number])
+    .sort((a, b) => a[0] - b[0]);
 
-  for (const counters of perUserCounters) {
-    const removed = counters[thresholdIndex];
-    const retained = counters[0] - removed;
-    itemsRemoved += removed;
-    if (retained === 0) {
-      usersWithAllDataRemoved++;
-    } else {
-      retainedCounts.push(retained);
-    }
+  let totalUsers = 0;
+  let totalItems = 0;
+  for (const [count, users] of entries) {
+    totalUsers += users;
+    totalItems += count * users;
   }
 
-  retainedCounts.sort((a, b) => a - b);
+  const percentileFromEntries = (percentile: number): number => {
+    const rank = Math.ceil((percentile / 100) * totalUsers);
+    let cumulative = 0;
+    for (const [count, users] of entries) {
+      cumulative += users;
+      if (cumulative >= rank) return count;
+    }
+    return entries.at(-1)![0];
+  };
+
+  return {
+    mean: totalItems / totalUsers,
+    median: percentileFromEntries(50),
+    p75: percentileFromEntries(75),
+    p90: percentileFromEntries(90),
+    p95: percentileFromEntries(95),
+    p99: percentileFromEntries(99),
+    max: entries.at(-1)![0],
+  };
+};
+
+export const computeConcentrationFromFrequency = (
+  frequency: Record<number, number>
+): ConcentrationResult => {
+  const entries = Object.entries(frequency)
+    .map(([k, v]) => [Number(k), v] as [number, number])
+    .sort((a, b) => b[0] - a[0]);
+
+  let totalUsers = 0;
+  let totalItems = 0;
+  for (const [count, users] of entries) {
+    totalUsers += users;
+    totalItems += count * users;
+  }
+
+  const topNPct = (percent: number): number => {
+    const n = Math.ceil((percent / 100) * totalUsers);
+    let usersAccum = 0;
+    let itemsAccum = 0;
+    for (const [count, users] of entries) {
+      const take = Math.min(users, n - usersAccum);
+      itemsAccum += count * take;
+      usersAccum += take;
+      if (usersAccum >= n) break;
+    }
+    return Math.round((itemsAccum / totalItems) * 100);
+  };
+
+  return {
+    top_1_pct_users_own_pct_of_items: topNPct(1),
+    top_5_pct_users_own_pct_of_items: topNPct(5),
+    top_10_pct_users_own_pct_of_items: topNPct(10),
+  };
+};
+
+export const computeUserBucketsFromFrequency = (
+  frequency: Record<number, number>
+): Record<string, UserBucket> => {
+  const buckets: Record<string, UserBucket> = {};
+  for (const { label } of USER_BUCKET_RANGES) {
+    buckets[label] = { user_count: 0, total_items: 0 };
+  }
+  for (const [countStr, users] of Object.entries(frequency)) {
+    const count = Number(countStr);
+    const range = USER_BUCKET_RANGES.find(
+      (r) => count >= r.min && count <= r.max
+    );
+    if (range) {
+      buckets[range.label].user_count += users;
+      buckets[range.label].total_items += count * users;
+    }
+  }
+  return buckets;
+};
+
+export const computeTtlSimulationFromFrequency = (
+  retainedFrequency: Record<number, number>,
+  usersFullyRemoved: number,
+  totalItems: number,
+  totalUsers: number
+): TtlSimulationResult => {
+  let itemsRetained = 0;
+  for (const [count, users] of Object.entries(retainedFrequency)) {
+    itemsRetained += Number(count) * users;
+  }
+  const itemsRemoved = totalItems - itemsRetained;
+
+  const hasRetained = Object.keys(retainedFrequency).length > 0;
 
   return {
     items_removed: itemsRemoved,
-    items_retained: totalItems - itemsRemoved,
+    items_retained: itemsRetained,
     pct_items_removed: Math.round((itemsRemoved / totalItems) * 100),
-    users_with_all_data_removed: usersWithAllDataRemoved,
-    users_with_data_retained: perUserCounters.length - usersWithAllDataRemoved,
-    items_per_user_after:
-      retainedCounts.length > 0
-        ? computePercentiles(retainedCounts)
-        : { mean: 0, median: 0, p75: 0, p90: 0, p95: 0, p99: 0, max: 0 },
+    users_with_all_data_removed: usersFullyRemoved,
+    users_with_data_retained: totalUsers - usersFullyRemoved,
+    items_per_user_after: hasRetained
+      ? computePercentilesFromFrequency(retainedFrequency)
+      : { mean: 0, median: 0, p75: 0, p90: 0, p95: 0, p99: 0, max: 0 },
   };
 };

--- a/src/analyse-activity-log/handler.ts
+++ b/src/analyse-activity-log/handler.ts
@@ -1,8 +1,17 @@
 import { Logger } from "@aws-lambda-powertools/logger";
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import {
+  LambdaClient,
+  InvokeCommand,
+  InvocationType,
+} from "@aws-sdk/client-lambda";
 import { Context } from "aws-lambda";
-import { scanSegment } from "./scan-segment.js";
-import { ageThresholdsFromNow, CounterIndex } from "./age-thresholds.js";
+import { scanSegment, SegmentCursor } from "./scan-segment.js";
+import {
+  AgeThresholds,
+  ageThresholdsFromNow,
+  CounterIndex,
+} from "./age-thresholds.js";
 import {
   computePercentiles,
   computeConcentration,
@@ -18,12 +27,20 @@ import {
 import { getEnvironmentVariable, zeroedArray } from "../common/utils.js";
 
 const SCAN_BUDGET_MS = 13 * 60 * 1000;
+const MAX_INVOCATIONS = 20;
 
 const logger = new Logger({ serviceName: "analyse-activity-log" });
 const client = new DynamoDBClient({});
+const lambdaClient = new LambdaClient({});
 
 export interface AnalyseActivityLogEvent {
   totalSegments: number;
+  scanBudgetMs?: number;
+  maxInvocations?: number;
+  cursors?: (SegmentCursor | null)[];
+  invocation?: number;
+  ageThresholds?: AgeThresholds;
+  scanStartedAt?: string;
 }
 
 export interface ScanReport {
@@ -55,14 +72,44 @@ export const handler = async (
 
   logger.info("Analysis started", { totalSegments: event.totalSegments });
 
+  const invocation = event.invocation ?? 1;
+  const maxInvocations = Math.min(
+    event.maxInvocations ?? MAX_INVOCATIONS,
+    MAX_INVOCATIONS
+  );
+  const scanBudgetMs = Math.min(
+    event.scanBudgetMs ?? SCAN_BUDGET_MS,
+    SCAN_BUDGET_MS
+  );
+
+  if (invocation > maxInvocations) {
+    throw new Error(
+      `Exceeded maximum invocations (${maxInvocations}). Scan did not converge.`
+    );
+  }
+
   const startTime = Date.now();
-  const deadlineMs = startTime + SCAN_BUDGET_MS;
-  const ageThresholds = ageThresholdsFromNow(Math.floor(startTime / 1000));
+  const deadlineMs = startTime + scanBudgetMs;
+  const scanStartedAt =
+    event.scanStartedAt ?? new Date(startTime).toISOString();
+  const ageThresholds: AgeThresholds =
+    event.ageThresholds ?? ageThresholdsFromNow(Math.floor(startTime / 1000));
   const tableName = getEnvironmentVariable("TABLE_NAME");
 
-  const segments = [...new Array(event.totalSegments).keys()];
+  const segmentsToScan = event.cursors
+    ? event.cursors
+        .map((cursor, segment) => ({ cursor, segment }))
+        .filter(
+          (entry): entry is { cursor: SegmentCursor; segment: number } =>
+            entry.cursor !== null
+        )
+    : [...new Array(event.totalSegments).keys()].map((segment) => ({
+        cursor: undefined as SegmentCursor | undefined,
+        segment,
+      }));
+
   const results = await Promise.all(
-    segments.map((segment) =>
+    segmentsToScan.map(({ segment, cursor }) =>
       scanSegment(
         client,
         tableName,
@@ -71,6 +118,7 @@ export const handler = async (
         ageThresholds,
         {
           deadlineMs,
+          resumeFrom: cursor,
         }
       )
     )
@@ -80,10 +128,49 @@ export const handler = async (
   const scanComplete = results.every((r) => r.exhausted);
 
   if (!scanComplete) {
-    logger.info("Scan incomplete — deadline reached", {
-      incompleteSegments: results.filter((r) => !r.exhausted).length,
+    const nextCursors: (SegmentCursor | null)[] = new Array(
+      event.totalSegments
+    ).fill(null);
+    for (let i = 0; i < segmentsToScan.length; i++) {
+      nextCursors[segmentsToScan[i].segment] = results[i].cursor ?? null;
+    }
+    const functionName = getEnvironmentVariable("AWS_LAMBDA_FUNCTION_NAME");
+
+    const nextEvent: AnalyseActivityLogEvent = {
+      totalSegments: event.totalSegments,
+      scanBudgetMs,
+      maxInvocations,
+      cursors: nextCursors,
+      invocation: invocation + 1,
+      ageThresholds,
+      scanStartedAt,
+    };
+
+    const payload = Buffer.from(JSON.stringify(nextEvent));
+
+    logger.info("Scan incomplete, invoking next chunk", {
+      incompleteSegments: nextCursors.filter((c) => c !== null).length,
       scanDurationSeconds,
+      payloadBytes: payload.byteLength,
     });
+
+    if (payload.byteLength > 256_000) {
+      throw new Error(
+        `Payload too large for async invoke: ${payload.byteLength} bytes`
+      );
+    }
+
+    const response = await lambdaClient.send(
+      new InvokeCommand({
+        FunctionName: functionName,
+        InvocationType: InvocationType.Event,
+        Payload: payload,
+      })
+    );
+
+    if (response.StatusCode !== 202) {
+      throw new Error(`Async invoke returned status ${response.StatusCode}`);
+    }
   }
 
   logger.info("Compiling report");
@@ -147,10 +234,12 @@ export const handler = async (
   };
 
   const report: ScanReport = {
-    scan_date: new Date(startTime).toISOString(),
+    scan_date: scanStartedAt,
     total_items: totalItems,
     total_users: allCounters.length,
-    scan_duration_seconds: scanDurationSeconds,
+    scan_duration_seconds: Math.round(
+      (Date.now() - new Date(scanStartedAt).getTime()) / 1000
+    ),
     scan_complete: scanComplete,
     items_per_user_distribution,
     concentration,

--- a/src/analyse-activity-log/handler.ts
+++ b/src/analyse-activity-log/handler.ts
@@ -7,24 +7,26 @@ import {
 } from "@aws-sdk/client-lambda";
 import { Context } from "aws-lambda";
 import { scanSegment, SegmentCursor } from "./scan-segment.js";
+import { AgeThresholds, ageThresholdsFromNow } from "./age-thresholds.js";
 import {
-  AgeThresholds,
-  ageThresholdsFromNow,
-  CounterIndex,
-} from "./age-thresholds.js";
+  buildChunkResult,
+  mergeChunkResults,
+  emptyChunkResult,
+  ChunkResult,
+} from "./chunk-result.js";
 import {
-  computePercentiles,
-  computeConcentration,
-  computeUserBuckets,
+  computePercentilesFromFrequency,
+  computeConcentrationFromFrequency,
+  computeUserBucketsFromFrequency,
   computeItemsByAgeBucket,
-  computeTtlSimulation,
+  computeTtlSimulationFromFrequency,
   AGE_BUCKET_LABELS,
   PercentileResult,
   ConcentrationResult,
   UserBucket,
   TtlSimulationResult,
 } from "./compute-report.js";
-import { getEnvironmentVariable, zeroedArray } from "../common/utils.js";
+import { getEnvironmentVariable } from "../common/utils.js";
 
 const SCAN_BUDGET_MS = 13 * 60 * 1000;
 const MAX_INVOCATIONS = 20;
@@ -41,6 +43,7 @@ export interface AnalyseActivityLogEvent {
   invocation?: number;
   ageThresholds?: AgeThresholds;
   scanStartedAt?: string;
+  accumulated?: ChunkResult;
 }
 
 export interface ScanReport {
@@ -125,6 +128,16 @@ export const handler = async (
   );
 
   const scanDurationSeconds = Math.round((Date.now() - startTime) / 1000);
+
+  const chunkResult = results.reduce((acc, r) => {
+    const partial = buildChunkResult(r.perUserCounters, r.exclusiveAgeBuckets);
+    return mergeChunkResults(acc, partial);
+  }, emptyChunkResult(AGE_BUCKET_LABELS.length));
+
+  const accumulated = event.accumulated
+    ? mergeChunkResults(event.accumulated, chunkResult)
+    : chunkResult;
+
   const scanComplete = results.every((r) => r.exhausted);
 
   if (!scanComplete) {
@@ -144,6 +157,7 @@ export const handler = async (
       invocation: invocation + 1,
       ageThresholds,
       scanStartedAt,
+      accumulated,
     };
 
     const payload = Buffer.from(JSON.stringify(nextEvent));
@@ -175,76 +189,48 @@ export const handler = async (
 
   logger.info("Compiling report");
 
-  const allCounters = results.flatMap((r) => r.perUserCounters);
-
-  if (allCounters.length === 0) {
+  const frequency = accumulated.totalCountFrequency;
+  if (Object.keys(frequency).length === 0) {
     throw new Error("Scan returned no items");
   }
 
-  const totalCounts = new Array(allCounters.length);
   let totalItems = 0;
-  for (let i = 0; i < allCounters.length; i++) {
-    const count = allCounters[i][CounterIndex.TOTAL];
-    totalCounts[i] = count;
-    totalItems += count;
+  let totalUsers = 0;
+  for (const [count, users] of Object.entries(frequency)) {
+    totalItems += Number(count) * users;
+    totalUsers += users;
   }
 
-  totalCounts.sort((a, b) => a - b);
-  const items_per_user_distribution = computePercentiles(totalCounts);
+  const TTL_KEYS = [
+    "3_months",
+    "6_months",
+    "12_months",
+    "18_months",
+    "24_months",
+  ] as const;
 
-  totalCounts.reverse();
-  const concentration = computeConcentration(totalCounts, totalItems);
-
-  const items_per_user_buckets = computeUserBuckets(totalCounts);
-
-  const ageBucketSums = zeroedArray(AGE_BUCKET_LABELS.length);
-  for (const r of results) {
-    for (let i = 0; i < r.exclusiveAgeBuckets.length; i++) {
-      ageBucketSums[i] += r.exclusiveAgeBuckets[i];
-    }
+  const ttl_impact_simulation: Record<string, TtlSimulationResult> = {};
+  for (const key of TTL_KEYS) {
+    ttl_impact_simulation[key] = computeTtlSimulationFromFrequency(
+      accumulated.ttlRetainedFrequency[key],
+      accumulated.usersFullyRemovedByTtl[key],
+      totalItems,
+      totalUsers
+    );
   }
-  const items_by_age_bucket = computeItemsByAgeBucket(ageBucketSums);
-
-  const ttl_impact_simulation: Record<string, TtlSimulationResult> = {
-    "3_months": computeTtlSimulation(
-      allCounters,
-      CounterIndex.OLDER_3M,
-      totalItems
-    ),
-    "6_months": computeTtlSimulation(
-      allCounters,
-      CounterIndex.OLDER_6M,
-      totalItems
-    ),
-    "12_months": computeTtlSimulation(
-      allCounters,
-      CounterIndex.OLDER_12M,
-      totalItems
-    ),
-    "18_months": computeTtlSimulation(
-      allCounters,
-      CounterIndex.OLDER_18M,
-      totalItems
-    ),
-    "24_months": computeTtlSimulation(
-      allCounters,
-      CounterIndex.OLDER_24M,
-      totalItems
-    ),
-  };
 
   const report: ScanReport = {
     scan_date: scanStartedAt,
     total_items: totalItems,
-    total_users: allCounters.length,
+    total_users: totalUsers,
     scan_duration_seconds: Math.round(
       (Date.now() - new Date(scanStartedAt).getTime()) / 1000
     ),
     scan_complete: scanComplete,
-    items_per_user_distribution,
-    concentration,
-    items_per_user_buckets,
-    items_by_age_bucket,
+    items_per_user_distribution: computePercentilesFromFrequency(frequency),
+    concentration: computeConcentrationFromFrequency(frequency),
+    items_per_user_buckets: computeUserBucketsFromFrequency(frequency),
+    items_by_age_bucket: computeItemsByAgeBucket(accumulated.ageBuckets),
     ttl_impact_simulation,
   };
 

--- a/src/analyse-activity-log/handler.ts
+++ b/src/analyse-activity-log/handler.ts
@@ -17,6 +17,8 @@ import {
 } from "./compute-report.js";
 import { getEnvironmentVariable, zeroedArray } from "../common/utils.js";
 
+const SCAN_BUDGET_MS = 13 * 60 * 1000;
+
 const logger = new Logger({ serviceName: "analyse-activity-log" });
 const client = new DynamoDBClient({});
 
@@ -29,6 +31,7 @@ export interface ScanReport {
   total_items: number;
   total_users: number;
   scan_duration_seconds: number;
+  scan_complete: boolean;
   items_per_user_distribution: PercentileResult;
   concentration: ConcentrationResult;
   items_per_user_buckets: Record<string, UserBucket>;
@@ -53,6 +56,7 @@ export const handler = async (
   logger.info("Analysis started", { totalSegments: event.totalSegments });
 
   const startTime = Date.now();
+  const deadlineMs = startTime + SCAN_BUDGET_MS;
   const ageThresholds = ageThresholdsFromNow(Math.floor(startTime / 1000));
   const tableName = getEnvironmentVariable("TABLE_NAME");
 
@@ -64,12 +68,23 @@ export const handler = async (
         tableName,
         segment,
         event.totalSegments,
-        ageThresholds
+        ageThresholds,
+        {
+          deadlineMs,
+        }
       )
     )
   );
 
   const scanDurationSeconds = Math.round((Date.now() - startTime) / 1000);
+  const scanComplete = results.every((r) => r.exhausted);
+
+  if (!scanComplete) {
+    logger.info("Scan incomplete — deadline reached", {
+      incompleteSegments: results.filter((r) => !r.exhausted).length,
+      scanDurationSeconds,
+    });
+  }
 
   logger.info("Compiling report");
 
@@ -136,6 +151,7 @@ export const handler = async (
     total_items: totalItems,
     total_users: allCounters.length,
     scan_duration_seconds: scanDurationSeconds,
+    scan_complete: scanComplete,
     items_per_user_distribution,
     concentration,
     items_per_user_buckets,

--- a/src/analyse-activity-log/scan-segment.ts
+++ b/src/analyse-activity-log/scan-segment.ts
@@ -107,7 +107,7 @@ export const scanSegment = async (
 
     lastEvaluatedKey = response.LastEvaluatedKey;
 
-    if (hasDeadline && lastEvaluatedKey && Date.now() >= options!.deadlineMs!) {
+    if (hasDeadline && lastEvaluatedKey && Date.now() >= options.deadlineMs!) {
       logger.info("Segment deadline reached", {
         segment,
         items: state.totalItems,

--- a/src/analyse-activity-log/scan-segment.ts
+++ b/src/analyse-activity-log/scan-segment.ts
@@ -19,6 +19,17 @@ export interface SegmentResult {
   exclusiveAgeBuckets: number[];
 }
 
+export interface SegmentCursor {
+  lastEvaluatedKey: Record<string, AttributeValue>;
+  lastUserId: string;
+  lastUserCounters: number[];
+}
+
+export interface TimedSegmentResult extends SegmentResult {
+  exhausted: boolean;
+  cursor?: SegmentCursor;
+}
+
 const logger = new Logger({ serviceName: "analyse-activity-log" });
 
 const processItem = (
@@ -57,17 +68,22 @@ export const scanSegment = async (
   tableName: string,
   segment: number,
   totalSegments: number,
-  ageThresholds: AgeThresholds
-): Promise<SegmentResult> => {
+  ageThresholds: AgeThresholds,
+  options?: { deadlineMs?: number; resumeFrom?: SegmentCursor }
+): Promise<TimedSegmentResult> => {
   const state = {
     perUserCounters: [] as number[][],
     exclusiveAgeBuckets: zeroedArray(AGE_BUCKET_LABELS.length),
-    currentUserId: null as string | null,
-    counters: zeroedArray(Object.keys(CounterIndex).length),
+    currentUserId: options?.resumeFrom?.lastUserId ?? null,
+    counters: options?.resumeFrom?.lastUserCounters
+      ? [...options.resumeFrom.lastUserCounters]
+      : zeroedArray(Object.keys(CounterIndex).length),
     totalItems: 0,
   };
 
-  let lastEvaluatedKey: ScanCommandOutput["LastEvaluatedKey"];
+  let lastEvaluatedKey: ScanCommandOutput["LastEvaluatedKey"] =
+    options?.resumeFrom?.lastEvaluatedKey;
+  const hasDeadline = options?.deadlineMs !== undefined;
 
   do {
     const response = await client.send(
@@ -90,6 +106,24 @@ export const scanSegment = async (
     }
 
     lastEvaluatedKey = response.LastEvaluatedKey;
+
+    if (hasDeadline && lastEvaluatedKey && Date.now() >= options!.deadlineMs!) {
+      logger.info("Segment deadline reached", {
+        segment,
+        items: state.totalItems,
+      });
+
+      return {
+        perUserCounters: state.perUserCounters,
+        exclusiveAgeBuckets: state.exclusiveAgeBuckets,
+        exhausted: false,
+        cursor: {
+          lastEvaluatedKey,
+          lastUserId: state.currentUserId!,
+          lastUserCounters: state.counters,
+        },
+      };
+    }
   } while (lastEvaluatedKey);
 
   if (state.currentUserId !== null) {
@@ -105,5 +139,6 @@ export const scanSegment = async (
   return {
     perUserCounters: state.perUserCounters,
     exclusiveAgeBuckets: state.exclusiveAgeBuckets,
+    exhausted: true,
   };
 };

--- a/src/tests/analyse-activity-log/chunk-result.test.ts
+++ b/src/tests/analyse-activity-log/chunk-result.test.ts
@@ -1,0 +1,80 @@
+import { describe, test, expect } from "vitest";
+import {
+  buildChunkResult,
+  mergeChunkResults,
+  emptyChunkResult,
+} from "../../analyse-activity-log/chunk-result.js";
+
+describe("buildChunkResult", () => {
+  test("builds frequency map from per-user counters", () => {
+    const perUserCounters = [
+      [3, 1, 0, 0, 0, 0, 0],
+      [3, 2, 1, 0, 0, 0, 0],
+      [5, 4, 3, 2, 1, 0, 0],
+    ];
+    const ageBuckets = [4, 3, 2, 1, 1, 0, 0];
+
+    const result = buildChunkResult(perUserCounters, ageBuckets);
+
+    expect(result.totalCountFrequency).toEqual({ 3: 2, 5: 1 });
+    expect(result.ageBuckets).toEqual([4, 3, 2, 1, 1, 0, 0]);
+  });
+
+  test("builds TTL retained frequency correctly", () => {
+    const perUserCounters = [
+      [10, 10, 10, 5, 0, 0, 0],
+      [6, 4, 2, 0, 0, 0, 0],
+    ];
+    const ageBuckets = [0, 0, 0, 0, 0, 0, 0];
+
+    const result = buildChunkResult(perUserCounters, ageBuckets);
+
+    expect(result.usersFullyRemovedByTtl["3_months"]).toBe(1);
+    expect(result.ttlRetainedFrequency["3_months"]).toEqual({ 4: 1 });
+  });
+
+  test("empty counters produce empty result", () => {
+    const result = buildChunkResult([], [0, 0, 0, 0, 0, 0, 0]);
+    expect(result.totalCountFrequency).toEqual({});
+  });
+});
+
+describe("mergeChunkResults", () => {
+  test("merges frequency maps additively", () => {
+    const a = buildChunkResult([[3, 1, 0, 0, 0, 0, 0]], [2, 1, 0, 0, 0, 0, 0]);
+    const b = buildChunkResult(
+      [
+        [3, 2, 1, 0, 0, 0, 0],
+        [5, 3, 2, 1, 0, 0, 0],
+      ],
+      [3, 2, 1, 1, 0, 0, 0]
+    );
+
+    const merged = mergeChunkResults(a, b);
+
+    expect(merged.totalCountFrequency).toEqual({ 3: 2, 5: 1 });
+    expect(merged.ageBuckets).toEqual([5, 3, 1, 1, 0, 0, 0]);
+  });
+
+  test("merges TTL data", () => {
+    const a = buildChunkResult(
+      [[10, 10, 10, 0, 0, 0, 0]],
+      [0, 0, 0, 0, 0, 0, 0]
+    );
+    const b = buildChunkResult([[5, 3, 0, 0, 0, 0, 0]], [0, 0, 0, 0, 0, 0, 0]);
+
+    const merged = mergeChunkResults(a, b);
+
+    expect(merged.usersFullyRemovedByTtl["3_months"]).toBe(1);
+    expect(merged.ttlRetainedFrequency["3_months"]).toEqual({ 5: 1 });
+  });
+});
+
+describe("emptyChunkResult", () => {
+  test("produces zeroed result", () => {
+    const result = emptyChunkResult(7);
+    expect(result.totalCountFrequency).toEqual({});
+    expect(result.ageBuckets).toEqual([0, 0, 0, 0, 0, 0, 0]);
+    expect(result.usersFullyRemovedByTtl["3_months"]).toBe(0);
+  });
+});

--- a/src/tests/analyse-activity-log/compute-report.test.ts
+++ b/src/tests/analyse-activity-log/compute-report.test.ts
@@ -1,103 +1,11 @@
 import { describe, test, expect } from "vitest";
 import {
-  computePercentiles,
-  computeConcentration,
-  computeUserBuckets,
   computeItemsByAgeBucket,
-  computeTtlSimulation,
+  computePercentilesFromFrequency,
+  computeConcentrationFromFrequency,
+  computeUserBucketsFromFrequency,
+  computeTtlSimulationFromFrequency,
 } from "../../analyse-activity-log/compute-report.js";
-import { CounterIndex } from "../../analyse-activity-log/age-thresholds.js";
-
-describe("computePercentiles", () => {
-  test("all same values", () => {
-    const result = computePercentiles([1, 1, 1, 1, 1]);
-    expect(result.mean).toBe(1);
-    expect(result.median).toBe(1);
-    expect(result.p75).toBe(1);
-    expect(result.p90).toBe(1);
-    expect(result.p95).toBe(1);
-    expect(result.p99).toBe(1);
-    expect(result.max).toBe(1);
-  });
-
-  test("uniform distribution 1 to 100", () => {
-    const sorted = Array.from({ length: 100 }, (_, i) => i + 1);
-    const result = computePercentiles(sorted);
-    expect(result.mean).toBe(50.5);
-    expect(result.median).toBe(50);
-    expect(result.p75).toBe(75);
-    expect(result.p90).toBe(90);
-    expect(result.p95).toBe(95);
-    expect(result.p99).toBe(99);
-    expect(result.max).toBe(100);
-  });
-
-  test("outlier distribution", () => {
-    const result = computePercentiles([1, 1, 1, 1, 1000]);
-    expect(result.mean).toBe(200.8);
-    expect(result.median).toBe(1);
-    expect(result.p99).toBe(1000);
-    expect(result.max).toBe(1000);
-  });
-
-  test("single user", () => {
-    const result = computePercentiles([5]);
-    expect(result.mean).toBe(5);
-    expect(result.median).toBe(5);
-    expect(result.p75).toBe(5);
-    expect(result.p90).toBe(5);
-    expect(result.p95).toBe(5);
-    expect(result.p99).toBe(5);
-    expect(result.max).toBe(5);
-  });
-});
-
-describe("computeConcentration", () => {
-  test("top 1 user of 100 owns 50% of items", () => {
-    const counts = [50, ...new Array(99).fill(0.5)].sort(
-      (a, b) => b - a
-    ) as number[];
-    const totalItems = 50 + 99 * 0.5;
-    const result = computeConcentration(counts, totalItems);
-    expect(result.top_1_pct_users_own_pct_of_items).toBe(50);
-  });
-
-  test("uniform distribution", () => {
-    const counts = new Array(100).fill(10);
-    const result = computeConcentration(counts, 1000);
-    expect(result.top_1_pct_users_own_pct_of_items).toBe(1);
-    expect(result.top_5_pct_users_own_pct_of_items).toBe(5);
-    expect(result.top_10_pct_users_own_pct_of_items).toBe(10);
-  });
-});
-
-describe("computeUserBuckets", () => {
-  test("classifies boundary values correctly", () => {
-    const counts = [
-      1, 5, 6, 10, 11, 25, 26, 50, 51, 100, 101, 500, 501, 1000, 1001, 10000,
-      10001, 100000, 100001,
-    ];
-    const result = computeUserBuckets(counts);
-    expect(result["1"].user_count).toBe(1);
-    expect(result["2-5"].user_count).toBe(1);
-    expect(result["6-10"].user_count).toBe(2);
-    expect(result["11-25"].user_count).toBe(2);
-    expect(result["26-50"].user_count).toBe(2);
-    expect(result["51-100"].user_count).toBe(2);
-    expect(result["101-500"].user_count).toBe(2);
-    expect(result["501-1000"].user_count).toBe(2);
-    expect(result["1001-10000"].user_count).toBe(2);
-    expect(result["10001-100000"].user_count).toBe(2);
-    expect(result["100000+"].user_count).toBe(1);
-  });
-
-  test("sums total_items per bucket", () => {
-    const counts = [1, 3, 4];
-    const result = computeUserBuckets(counts);
-    expect(result["1"].total_items).toBe(1);
-    expect(result["2-5"].total_items).toBe(7);
-  });
-});
 
 describe("computeItemsByAgeBucket", () => {
   test("labels match expected output keys", () => {
@@ -119,11 +27,115 @@ describe("computeItemsByAgeBucket", () => {
   });
 });
 
-describe("computeTtlSimulation", () => {
-  test("user with all items older than 3m is fully removed", () => {
-    // [TOTAL, OLDER_1M, OLDER_3M, OLDER_6M, OLDER_12M, OLDER_18M, OLDER_24M]
-    const userCounters = [[5, 5, 5, 3, 0, 0, 0]];
-    const result = computeTtlSimulation(userCounters, CounterIndex.OLDER_3M, 5);
+describe("computePercentilesFromFrequency", () => {
+  test("uniform distribution 1 to 100", () => {
+    const frequency: Record<number, number> = {};
+    for (let i = 1; i <= 100; i++) frequency[i] = 1;
+    const result = computePercentilesFromFrequency(frequency);
+    expect(result.mean).toBe(50.5);
+    expect(result.median).toBe(50);
+    expect(result.p75).toBe(75);
+    expect(result.p90).toBe(90);
+    expect(result.p95).toBe(95);
+    expect(result.p99).toBe(99);
+    expect(result.max).toBe(100);
+  });
+
+  test("all same values", () => {
+    const result = computePercentilesFromFrequency({ 1: 5 });
+    expect(result.mean).toBe(1);
+    expect(result.median).toBe(1);
+    expect(result.p75).toBe(1);
+    expect(result.p90).toBe(1);
+    expect(result.p95).toBe(1);
+    expect(result.p99).toBe(1);
+    expect(result.max).toBe(1);
+  });
+
+  test("outlier distribution", () => {
+    const result = computePercentilesFromFrequency({ 1: 4, 1000: 1 });
+    expect(result.mean).toBe(200.8);
+    expect(result.median).toBe(1);
+    expect(result.p99).toBe(1000);
+    expect(result.max).toBe(1000);
+  });
+
+  test("single user", () => {
+    const result = computePercentilesFromFrequency({ 5: 1 });
+    expect(result.mean).toBe(5);
+    expect(result.median).toBe(5);
+    expect(result.p75).toBe(5);
+    expect(result.p90).toBe(5);
+    expect(result.p95).toBe(5);
+    expect(result.p99).toBe(5);
+    expect(result.max).toBe(5);
+  });
+});
+
+describe("computeConcentrationFromFrequency", () => {
+  test("uniform distribution", () => {
+    const result = computeConcentrationFromFrequency({ 10: 100 });
+    expect(result.top_1_pct_users_own_pct_of_items).toBe(1);
+    expect(result.top_5_pct_users_own_pct_of_items).toBe(5);
+    expect(result.top_10_pct_users_own_pct_of_items).toBe(10);
+  });
+
+  test("top 1 user of 100 owns 50% of items", () => {
+    // 1 user with 50 items, 99 users with 1 item each = 149 total
+    const frequency = { 50: 1, 1: 99 };
+    const result = computeConcentrationFromFrequency(frequency);
+    expect(result.top_1_pct_users_own_pct_of_items).toBe(34);
+  });
+});
+
+describe("computeUserBucketsFromFrequency", () => {
+  test("classifies boundary values correctly", () => {
+    const frequency = {
+      1: 1,
+      5: 1,
+      6: 1,
+      10: 1,
+      11: 1,
+      25: 1,
+      26: 1,
+      50: 1,
+      51: 1,
+      100: 1,
+      101: 1,
+      500: 1,
+      501: 1,
+      1000: 1,
+      1001: 1,
+      10000: 1,
+      10001: 1,
+      100000: 1,
+      100001: 1,
+    };
+    const result = computeUserBucketsFromFrequency(frequency);
+    expect(result["1"].user_count).toBe(1);
+    expect(result["2-5"].user_count).toBe(1);
+    expect(result["6-10"].user_count).toBe(2);
+    expect(result["11-25"].user_count).toBe(2);
+    expect(result["26-50"].user_count).toBe(2);
+    expect(result["51-100"].user_count).toBe(2);
+    expect(result["101-500"].user_count).toBe(2);
+    expect(result["501-1000"].user_count).toBe(2);
+    expect(result["1001-10000"].user_count).toBe(2);
+    expect(result["10001-100000"].user_count).toBe(2);
+    expect(result["100000+"].user_count).toBe(1);
+  });
+
+  test("sums total_items per bucket", () => {
+    const frequency = { 1: 1, 3: 1, 4: 1 };
+    const result = computeUserBucketsFromFrequency(frequency);
+    expect(result["1"].total_items).toBe(1);
+    expect(result["2-5"].total_items).toBe(7);
+  });
+});
+
+describe("computeTtlSimulationFromFrequency", () => {
+  test("user with all items removed", () => {
+    const result = computeTtlSimulationFromFrequency({}, 1, 5, 1);
     expect(result.items_removed).toBe(5);
     expect(result.items_retained).toBe(0);
     expect(result.pct_items_removed).toBe(100);
@@ -131,9 +143,8 @@ describe("computeTtlSimulation", () => {
     expect(result.users_with_data_retained).toBe(0);
   });
 
-  test("user with no items older than 3m has 0 removed", () => {
-    const userCounters = [[5, 2, 0, 0, 0, 0, 0]];
-    const result = computeTtlSimulation(userCounters, CounterIndex.OLDER_3M, 5);
+  test("user with no items removed", () => {
+    const result = computeTtlSimulationFromFrequency({ 5: 1 }, 0, 5, 1);
     expect(result.items_removed).toBe(0);
     expect(result.items_retained).toBe(5);
     expect(result.pct_items_removed).toBe(0);
@@ -142,28 +153,20 @@ describe("computeTtlSimulation", () => {
     expect(result.items_per_user_after.mean).toBe(5);
   });
 
-  test("user with 5 total, 3 older than 6m", () => {
-    const userCounters = [[5, 5, 4, 3, 0, 0, 0]];
-    const result = computeTtlSimulation(userCounters, CounterIndex.OLDER_6M, 5);
-    expect(result.items_removed).toBe(3);
-    expect(result.items_retained).toBe(2);
-    expect(result.pct_items_removed).toBe(60);
-    expect(result.users_with_all_data_removed).toBe(0);
-    expect(result.users_with_data_retained).toBe(1);
-    expect(result.items_per_user_after.mean).toBe(2);
+  test("mixed removal across users", () => {
+    // 1 user fully removed, 2 users retain 5 items each
+    const result = computeTtlSimulationFromFrequency({ 5: 2 }, 1, 20, 3);
+    expect(result.items_removed).toBe(10);
+    expect(result.items_retained).toBe(10);
+    expect(result.pct_items_removed).toBe(50);
+    expect(result.users_with_all_data_removed).toBe(1);
+    expect(result.users_with_data_retained).toBe(2);
+    expect(result.items_per_user_after.mean).toBe(5);
   });
 
   test("post-TTL percentiles exclude fully-removed users", () => {
-    const userCounters = [
-      [10, 10, 10, 0, 0, 0, 0], // fully removed at 3m
-      [5, 3, 0, 0, 0, 0, 0], // retains 5
-      [8, 6, 2, 0, 0, 0, 0], // retains 6
-    ];
-    const result = computeTtlSimulation(
-      userCounters,
-      CounterIndex.OLDER_3M,
-      23
-    );
+    // 1 fully removed, 1 retains 5, 1 retains 6
+    const result = computeTtlSimulationFromFrequency({ 5: 1, 6: 1 }, 1, 23, 3);
     expect(result.users_with_all_data_removed).toBe(1);
     expect(result.users_with_data_retained).toBe(2);
     expect(result.items_per_user_after.mean).toBe(5.5);

--- a/src/tests/analyse-activity-log/handler.test.ts
+++ b/src/tests/analyse-activity-log/handler.test.ts
@@ -321,5 +321,177 @@ describe("analyse-activity-log handler", () => {
         }),
       });
     });
+
+    test("produces same report when data is split across two invocations", async () => {
+      // Invocation 1: segment 0 completes, segment 1 hits deadline mid-user
+      mockScanSegment
+        .mockResolvedValueOnce({
+          perUserCounters: [
+            [1, 0, 0, 0, 0, 0, 0],
+            [4, 2, 1, 0, 0, 0, 0],
+            [12, 10, 8, 5, 2, 0, 0],
+            [50, 45, 40, 30, 20, 10, 5],
+          ],
+          exclusiveAgeBuckets: [10, 12, 8, 10, 12, 10, 5],
+          exhausted: true,
+        })
+        .mockResolvedValueOnce({
+          perUserCounters: [
+            [1, 0, 0, 0, 0, 0, 0],
+            [3, 1, 0, 0, 0, 0, 0],
+          ],
+          exclusiveAgeBuckets: [3, 1, 0, 0, 0, 0, 0],
+          exhausted: false,
+          cursor: {
+            lastEvaluatedKey: { user_id: { S: "user-d" } },
+            lastUserId: "user-d",
+            lastUserCounters: [4, 3, 2, 1, 0, 0, 0],
+          },
+        });
+
+      await handler({ totalSegments: 2 }, mockContext);
+
+      // Extract the payload from the self-invocation
+      const invokeCall = lambdaMock.commandCalls(InvokeCommand)[0];
+      const nextEvent = JSON.parse(
+        Buffer.from(invokeCall.args[0].input.Payload!).toString()
+      );
+
+      // Invocation 2: segment 1 completes — cursor user (4 items) flushed, then 2 more users
+      vi.clearAllMocks();
+      mockScanSegment.mockResolvedValueOnce({
+        perUserCounters: [
+          [4, 3, 2, 1, 0, 0, 0],
+          [8, 6, 4, 2, 0, 0, 0],
+          [25, 20, 15, 10, 5, 2, 0],
+        ],
+        exclusiveAgeBuckets: [5, 9, 6, 5, 5, 2, 1],
+        exhausted: true,
+      });
+
+      const result = await handler(nextEvent, mockContext);
+
+      // 4 users from seg0 + 2 from seg1 inv1 + 3 from seg1 inv2 (includes resumed cursor user)
+      expect(result.total_users).toBe(9);
+      expect(result.total_items).toBe(108);
+      expect(result.items_per_user_distribution.max).toBe(50);
+      expect(result.items_by_age_bucket["0-1_months"].count).toBe(18);
+      expect(result.items_by_age_bucket["1-3_months"].count).toBe(22);
+      expect(result.items_by_age_bucket["3-6_months"].count).toBe(14);
+      expect(result.items_by_age_bucket["6-12_months"].count).toBe(15);
+      expect(result.items_by_age_bucket["12-18_months"].count).toBe(17);
+      expect(result.items_by_age_bucket["18-24_months"].count).toBe(12);
+      expect(result.items_by_age_bucket["24+_months"].count).toBe(6);
+    });
+
+    test("correctly maps cursors to segment indices across 3+ invocations", async () => {
+      // Invocation 2: 3 segments, only segment 2 still active
+      const cursor = {
+        lastEvaluatedKey: { user_id: { S: "user-z" } },
+        lastUserId: "user-z",
+        lastUserCounters: [1, 0, 0, 0, 0, 0, 0],
+      };
+
+      mockScanSegment.mockResolvedValueOnce({
+        perUserCounters: [[2, 0, 0, 0, 0, 0, 0]],
+        exclusiveAgeBuckets: [2, 0, 0, 0, 0, 0, 0],
+        exhausted: false,
+        cursor: {
+          lastEvaluatedKey: { user_id: { S: "user-zz" } },
+          lastUserId: "user-zz",
+          lastUserCounters: [1, 0, 0, 0, 0, 0, 0],
+        },
+      });
+
+      await handler(
+        {
+          totalSegments: 3,
+          cursors: [null, null, cursor],
+          accumulated: {
+            totalCountFrequency: { 5: 2 },
+            ageBuckets: [10, 0, 0, 0, 0, 0, 0],
+            ttlRetainedFrequency: {
+              "3_months": { 5: 2 },
+              "6_months": { 5: 2 },
+              "12_months": { 5: 2 },
+              "18_months": { 5: 2 },
+              "24_months": { 5: 2 },
+            },
+            usersFullyRemovedByTtl: {
+              "3_months": 0,
+              "6_months": 0,
+              "12_months": 0,
+              "18_months": 0,
+              "24_months": 0,
+            },
+          },
+          invocation: 3,
+        },
+        mockContext
+      );
+
+      // Should only scan segment 2
+      expect(mockScanSegment).toHaveBeenCalledTimes(1);
+      expect(mockScanSegment).toHaveBeenCalledWith(
+        expect.anything(),
+        "activity_log",
+        2,
+        3,
+        expect.any(Array),
+        expect.objectContaining({ resumeFrom: cursor })
+      );
+
+      // nextCursors should preserve segment indices
+      const invokeCall = lambdaMock.commandCalls(InvokeCommand)[0];
+      const payload = JSON.parse(
+        Buffer.from(invokeCall.args[0].input.Payload!).toString()
+      );
+      expect(payload.cursors).toHaveLength(3);
+      expect(payload.cursors[0]).toBeNull();
+      expect(payload.cursors[1]).toBeNull();
+      expect(payload.cursors[2]).not.toBeNull();
+      expect(payload.cursors[2].lastUserId).toBe("user-zz");
+    });
+
+    test("throws when payload exceeds 256KB", async () => {
+      const largeCursor = {
+        lastEvaluatedKey: { user_id: { S: "x".repeat(260000) } },
+        lastUserId: "user-x",
+        lastUserCounters: [1, 0, 0, 0, 0, 0, 0],
+      };
+
+      mockScanSegment.mockResolvedValue({
+        perUserCounters: [[1, 0, 0, 0, 0, 0, 0]],
+        exclusiveAgeBuckets: [1, 0, 0, 0, 0, 0, 0],
+        exhausted: false,
+        cursor: largeCursor,
+      });
+
+      await expect(handler({ totalSegments: 1 }, mockContext)).rejects.toThrow(
+        "Payload too large for async invoke"
+      );
+    });
+
+    test("throws when async invoke returns non-202 status", async () => {
+      lambdaMock.reset();
+      lambdaMock.on(InvokeCommand).resolves({ StatusCode: 500 });
+
+      const cursor = {
+        lastEvaluatedKey: { user_id: { S: "user-x" } },
+        lastUserId: "user-x",
+        lastUserCounters: [1, 0, 0, 0, 0, 0, 0],
+      };
+
+      mockScanSegment.mockResolvedValue({
+        perUserCounters: [[1, 0, 0, 0, 0, 0, 0]],
+        exclusiveAgeBuckets: [1, 0, 0, 0, 0, 0, 0],
+        exhausted: false,
+        cursor,
+      });
+
+      await expect(handler({ totalSegments: 1 }, mockContext)).rejects.toThrow(
+        "Async invoke returned status 500"
+      );
+    });
   });
 });

--- a/src/tests/analyse-activity-log/handler.test.ts
+++ b/src/tests/analyse-activity-log/handler.test.ts
@@ -1,5 +1,7 @@
 import { vi, describe, test, expect, beforeEach } from "vitest";
 import { Context } from "aws-lambda";
+import { mockClient } from "aws-sdk-client-mock";
+import { LambdaClient, InvokeCommand } from "@aws-sdk/client-lambda";
 
 vi.mock(
   "../../analyse-activity-log/scan-segment.js",
@@ -20,11 +22,15 @@ import { scanSegment } from "../../analyse-activity-log/scan-segment.js";
 
 const mockContext = {} as Context;
 const mockScanSegment = vi.mocked(scanSegment);
+const lambdaMock = mockClient(LambdaClient);
 
 describe("analyse-activity-log handler", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    lambdaMock.reset();
+    lambdaMock.on(InvokeCommand).resolves({ StatusCode: 202 });
     process.env.TABLE_NAME = "activity_log";
+    process.env.AWS_LAMBDA_FUNCTION_NAME = "test-function";
   });
 
   describe("input validation", () => {
@@ -104,9 +110,56 @@ describe("analyse-activity-log handler", () => {
       const result = await handler({ totalSegments: 2 }, mockContext);
 
       expect(result.scan_complete).toBe(true);
+      expect(lambdaMock.commandCalls(InvokeCommand)).toHaveLength(0);
     });
 
-    test("returns scan_complete false when segments incomplete", async () => {
+    test("throws when max invocations exceeded", async () => {
+      await expect(
+        handler({ totalSegments: 1, invocation: 21 }, mockContext)
+      ).rejects.toThrow("Exceeded maximum invocations (20)");
+    });
+
+    test("respects custom maxInvocations", async () => {
+      await expect(
+        handler(
+          { totalSegments: 1, maxInvocations: 3, invocation: 4 },
+          mockContext
+        )
+      ).rejects.toThrow("Exceeded maximum invocations (3)");
+    });
+
+    test("passes ageThresholds and scanStartedAt to next invocation", async () => {
+      const cursor = {
+        lastEvaluatedKey: { user_id: { S: "user-x" } },
+        lastUserId: "user-x",
+        lastUserCounters: [1, 0, 0, 0, 0, 0, 0],
+      };
+
+      mockScanSegment.mockResolvedValue({
+        perUserCounters: [[1, 0, 0, 0, 0, 0, 0]],
+        exclusiveAgeBuckets: [1, 0, 0, 0, 0, 0, 0],
+        exhausted: false,
+        cursor,
+      });
+
+      await handler({ totalSegments: 1 }, mockContext);
+
+      const invokeCall = lambdaMock.commandCalls(InvokeCommand)[0];
+      const payload = JSON.parse(
+        Buffer.from(invokeCall.args[0].input.Payload!).toString()
+      );
+
+      expect(payload.ageThresholds).toHaveLength(6);
+      expect(payload.scanStartedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    });
+
+    test("self-invokes with cursors when segments incomplete", async () => {
+      const cursor = {
+        lastEvaluatedKey: { user_id: { S: "user-x" } },
+        lastUserId: "user-x",
+        lastUserCounters: [3, 1, 0, 0, 0, 0, 0],
+      };
+
       mockScanSegment
         .mockResolvedValueOnce({
           perUserCounters: [[3, 1, 0, 0, 0, 0, 0]],
@@ -117,16 +170,17 @@ describe("analyse-activity-log handler", () => {
           perUserCounters: [[2, 0, 0, 0, 0, 0, 0]],
           exclusiveAgeBuckets: [2, 0, 0, 0, 0, 0, 0],
           exhausted: false,
-          cursor: {
-            lastEvaluatedKey: { user_id: { S: "user-x" } },
-            lastUserId: "user-x",
-            lastUserCounters: [2, 0, 0, 0, 0, 0, 0],
-          },
+          cursor,
         });
 
-      const result = await handler({ totalSegments: 2 }, mockContext);
+      await handler({ totalSegments: 2 }, mockContext);
 
-      expect(result.scan_complete).toBe(false);
+      expect(lambdaMock.commandCalls(InvokeCommand)).toHaveLength(1);
+      const invokeCall = lambdaMock.commandCalls(InvokeCommand)[0];
+      const payload = JSON.parse(
+        Buffer.from(invokeCall.args[0].input.Payload!).toString()
+      );
+      expect(payload.cursors).toEqual([null, cursor]);
     });
 
     test("returns report from whatever was scanned", async () => {

--- a/src/tests/analyse-activity-log/handler.test.ts
+++ b/src/tests/analyse-activity-log/handler.test.ts
@@ -54,10 +54,11 @@ describe("analyse-activity-log handler", () => {
   });
 
   describe("scan orchestration", () => {
-    test("calls scanSegment once per segment", async () => {
+    test("calls scanSegment with deadline option", async () => {
       mockScanSegment.mockResolvedValue({
         perUserCounters: [[1, 0, 0, 0, 0, 0, 0]],
         exclusiveAgeBuckets: [1, 0, 0, 0, 0, 0, 0],
+        exhausted: true,
       });
 
       await handler({ totalSegments: 3 }, mockContext);
@@ -68,21 +69,8 @@ describe("analyse-activity-log handler", () => {
         "activity_log",
         0,
         3,
-        expect.any(Array)
-      );
-      expect(mockScanSegment).toHaveBeenCalledWith(
-        expect.anything(),
-        "activity_log",
-        1,
-        3,
-        expect.any(Array)
-      );
-      expect(mockScanSegment).toHaveBeenCalledWith(
-        expect.anything(),
-        "activity_log",
-        2,
-        3,
-        expect.any(Array)
+        expect.any(Array),
+        expect.objectContaining({ deadlineMs: expect.any(Number) })
       );
     });
 
@@ -98,6 +86,7 @@ describe("analyse-activity-log handler", () => {
       mockScanSegment.mockResolvedValue({
         perUserCounters: [],
         exclusiveAgeBuckets: [0, 0, 0, 0, 0, 0, 0],
+        exhausted: true,
       });
 
       await expect(handler({ totalSegments: 1 }, mockContext)).rejects.toThrow(
@@ -105,7 +94,42 @@ describe("analyse-activity-log handler", () => {
       );
     });
 
-    test("returns summed totals from all segments", async () => {
+    test("returns scan_complete true when all segments exhaust", async () => {
+      mockScanSegment.mockResolvedValue({
+        perUserCounters: [[3, 1, 0, 0, 0, 0, 0]],
+        exclusiveAgeBuckets: [2, 1, 0, 0, 0, 0, 0],
+        exhausted: true,
+      });
+
+      const result = await handler({ totalSegments: 2 }, mockContext);
+
+      expect(result.scan_complete).toBe(true);
+    });
+
+    test("returns scan_complete false when segments incomplete", async () => {
+      mockScanSegment
+        .mockResolvedValueOnce({
+          perUserCounters: [[3, 1, 0, 0, 0, 0, 0]],
+          exclusiveAgeBuckets: [2, 1, 0, 0, 0, 0, 0],
+          exhausted: true,
+        })
+        .mockResolvedValueOnce({
+          perUserCounters: [[2, 0, 0, 0, 0, 0, 0]],
+          exclusiveAgeBuckets: [2, 0, 0, 0, 0, 0, 0],
+          exhausted: false,
+          cursor: {
+            lastEvaluatedKey: { user_id: { S: "user-x" } },
+            lastUserId: "user-x",
+            lastUserCounters: [2, 0, 0, 0, 0, 0, 0],
+          },
+        });
+
+      const result = await handler({ totalSegments: 2 }, mockContext);
+
+      expect(result.scan_complete).toBe(false);
+    });
+
+    test("returns report from whatever was scanned", async () => {
       mockScanSegment
         .mockResolvedValueOnce({
           perUserCounters: [
@@ -113,10 +137,12 @@ describe("analyse-activity-log handler", () => {
             [5, 2, 1, 0, 0, 0, 0],
           ],
           exclusiveAgeBuckets: [5, 2, 1, 0, 0, 0, 0],
+          exhausted: true,
         })
         .mockResolvedValueOnce({
           perUserCounters: [[2, 0, 0, 0, 0, 0, 0]],
           exclusiveAgeBuckets: [2, 0, 0, 0, 0, 0, 0],
+          exhausted: true,
         });
 
       const result = await handler({ totalSegments: 2 }, mockContext);
@@ -144,6 +170,7 @@ describe("analyse-activity-log handler", () => {
             [50, 45, 40, 30, 20, 10, 5],
           ],
           exclusiveAgeBuckets: [10, 12, 8, 10, 12, 10, 5],
+          exhausted: true,
         })
         .mockResolvedValueOnce({
           perUserCounters: [
@@ -153,6 +180,7 @@ describe("analyse-activity-log handler", () => {
             [25, 20, 15, 10, 5, 2, 0],
           ],
           exclusiveAgeBuckets: [8, 10, 6, 5, 5, 2, 1],
+          exhausted: true,
         });
 
       const result = await handler({ totalSegments: 2 }, mockContext);

--- a/src/tests/analyse-activity-log/scan-segment.test.ts
+++ b/src/tests/analyse-activity-log/scan-segment.test.ts
@@ -24,7 +24,7 @@ describe("scanSegment", () => {
     dynamoMock.reset();
   });
 
-  test("empty segment returns zero counts", async () => {
+  test("empty segment returns exhausted true", async () => {
     dynamoMock.on(ScanCommand).resolves({ Items: [] });
 
     const result = await scanSegment(
@@ -36,6 +36,7 @@ describe("scanSegment", () => {
     );
 
     expect(result.perUserCounters).toHaveLength(0);
+    expect(result.exhausted).toBe(true);
   });
 
   test("single-item user", async () => {
@@ -53,6 +54,7 @@ describe("scanSegment", () => {
 
     expect(result.perUserCounters).toHaveLength(1);
     expect(result.perUserCounters[0][CounterIndex.TOTAL]).toBe(1);
+    expect(result.exhausted).toBe(true);
   });
 
   test("3 users across 2 pages with middle user spanning page boundary", async () => {
@@ -85,6 +87,7 @@ describe("scanSegment", () => {
     expect(result.perUserCounters[0][CounterIndex.TOTAL]).toBe(2);
     expect(result.perUserCounters[1][CounterIndex.TOTAL]).toBe(2);
     expect(result.perUserCounters[2][CounterIndex.TOTAL]).toBe(1);
+    expect(result.exhausted).toBe(true);
   });
 
   test("age bucket counting at threshold boundaries", async () => {
@@ -127,5 +130,112 @@ describe("scanSegment", () => {
     expect(result.perUserCounters[0][CounterIndex.OLDER_18M]).toBe(2);
     expect(result.perUserCounters[0][CounterIndex.OLDER_24M]).toBe(1);
     expect(result.exclusiveAgeBuckets).toEqual([1, 2, 1, 1, 1, 1, 1]);
+  });
+
+  describe("time-budgeted scanning", () => {
+    test("stops and returns cursor when deadline reached", async () => {
+      const lastKey = { user_id: { S: "user-b" } };
+
+      dynamoMock
+        .on(ScanCommand)
+        .resolvesOnce({
+          Items: [
+            makeItem("user-a", NOW_SECONDS - 10),
+            makeItem("user-b", NOW_SECONDS - 20),
+          ],
+          LastEvaluatedKey: lastKey,
+        })
+        .resolvesOnce({
+          Items: [makeItem("user-c", NOW_SECONDS - 30)],
+        });
+
+      const result = await scanSegment(
+        dynamoMock as unknown as DynamoDBClient,
+        "table",
+        0,
+        1,
+        thresholds,
+        { deadlineMs: Date.now() - 1 }
+      );
+
+      expect(result.exhausted).toBe(false);
+      expect(result.cursor).toBeDefined();
+      expect(result.cursor!.lastEvaluatedKey).toEqual(lastKey);
+      expect(result.cursor!.lastUserId).toBe("user-b");
+      expect(result.cursor!.lastUserCounters[CounterIndex.TOTAL]).toBe(1);
+    });
+
+    test("completes normally when deadline not reached", async () => {
+      dynamoMock.on(ScanCommand).resolves({
+        Items: [makeItem("user-a", NOW_SECONDS - 10)],
+      });
+
+      const result = await scanSegment(
+        dynamoMock as unknown as DynamoDBClient,
+        "table",
+        0,
+        1,
+        thresholds,
+        { deadlineMs: Date.now() + 60000 }
+      );
+
+      expect(result.exhausted).toBe(true);
+      expect(result.cursor).toBeUndefined();
+    });
+  });
+
+  describe("resuming from cursor", () => {
+    test("resumes with carried-over user counters", async () => {
+      dynamoMock.on(ScanCommand).resolves({
+        Items: [
+          makeItem("user-b", NOW_SECONDS - 10),
+          makeItem("user-c", NOW_SECONDS - 20),
+        ],
+      });
+
+      const result = await scanSegment(
+        dynamoMock as unknown as DynamoDBClient,
+        "table",
+        0,
+        1,
+        thresholds,
+        {
+          resumeFrom: {
+            lastEvaluatedKey: { user_id: { S: "user-a" } },
+            lastUserId: "user-b",
+            lastUserCounters: [2, 1, 0, 0, 0, 0, 0],
+          },
+        }
+      );
+
+      expect(result.perUserCounters).toHaveLength(2);
+      expect(result.perUserCounters[0][CounterIndex.TOTAL]).toBe(3);
+      expect(result.perUserCounters[1][CounterIndex.TOTAL]).toBe(1);
+    });
+
+    test("flushes resumed user if next page has different user", async () => {
+      dynamoMock.on(ScanCommand).resolves({
+        Items: [makeItem("user-c", NOW_SECONDS - 10)],
+      });
+
+      const result = await scanSegment(
+        dynamoMock as unknown as DynamoDBClient,
+        "table",
+        0,
+        1,
+        thresholds,
+        {
+          resumeFrom: {
+            lastEvaluatedKey: { user_id: { S: "user-b" } },
+            lastUserId: "user-b",
+            lastUserCounters: [5, 3, 2, 0, 0, 0, 0],
+          },
+        }
+      );
+
+      expect(result.perUserCounters).toHaveLength(2);
+      expect(result.perUserCounters[0][CounterIndex.TOTAL]).toBe(5);
+      expect(result.perUserCounters[1][CounterIndex.TOTAL]).toBe(1);
+    });
   });
 });

--- a/src/tests/analyse-activity-log/scan-segment.test.ts
+++ b/src/tests/analyse-activity-log/scan-segment.test.ts
@@ -238,4 +238,25 @@ describe("scanSegment", () => {
       expect(result.perUserCounters[1][CounterIndex.TOTAL]).toBe(1);
     });
   });
+
+  test("skips items with missing user_id or invalid timestamp", async () => {
+    dynamoMock.on(ScanCommand).resolves({
+      Items: [
+        { timestamp: { N: String(NOW_SECONDS * 1000) } },
+        { user_id: { S: "user-a" }, timestamp: { N: "not-a-number" } },
+        makeItem("user-b", NOW_SECONDS - 10),
+      ],
+    });
+
+    const result = await scanSegment(
+      dynamoMock as unknown as DynamoDBClient,
+      "table",
+      0,
+      1,
+      thresholds
+    );
+
+    expect(result.perUserCounters).toHaveLength(1);
+    expect(result.perUserCounters[0][CounterIndex.TOTAL]).toBe(1);
+  });
 });

--- a/template.yaml
+++ b/template.yaml
@@ -5488,6 +5488,11 @@ Resources:
               - kms:Decrypt
             Resource:
               - !GetAtt DatabaseKmsKey.Arn
+          - Effect: Allow
+            Action:
+              - lambda:InvokeFunction
+            Resource:
+              - !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${Environment}-${AWS::StackName}-analyse-activity-log
 
   AnalyseActivityLogFunctionLogGroup:
     Type: AWS::Logs::LogGroup


### PR DESCRIPTION
## Proposed changes

### What changed

The analysis Lambda now self-invokes to handle tables that exceed the 15-minute Lambda timeout. Instead of scanning the entire table in one execution, it:

1. Scans for 13 minutes across all segments in parallel
2. Stops at the deadline, preserving scan position and in-progress user state via cursors
3. Converts per-user counters into compact frequency maps (ChunkResult) that accumulate across invocations
4. Async-invokes itself with the accumulated state and cursors for incomplete segments
5. On the final invocation, computes the report from the merged frequency maps

The frequency-map approach keeps the payload bounded (~few KB) regardless of user count while producing exact percentiles, concentration metrics, and TTL simulations.

### Why did it change

The Lambda timed out at 15 minutes having scanned about a third of the items needed in production. This change enables it to complete scans of any table size within the Lambda execution model.

### Related links

- Previous PR: #1034 (original Lambda)

## Checklists

### Environment variables or secrets

- [x] Added parameters to Cloudformation template

### Permissions

- [x] This PR adds or changes permissions

Adds `lambda:InvokeFunction` scoped to the function's own ARN (self-invocation only).

### Monitoring

- [ ] This PR includes changes that need to be monitored in production as the scope of the change could cause issues