### PR TITLE
BAU: restore DeadLetterQueue on SQS-triggered Lambdas to fix deploy

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -1365,6 +1365,9 @@ Resources:
           Type: SQS
           Properties:
             Queue: !GetAtt UserServicesToFormatQueue.Arn
+      DeadLetterQueue:
+        Type: SQS
+        TargetArn: !GetAtt FormatUserServicesDeadLetterQueue.Arn
       Handler: format-user-services.handler
       Role: !GetAtt FormatUserServicesRole.Arn
       ReservedConcurrentExecutions: 30
@@ -1644,6 +1647,9 @@ Resources:
           Type: SQS
           Properties:
             Queue: !GetAtt UserServicesToWriteQueue.Arn
+      DeadLetterQueue:
+        Type: SQS
+        TargetArn: !GetAtt WriteUserServicesDeadLetterQueue.Arn
       Handler: write-user-services.handler
       Role: !GetAtt WriteServiceRecordRole.Arn
       Environment:
@@ -2534,6 +2540,9 @@ Resources:
           Type: SQS
           Properties:
             Queue: !GetAtt ActivityLogToWriteQueue.Arn
+      DeadLetterQueue:
+        Type: SQS
+        TargetArn: !GetAtt WriteActivityLogDeadLetterQueue.Arn
       Handler: write-activity-log.handler
       Role: !GetAtt WriteActivityRecordRole.Arn
       ReservedConcurrentExecutions: 30


### PR DESCRIPTION
## Proposed changes

### What changed

Restored the (inert) `DeadLetterQueue` SAM property on `FormatUserServicesFunction`, `WriteUserServicesFunction`, and `WriteActivityLogFunction`.

### Why did it change

CloudFormation fails when removing `DeadLetterConfig` from a Lambda that uses `DeploymentPreference` (canary deploys). The previously published version still has `DeadLetterConfig` set, and CloudFormation requires all versions referenced by the alias to have the same DLQ target.

Error in production: "Specified versions must be configured with the same DLQ target"

The actual DLQ fix (RedrivePolicy on the source queue) from PR #1057 is already in place and working correctly. This property is inert but required for version compatibility during canary transitions. It can be removed in a future deploy once the alias has fully shifted to a version published without it.

### Related links

- #1057 (original DLQ fix)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Permissions

- [ ] This PR adds or changes permissions

### Monitoring

- [ ] This PR includes changes that need to be monitored in production as the scope of the change could cause issues

## Testing

- SAM validate passes
- Fixes CloudFormation deploy failure observed in production

## How to review

This is a 3-line addition restoring a property that was removed in #1057. The property is inert for SQS ESM triggers but required by CloudFormation during canary deploys for version consistency.