### PR TITLE
BAU: fix inert DLQs by adding RedrivePolicy to SQS source queues

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -1227,6 +1227,9 @@ Resources:
     Type: AWS::SQS::Queue
     Properties:
       KmsMasterKeyId: !GetAtt QueueKmsKey.Arn
+      RedrivePolicy:
+        deadLetterTargetArn: !GetAtt FormatUserServicesDeadLetterQueue.Arn
+        maxReceiveCount: 5
     DeletionPolicy: Delete
     UpdateReplacePolicy: Delete
 
@@ -1362,9 +1365,6 @@ Resources:
           Type: SQS
           Properties:
             Queue: !GetAtt UserServicesToFormatQueue.Arn
-      DeadLetterQueue:
-        Type: SQS
-        TargetArn: !GetAtt FormatUserServicesDeadLetterQueue.Arn
       Handler: format-user-services.handler
       Role: !GetAtt FormatUserServicesRole.Arn
       ReservedConcurrentExecutions: 30
@@ -1437,10 +1437,6 @@ Resources:
           - Effect: Allow
             Action:
               - sqs:SendMessage
-            Resource: !GetAtt FormatUserServicesDeadLetterQueue.Arn
-          - Effect: Allow
-            Action:
-              - sqs:SendMessage
             Resource: !GetAtt UserServicesToWriteQueue.Arn
           - Effect: Allow
             Action:
@@ -1468,6 +1464,9 @@ Resources:
     Type: AWS::SQS::Queue
     Properties:
       KmsMasterKeyId: !GetAtt QueueKmsKey.Arn
+      RedrivePolicy:
+        deadLetterTargetArn: !GetAtt WriteUserServicesDeadLetterQueue.Arn
+        maxReceiveCount: 5
     DeletionPolicy: Delete
     UpdateReplacePolicy: Delete
 
@@ -1645,9 +1644,6 @@ Resources:
           Type: SQS
           Properties:
             Queue: !GetAtt UserServicesToWriteQueue.Arn
-      DeadLetterQueue:
-        Type: SQS
-        TargetArn: !GetAtt WriteUserServicesDeadLetterQueue.Arn
       Handler: write-user-services.handler
       Role: !GetAtt WriteServiceRecordRole.Arn
       Environment:
@@ -1715,10 +1711,6 @@ Resources:
               - sqs:DeleteMessage
               - sqs:GetQueueAttributes
             Resource: !GetAtt UserServicesToWriteQueue.Arn
-          - Effect: Allow
-            Action:
-              - sqs:SendMessage
-            Resource: !GetAtt WriteUserServicesDeadLetterQueue.Arn
           - Effect: Allow
             Action:
               - dynamodb:PutItem
@@ -2542,9 +2534,6 @@ Resources:
           Type: SQS
           Properties:
             Queue: !GetAtt ActivityLogToWriteQueue.Arn
-      DeadLetterQueue:
-        Type: SQS
-        TargetArn: !GetAtt WriteActivityLogDeadLetterQueue.Arn
       Handler: write-activity-log.handler
       Role: !GetAtt WriteActivityRecordRole.Arn
       ReservedConcurrentExecutions: 30
@@ -2619,10 +2608,6 @@ Resources:
               - sqs:DeleteMessage
               - sqs:GetQueueAttributes
             Resource: !GetAtt ActivityLogToWriteQueue.Arn
-          - Effect: Allow
-            Action:
-              - sqs:SendMessage
-            Resource: !GetAtt WriteActivityLogDeadLetterQueue.Arn
           - Effect: Allow
             Action:
               - dynamodb:PutItem
@@ -2919,6 +2904,9 @@ Resources:
     Type: AWS::SQS::Queue
     Properties:
       KmsMasterKeyId: !GetAtt QueueKmsKey.Arn
+      RedrivePolicy:
+        deadLetterTargetArn: !GetAtt WriteActivityLogDeadLetterQueue.Arn
+        maxReceiveCount: 5
     DeletionPolicy: Delete
     UpdateReplacePolicy: Delete
 


### PR DESCRIPTION
## Proposed changes

### What changed

- Added `RedrivePolicy` (maxReceiveCount=5) to 3 internal SQS source queues: `UserServicesToFormatQueue`, `UserServicesToWriteQueue`, `ActivityLogToWriteQueue`
- Removed the inert `DeadLetterQueue` SAM property from `FormatUserServicesFunction`, `WriteUserServicesFunction`, `WriteActivityLogFunction`
- Removed the now-unnecessary `sqs:SendMessage` permission on the DLQs from the Lambda roles

### Why did it change

The SAM `DeadLetterQueue` property (Lambda `DeadLetterConfig`) only applies to asynchronous invocations. SQS event source mappings invoke Lambda synchronously, so the property was completely inert - failed messages returned to the source queue and retried every 30 seconds indefinitely (up to 4 days per the message retention period) without ever reaching the DLQ.

Confirmed in dev by sending a broken message to `account-mgmt-backend-ActivityLogToWriteQueue-M6acde0fTJUX` - the lambda kept retriggering every 30 seconds and the DLQ never received a message.

Sources:
- https://docs.aws.amazon.com/lambda/latest/api/API_DeadLetterConfig.html - "The dead-letter queue for failed asynchronous invocations."
- https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html - "Lambda polls the queue and invokes your function synchronously"
- https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-dead-letter-queues.html

### Related links

- Existing pattern: `AuditOutputQueue` already uses `RedrivePolicy` with `maxReceiveCount: 5`

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Permissions

- [x] This PR adds or changes permissions

IAM: removed `sqs:SendMessage` on DLQ ARNs from 3 Lambda roles (no longer needed - SQS service moves messages via RedrivePolicy, not the Lambda).

### Monitoring

- [x] This PR includes changes that need to be monitored in production as the scope of the change could cause issues

After deploy, messages that previously retried indefinitely will now move to the DLQ after 5 attempts. Monitor the existing DLQ CloudWatch alarms - they should now fire if messages genuinely fail (previously they would never fire for these queues).

## Testing

- Manually tested in dev: sent broken message to ActivityLogToWriteQueue, confirmed lambda retriggers every 30s without DLQ capture (proving the previous config was broken), then deployed this branch and saw messages go to the DLQ.

## How to review

This is an infrastructure-only change (template.yaml). No application code changes. Review the 3 queue definitions for correct `RedrivePolicy` and confirm the removed `DeadLetterQueue` blocks and IAM statements were indeed for the affected functions only.