### PR TITLE
OLH-4305 add inactive account tracker deletion lambda

### DIFF
--- a/src/delete-inactive-account-tracker.ts
+++ b/src/delete-inactive-account-tracker.ts
@@ -1,0 +1,94 @@
+import { Context, SNSEvent } from "aws-lambda";
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import {
+  DynamoDBDocumentClient,
+  QueryCommand,
+  DeleteCommand,
+} from "@aws-sdk/lib-dynamodb";
+import { UserData } from "./common/model.js";
+import { getEnvironmentVariable } from "./common/utils.js";
+import { Logger } from "@aws-lambda-powertools/logger";
+
+const logger = new Logger();
+
+const marshallOptions = {
+  convertClassInstanceToMap: true,
+};
+const translateConfig = { marshallOptions };
+
+const dynamoClient = new DynamoDBClient({});
+const dynamoDocClient = DynamoDBDocumentClient.from(
+  dynamoClient,
+  translateConfig
+);
+
+export const validateUserData = (userData: UserData): UserData => {
+  if (userData.user_id) {
+    return userData;
+  }
+  throw new Error(
+    `userData did not have a user_id: ${JSON.stringify(userData)}`
+  );
+};
+
+export const deleteUserData = async (
+  userData: UserData
+): Promise<void> => {
+  const TABLE_NAME = getEnvironmentVariable("TABLE_NAME");
+
+  const queryResponse = await dynamoDocClient.send(
+    new QueryCommand({
+      TableName: TABLE_NAME,
+      IndexName: "CommonSubjectIdIndex",
+      KeyConditionExpression: "commonSubjectId = :uid",
+      ExpressionAttributeValues: { ":uid": userData.user_id },
+    })
+  );
+
+  if (!queryResponse.Items || queryResponse.Items.length === 0) {
+    logger.info("no inactive account tracker records found for user");
+    return;
+  }
+
+  await Promise.all(
+    queryResponse.Items.map((item) =>
+      dynamoDocClient.send(
+        new DeleteCommand({
+          TableName: TABLE_NAME,
+          Key: {
+            dateForDeletion: item.dateForDeletion,
+            commonSubjectId: item.commonSubjectId,
+          },
+        })
+      )
+    )
+  );
+};
+
+export const handler = async (
+  event: SNSEvent,
+  context: Context
+): Promise<void> => {
+  logger.addContext(context);
+  await Promise.all(
+    event.Records.map(async (record) => {
+      try {
+        logger.info(
+          `started processing message with ID: ${record.Sns.MessageId}`
+        );
+        const userData: UserData = JSON.parse(record.Sns.Message);
+        validateUserData(userData);
+        await deleteUserData(userData);
+        logger.info(
+          `finished processing message with ID: ${record.Sns.MessageId}`
+        );
+      } catch (error) {
+        throw new Error(
+          `Unable to delete inactive account tracker data for message with ID: ${record.Sns.MessageId}, ${
+            (error as Error).message
+          }`, { cause: error }
+        );
+      }
+    })
+  );
+};

--- a/src/delete-inactive-account-tracker.ts
+++ b/src/delete-inactive-account-tracker.ts
@@ -50,7 +50,7 @@ export const deleteUserData = async (
     return;
   }
 
