### PR TITLE
BAU: restore sqs:SendMessage permissions on DLQs for Lambda roles

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -1440,6 +1440,10 @@ Resources:
           - Effect: Allow
             Action:
               - sqs:SendMessage
+            Resource: !GetAtt FormatUserServicesDeadLetterQueue.Arn
+          - Effect: Allow
+            Action:
+              - sqs:SendMessage
             Resource: !GetAtt UserServicesToWriteQueue.Arn
           - Effect: Allow
             Action:
@@ -1717,6 +1721,10 @@ Resources:
               - sqs:DeleteMessage
               - sqs:GetQueueAttributes
             Resource: !GetAtt UserServicesToWriteQueue.Arn
+          - Effect: Allow
+            Action:
+              - sqs:SendMessage
+            Resource: !GetAtt WriteUserServicesDeadLetterQueue.Arn
           - Effect: Allow
             Action:
               - dynamodb:PutItem
@@ -2617,6 +2625,10 @@ Resources:
               - sqs:DeleteMessage
               - sqs:GetQueueAttributes
             Resource: !GetAtt ActivityLogToWriteQueue.Arn
+          - Effect: Allow
+            Action:
+              - sqs:SendMessage
+            Resource: !GetAtt WriteActivityLogDeadLetterQueue.Arn
           - Effect: Allow
             Action:
               - dynamodb:PutItem


### PR DESCRIPTION
## Proposed changes

### What changed

Restored `sqs:SendMessage` permissions on the DLQ ARNs for `FormatUserServicesRole`, `WriteServiceRecordRole`, and `WriteActivityRecordRole`.

### Why did it change

The `DeadLetterQueue` SAM property requires the Lambda execution role to have `sqs:SendMessage` on the DLQ target. These were removed in #1057 alongside the `DeadLetterQueue` property, but the property was restored in #1059 without restoring the permissions.

Error: "The provided execution role does not have permissions to call SendMessage on SQS"

### Related links

- #1057 (original DLQ fix - removed permissions)
- #1059 (restored DeadLetterQueue property but missed permissions)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Permissions

- [x] This PR adds or changes permissions

Restores `sqs:SendMessage` on DLQ ARNs for 3 Lambda roles (was present before #1057).

### Monitoring

- [ ] This PR includes changes that need to be monitored in production as the scope of the change could cause issues

## Testing

- SAM validate passes
- Restores permissions to pre-#1057 state

## How to review

Compare against the state before #1057 - these 3 permission statements existed previously and were incorrectly removed.