### PR TITLE
BAU: remove inert DeadLetterQueue config and sqs:SendMessage permissions

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -1365,9 +1365,6 @@ Resources:
           Type: SQS
           Properties:
             Queue: !GetAtt UserServicesToFormatQueue.Arn
-      DeadLetterQueue:
-        Type: SQS
-        TargetArn: !GetAtt FormatUserServicesDeadLetterQueue.Arn
       Handler: format-user-services.handler
       Role: !GetAtt FormatUserServicesRole.Arn
       ReservedConcurrentExecutions: 30
@@ -1437,10 +1434,6 @@ Resources:
               - sqs:DeleteMessage
               - sqs:GetQueueAttributes
             Resource: !GetAtt UserServicesToFormatQueue.Arn
-          - Effect: Allow
-            Action:
-              - sqs:SendMessage
-            Resource: !GetAtt FormatUserServicesDeadLetterQueue.Arn
           - Effect: Allow
             Action:
               - sqs:SendMessage
@@ -1651,9 +1644,6 @@ Resources:
           Type: SQS
           Properties:
             Queue: !GetAtt UserServicesToWriteQueue.Arn
-      DeadLetterQueue:
-        Type: SQS
-        TargetArn: !GetAtt WriteUserServicesDeadLetterQueue.Arn
       Handler: write-user-services.handler
       Role: !GetAtt WriteServiceRecordRole.Arn
       Environment:
@@ -1721,10 +1711,6 @@ Resources:
               - sqs:DeleteMessage
               - sqs:GetQueueAttributes
             Resource: !GetAtt UserServicesToWriteQueue.Arn
-          - Effect: Allow
-            Action:
-              - sqs:SendMessage
-            Resource: !GetAtt WriteUserServicesDeadLetterQueue.Arn
           - Effect: Allow
             Action:
               - dynamodb:PutItem
@@ -2548,9 +2534,6 @@ Resources:
           Type: SQS
           Properties:
             Queue: !GetAtt ActivityLogToWriteQueue.Arn
-      DeadLetterQueue:
-        Type: SQS
-        TargetArn: !GetAtt WriteActivityLogDeadLetterQueue.Arn
       Handler: write-activity-log.handler
       Role: !GetAtt WriteActivityRecordRole.Arn
       ReservedConcurrentExecutions: 30
@@ -2625,10 +2608,6 @@ Resources:
               - sqs:DeleteMessage
               - sqs:GetQueueAttributes
             Resource: !GetAtt ActivityLogToWriteQueue.Arn
-          - Effect: Allow
-            Action:
-              - sqs:SendMessage
-            Resource: !GetAtt WriteActivityLogDeadLetterQueue.Arn
           - Effect: Allow
             Action:
               - dynamodb:PutItem


### PR DESCRIPTION
## Proposed changes

### What changed

Removes the inert `DeadLetterQueue` SAM property and associated `sqs:SendMessage` IAM permissions from `FormatUserServicesFunction`, `WriteUserServicesFunction`, and `WriteActivityLogFunction`.

### Why did it change

#1059 and #1060 temporarily restored these to unblock the canary deploy (CloudFormation requires version consistency for `DeadLetterConfig` during alias transitions). The canary has now completed, so the new Lambda version without `DeadLetterConfig` is fully active and these can be safely removed.

The `RedrivePolicy` on the source queues (#1057) remains in place and is the actual working DLQ mechanism.

### Related links

- #1057 (added RedrivePolicy - the actual fix)
- #1059 (temporary: restored DeadLetterQueue for canary)
- #1060 (temporary: restored sqs:SendMessage for canary)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Permissions

- [x] This PR adds or changes permissions

Removes `sqs:SendMessage` on DLQ ARNs from 3 Lambda roles (no longer needed).

### Monitoring

- [ ] This PR includes changes that need to be monitored in production as the scope of the change could cause issues

## Testing

- SAM validate passes
- Canary deploy has already published a version without DeadLetterConfig, so removing it now will not cause version mismatch

## How to review

This is the reverse of #1059 and #1060. Net effect is the same as #1057 originally intended.