### PR TITLE
BAU: fix missing await and add timeout diagnosis logging to delete-activity-log

### DIFF
--- a/src/delete-activity-log.ts
+++ b/src/delete-activity-log.ts
@@ -45,8 +45,11 @@ export const getAllActivityLogEntriesForUser = async (
     ScanIndexForward: true,
     ExclusiveStartKey: lastEvaluatedKey,
   };
+  let pageCount = 0;
   do {
+    logger.info(`querying page ${pageCount + 1}`);
     const response = await dynamoDocClient.send(new QueryCommand(command));
+    pageCount++;
 
     if (response.Items) {
       queryResult.push(...(response.Items as ActivityLogEntry[]));
@@ -55,6 +58,9 @@ export const getAllActivityLogEntriesForUser = async (
     lastEvaluatedKey = response.LastEvaluatedKey ?? undefined;
   } while (lastEvaluatedKey);
 
+  logger.info(
+    `queried ${queryResult.length} activity log entries across ${pageCount} pages`
+  );
   return queryResult.length > 0 ? queryResult : undefined;
 };
 
@@ -92,6 +98,7 @@ export const batchDeleteActivityLog = async (
   activityLogEntries: ActivityLogEntry[]
 ) => {
   const batchArray = buildBatchDeletionRequestArray(activityLogEntries);
+  logger.info(`deleting ${activityLogEntries.length} entries in ${batchArray.length} batches`);
   await Promise.all(
     batchArray.map(async (arrayOf25orFewerItems) => {
       try {
@@ -123,9 +130,11 @@ export const handler = async (
         );
         const userData: UserData = JSON.parse(record.Sns.Message);
         validateUserData(userData);
+        logger.info("querying activity log entries");
         const activityLogEntries: ActivityLogEntry[] | undefined =
           await getAllActivityLogEntriesForUser(TABLE_NAME, userData);
         if (activityLogEntries) {
+          logger.info("starting batch deletion");
           await batchDeleteActivityLog(TABLE_NAME, activityLogEntries);
         }
         logger.info(

--- a/src/delete-activity-log.ts
+++ b/src/delete-activity-log.ts
@@ -92,7 +92,7 @@ export const batchDeleteActivityLog = async (
   activityLogEntries: ActivityLogEntry[]
 ) => {
   const batchArray = buildBatchDeletionRequestArray(activityLogEntries);
-  Promise.all(
+  await Promise.all(
     batchArray.map(async (arrayOf25orFewerItems) => {
       try {
         const batchcommand = new BatchWriteItemCommand({

--- a/src/tests/delete-activity-log.test.ts
+++ b/src/tests/delete-activity-log.test.ts
@@ -115,11 +115,19 @@ describe("deleteUserData", () => {
     expect(batchDeletePayload[0][0]).toEqual(deleteRequest);
   });
 
-  test("test batch deletion request when 65 items to delete", () => {
+  test("test batch deletion request when 65 items to delete", async () => {
     const arrayOf56Activities: ActivityLogEntry[] =
       Array(56).fill(activityLogEntry);
-    batchDeleteActivityLog("TABLE_NAME", arrayOf56Activities);
+    await batchDeleteActivityLog("TABLE_NAME", arrayOf56Activities);
     expect(dynamoMock.commandCalls(BatchWriteItemCommand).length).toEqual(3);
+  });
+
+  test("propagates errors from failed batch deletes", async () => {
+    dynamoMock.on(BatchWriteItemCommand).rejects(new Error("DynamoDB error"));
+    const entries: ActivityLogEntry[] = [activityLogEntry];
+    await expect(
+      batchDeleteActivityLog("TABLE_NAME", entries)
+    ).rejects.toThrow("DynamoDB error");
   });
 });
 


### PR DESCRIPTION
## Proposed changes

### What changed

- Fixed a missing `await` on `Promise.all` in `batchDeleteActivityLog` — batch deletes were fire-and-forget, meaning errors were silently swallowed and the function could report success while deletes actually failed.
- Added phase logging to identify where time is spent if the Lambda times out again:
  - Before/after DynamoDB query pagination (with page number and total entry count)
  - Before batch deletion (with entry and batch counts)

### Why did it change

The `delete-activity-log` Lambda timed out in production (10s limit hit). The only log emitted was "started processing". No visibility into whether the query or the deletion phase was responsible. The missing `await` was also a correctness bug independent of the timeout.

### Related links

- Lambda timeout observed: 2026-06-15T09:22:37Z, RequestId `571d3248-...`

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Permissions

- [ ] This PR adds or changes permissions

### Monitoring

- [ ] This PR includes changes that need to be monitored in production as the scope of the change could cause issues