-  await Promise.all(
+  await Promise.allSettled(
     queryResponse.Items.map((item) =>
       dynamoDocClient.send(
         new DeleteCommand({
@@ -70,7 +70,7 @@ export const handler = async (
   context: Context
 ): Promise<void> => {
   logger.addContext(context);
-  await Promise.all(
+  await Promise.allSettled(
     event.Records.map(async (record) => {
       try {
         logger.info(
@@ -84,8 +84,7 @@ export const handler = async (
         );
       } catch (error) {
         throw new Error(
-          `Unable to delete inactive account tracker data for message with ID: ${record.Sns.MessageId}, ${
-            (error as Error).message
+          `Unable to delete inactive account tracker data for message with ID: ${record.Sns.MessageId}, ${(error as Error).message
           }`, { cause: error }
         );
       }

--- a/src/delete-inactive-account-tracker.ts
+++ b/src/delete-inactive-account-tracker.ts
@@ -50,7 +50,7 @@ export const deleteUserData = async (
     return;
   }
 
-  await Promise.allSettled(
+  await Promise.all(
     queryResponse.Items.map((item) =>
       dynamoDocClient.send(
         new DeleteCommand({
@@ -70,7 +70,7 @@ export const handler = async (
   context: Context
 ): Promise<void> => {
   logger.addContext(context);
-  await Promise.allSettled(
+  await Promise.all(
     event.Records.map(async (record) => {
       try {
         logger.info(
@@ -84,7 +84,8 @@ export const handler = async (
         );
       } catch (error) {
         throw new Error(
-          `Unable to delete inactive account tracker data for message with ID: ${record.Sns.MessageId}, ${(error as Error).message
+          `Unable to delete inactive account tracker data for message with ID: ${record.Sns.MessageId}, ${
+            (error as Error).message
           }`, { cause: error }
         );
       }

--- a/src/tests/delete-inactive-account-tracker.test.ts
+++ b/src/tests/delete-inactive-account-tracker.test.ts
@@ -1,0 +1,126 @@
+import { vi, describe, test, expect, beforeEach, afterEach } from "vitest";
+import {
+  DynamoDBDocumentClient,
+  QueryCommand,
+  DeleteCommand,
+} from "@aws-sdk/lib-dynamodb";
+import { mockClient } from "aws-sdk-client-mock";
+import {
+  handler,
+  validateUserData,
+  deleteUserData,
+} from "../delete-inactive-account-tracker.js";
+
+import {
+  TEST_SNS_EVENT_WITH_TWO_RECORDS,
+  TEST_USER_DATA,
+} from "./testFixtures.js";
+import { Context } from "aws-lambda";
+
+const dynamoMock = mockClient(DynamoDBDocumentClient);
+
+describe("deleteUserData", () => {
+  beforeEach(() => {
+    dynamoMock.reset();
+    process.env.TABLE_NAME = "TABLE_NAME";
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("queries the GSI and deletes matching records", async () => {
+    dynamoMock.on(QueryCommand).resolves({
+      Items: [
+        { dateForDeletion: "2030-01-01", commonSubjectId: "user-id" },
+      ],
+    });
+
+    await deleteUserData(TEST_USER_DATA);
+
+    expect(dynamoMock).toHaveReceivedCommandWith(QueryCommand, {
+      TableName: "TABLE_NAME",
+      IndexName: "CommonSubjectIdIndex",
+      KeyConditionExpression: "commonSubjectId = :uid",
+      ExpressionAttributeValues: { ":uid": TEST_USER_DATA.user_id },
+    });
+    expect(dynamoMock).toHaveReceivedCommandWith(DeleteCommand, {
+      TableName: "TABLE_NAME",
+      Key: { dateForDeletion: "2030-01-01", commonSubjectId: "user-id" },
+    });
+  });
+
+  test("does not delete when no records found", async () => {
+    dynamoMock.on(QueryCommand).resolves({ Items: [] });
+
+    await deleteUserData(TEST_USER_DATA);
+
+    expect(dynamoMock.commandCalls(DeleteCommand).length).toEqual(0);
+  });
+
+  test("deletes multiple records when query returns many", async () => {
+    dynamoMock.on(QueryCommand).resolves({
+      Items: [
+        { dateForDeletion: "2030-01-01", commonSubjectId: "user-id" },
+        { dateForDeletion: "2031-01-01", commonSubjectId: "user-id" },
+      ],
+    });
+
+    await deleteUserData(TEST_USER_DATA);
+
+    expect(dynamoMock.commandCalls(DeleteCommand).length).toEqual(2);
+  });
+});
+
+describe("handler", () => {
+  beforeEach(() => {
+    dynamoMock.reset();
+    process.env.TABLE_NAME = "TABLE_NAME";
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("it iterates over each record in the batch", async () => {
+    dynamoMock.on(QueryCommand).resolves({
+      Items: [
+        { dateForDeletion: "2030-01-01", commonSubjectId: "user-id" },
+      ],
+    });
+
+    await handler(TEST_SNS_EVENT_WITH_TWO_RECORDS, {} as Context);
+    expect(dynamoMock.commandCalls(DeleteCommand).length).toEqual(2);
+  });
+
+  describe("error handling", () => {
+    beforeEach(() => {
+      dynamoMock.on(QueryCommand).rejects("mock error");
+    });
+
+    test("throws error with message ID", async () => {
+      let errorMessage;
+      try {
+        await handler(TEST_SNS_EVENT_WITH_TWO_RECORDS, {} as Context);
+      } catch (error) {
+        errorMessage = (error as Error).message;
+      }
+      expect(errorMessage).toContain(
+        "Unable to delete inactive account tracker data for message with ID: MessageId, mock error"
+      );
+    });
+  });
+});
+
+describe("validateUserData", () => {
+  test("doesn't throw an error with valid data", () => {
+    expect(validateUserData(TEST_USER_DATA)).toBe(TEST_USER_DATA);
+  });
+
+  test("throws an error when user_id is missing", () => {
+    const userData = JSON.parse(JSON.stringify({ foo: "bar" }));
+    expect(() => {
+      validateUserData(userData);
+    }).toThrow();
+  });
+});

--- a/template.yaml
+++ b/template.yaml
@@ -3999,6 +3999,335 @@ Resources:
       AlarmActions:
         - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/LowAlertNotificationTopic/ARN}}"
 
+  ####################################
+  # Deleting Inactive Account Tracker Records
+  ####################################
+
+  DeleteInactiveAccountTrackerSubscription:
+    Condition: IsDevelopment
+    DependsOn: DeleteInactiveAccountTrackerFunctionAliaslive
+    Type: AWS::SNS::Subscription
+    Properties:
+      Endpoint: !Join [":", [!GetAtt DeleteInactiveAccountTrackerFunction.Arn, live]]
+      Protocol: lambda
+      RedrivePolicy:
+        deadLetterTargetArn: !GetAtt DeleteInactiveAccountTrackerSubscriptionDeadLetterQueue.Arn
+      TopicArn: !Ref UserAccountDeletionTopic
+
+  DeleteInactiveAccountTrackerSubscriptionDeadLetterQueue:
+    Type: AWS::SQS::Queue
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Properties:
+      MessageRetentionPeriod: 1209600
+      KmsMasterKeyId: !GetAtt QueueKmsKey.Arn
+
+  DeleteInactiveAccountTrackerSubscriptionDeadLetterQueuePolicy:
+    Type: AWS::SQS::QueuePolicy
+    Properties:
+      Queues:
+        - !Ref DeleteInactiveAccountTrackerSubscriptionDeadLetterQueue
+      PolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: sns.amazonaws.com
+            Action: "sqs:SendMessage"
+            Resource: !GetAtt DeleteInactiveAccountTrackerSubscriptionDeadLetterQueue.Arn
+            Condition:
+              ArnEquals:
+                "aws:SourceArn": !Ref UserAccountDeletionTopic
+
+  DeleteInactiveAccountTrackerFunction:
+    DependsOn:
+      - DeleteInactiveAccountTrackerFunctionLogGroup
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Sub ${Environment}-${AWS::StackName}-delete-inactive-account-tracker
+      CodeUri: src
+      PackageType: Zip
+      DeadLetterQueue:
+        Type: SQS
+        TargetArn: !GetAtt DeleteInactiveAccountTrackerDeadLetterQueue.Arn
+      Handler: delete-inactive-account-tracker.handler
+      Role: !GetAtt DeleteInactiveAccountTrackerRole.Arn
+      Environment:
+        Variables:
+          TABLE_NAME: !Ref InactveAccountTrackerStoreTableName
+          NODE_OPTIONS: --enable-source-maps
+      DeploymentPreference:
+        Alarms:
+          Fn::If:
+            - IsNotDevelopmentOrDemo
+            - - !Ref DeleteInactiveAccountTrackerFunctionSuccessRate
+            - - !Ref AWS::NoValue
+    Metadata:
+      BuildMethod: esbuild
+      BuildProperties:
+        Minify: true
+        Format: "esm"
+        OutExtension:
+          - .js=.mjs
+        Target: "es2022"
+        Sourcemap: true
+        EntryPoints:
+          - delete-inactive-account-tracker.ts
+        Banner:
+          - js=import { createRequire } from 'module'; const require = createRequire(import.meta.url);
+
+  DeleteInactiveAccountTrackerLambdaInvokePermission:
+    Condition: IsDevelopment
+    DependsOn: DeleteInactiveAccountTrackerFunctionAliaslive
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      Principal: sns.amazonaws.com
+      SourceArn:
+        Ref: UserAccountDeletionTopic
+      FunctionName: !Join [":", [!GetAtt DeleteInactiveAccountTrackerFunction.Arn, live]]
+
+  DeleteInactiveAccountTrackerRole:
+    Type: AWS::IAM::Role
+    Properties:
+      PermissionsBoundary: !If
+        - UsePermissionsBoundary
+        - !Ref PermissionsBoundary
+        - !Ref AWS::NoValue
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
+        - !Ref DeleteInactiveAccountTrackerPolicy
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - "sts:AssumeRole"
+
+  DeleteInactiveAccountTrackerPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - sqs:SendMessage
+            Resource: !GetAtt DeleteInactiveAccountTrackerDeadLetterQueue.Arn
+          - Effect: Allow
+            Action:
+              - dynamodb:Query
+            Resource:
+              - !Sub
+                - "${Arn}/index/CommonSubjectIdIndex"
+                - Arn: !GetAtt InactiveAccountTrackerStore.Arn
+          - Effect: Allow
+            Action:
+              - dynamodb:DeleteItem
+            Resource:
+              - !GetAtt InactiveAccountTrackerStore.Arn
+          - Effect: Allow
+            Action:
+              - kms:Decrypt
+              - kms:GenerateDataKey*
+              - kms:ReEncrypt*
+            Resource:
+              - !GetAtt QueueKmsKey.Arn
+              - !GetAtt DatabaseKmsKey.Arn
+              - !GetAtt LoggingKmsKey.Arn
+              - !GetAtt LambdaKMSKey.Arn
+
+  DeleteInactiveAccountTrackerFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/${Environment}-${AWS::StackName}-delete-inactive-account-tracker"
+      RetentionInDays: 30
+      KmsKeyId: !GetAtt LoggingKmsKey.Arn
+
+  DeleteInactiveAccountTrackerCSLSSubscription:
+    Condition: ExportLogsToSplunk
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn: !Sub "{{resolve:ssm:/${Environment}/Platform/Logs/Subscription/CSLS/ARN}}"
+      FilterPattern: ""
+      LogGroupName: !Ref DeleteInactiveAccountTrackerFunctionLogGroup
+
+  DeleteInactiveAccountTrackerDeadLetterQueue:
+    Type: AWS::SQS::Queue
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Properties:
+      MessageRetentionPeriod: 1209600
+      KmsMasterKeyId: !GetAtt QueueKmsKey.Arn
+
+  DeleteInactiveAccountTrackerDeadLetterQueuePolicy:
+    Type: AWS::SQS::QueuePolicy
+    Properties:
+      Queues:
+        - !Ref DeleteInactiveAccountTrackerDeadLetterQueue
+      PolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: sns.amazonaws.com
+            Action: "sqs:SendMessage"
+            Resource: !GetAtt DeleteInactiveAccountTrackerDeadLetterQueue.Arn
+            Condition:
+              ArnEquals:
+                "aws:SourceArn": !Ref UserAccountDeletionTopic
+
+  DeleteInactiveAccountTrackerDeadLetterQueueAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName:
+        !Join [
+          "-",
+          [
+            !Ref AWS::StackName,
+            !Ref Environment,
+            DeleteInactiveAccountTrackerDeadLetterQueueAlarm,
+          ],
+        ]
+      AlarmDescription: More than 1 inactive account tracker record failed to be deleted in the last 5 minutes.
+      Namespace: "AWS/SQS"
+      MetricName: "ApproximateNumberOfMessagesVisible"
+      Dimensions:
+        - Name: "QueueName"
+          Value: !GetAtt DeleteInactiveAccountTrackerDeadLetterQueue.QueueName
+      Statistic: "Sum"
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: "GreaterThanOrEqualToThreshold"
+      AlarmActions:
+        - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/LowAlertNotificationTopic/ARN}}"
+      ActionsEnabled: true
+
+  DeleteInactiveAccountTrackerSubscriptionDeadLetterQueueAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName:
+        !Join [
+          "-",
+          [
+            !Ref AWS::StackName,
+            !Ref Environment,
+            DeleteInactiveAccountTrackerSubscriptionDeadLetterQueueAlarm,
+          ],
+        ]
+      AlarmDescription: More than 1 deletion of inactive account tracker records failed in the last 5 minutes.
+      Namespace: "AWS/SQS"
+      MetricName: "ApproximateNumberOfMessagesVisible"
+      Dimensions:
+        - Name: "QueueName"
+          Value: !GetAtt DeleteInactiveAccountTrackerSubscriptionDeadLetterQueue.QueueName
+      Statistic: "Sum"
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: "GreaterThanOrEqualToThreshold"
+      AlarmActions:
+        - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/LowAlertNotificationTopic/ARN}}"
+      ActionsEnabled: true
+
+  DeleteInactiveAccountTrackerDeadLetterQueueOldestMessageAgeAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName:
+        !Join [
+          "-",
+          [
+            !Ref AWS::StackName,
+            !Ref Environment,
+            DeleteInactiveAccountTrackerDeadLetterQueueOldestMessageAgeAlarm,
+          ],
+        ]
+      MetricName: ApproximateAgeOfOldestMessage
+      Namespace: AWS/SQS
+      Statistic: Maximum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 300
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Dimensions:
+        - Name: QueueName
+          Value: !GetAtt DeleteInactiveAccountTrackerDeadLetterQueue.QueueName
+      AlarmActions:
+        - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/LowAlertNotificationTopic/ARN}}"
+
+  DeleteInactiveAccountTrackerSubscriptionDeadLetterQueueOldestMessageAgeAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName:
+        !Join [
+          "-",
+          [
+            !Ref AWS::StackName,
+            !Ref Environment,
+            DeleteInactiveAccountTrackerSubscriptionDeadLetterQueueOldestMessageAgeAlarm,
+          ],
+        ]
+      MetricName: ApproximateAgeOfOldestMessage
+      Namespace: AWS/SQS
+      Statistic: Maximum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 300
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Dimensions:
+        - Name: QueueName
+          Value: !GetAtt DeleteInactiveAccountTrackerSubscriptionDeadLetterQueue.QueueName
+      AlarmActions:
+        - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/LowAlertNotificationTopic/ARN}}"
+
+  DeleteInactiveAccountTrackerFunctionSuccessRate:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName:
+        !Join [
+          "-",
+          [
+            !Ref AWS::StackName,
+            !Ref Environment,
+            DeleteInactiveAccountTrackerFunctionSuccessRate,
+          ],
+        ]
+      Metrics:
+        - Id: errors
+          MetricStat:
+            Metric:
+              Namespace: AWS/Lambda
+              MetricName: Errors
+              Dimensions:
+                - Name: FunctionName
+                  Value: !Ref DeleteInactiveAccountTrackerFunction
+            Period: 300
+            Stat: Sum
+          ReturnData: false
+        - Id: invocations
+          MetricStat:
+            Metric:
+              Namespace: AWS/Lambda
+              MetricName: Invocations
+              Dimensions:
+                - Name: FunctionName
+                  Value: !Ref DeleteInactiveAccountTrackerFunction
+            Period: 300
+            Stat: Sum
+          ReturnData: false
+        - Id: successRate
+          Expression: "1 - (errors / invocations)"
+          Label: "Success Rate"
+          ReturnData: true
+      Threshold: 0.95
+      ComparisonOperator: LessThanThreshold
+      EvaluationPeriods: 1
+      AlarmActions:
+        - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/LowAlertNotificationTopic/ARN}}"
+
   ######################
   # Mark Suspicious Activity as Reported
   ######################


### PR DESCRIPTION
## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->

### What changed

Create a lambda to delete data for a specified user from the inactive account tracker table (enabled only in development)

subscribe that lambda to to UserAccountDeletion SNS topic


### Why did it change

This is required as we will store user data which needs to be removed when the user delete's their account 

### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists

<!-- Merging this PR deploys to production. Please answer accurately. -->

### Environment variables or secrets

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Added parameters to Cloudformation template
- [ ] Added new secret or systems manager parameter
- [ ] Added new environment variable

### Permissions

- [ ] This PR adds or changes permissions

### Monitoring

- [ ] This PR includes changes that need to be monitored in production as the scope of the change could cause issues

## Testing

Deployed the branch to dev and manually triggered an event on the SNS topic

## How to review

<!-- Describe any non-standard steps to review this work, or highlight any areas that you'd like the reviewer's opinion on -->
