### PR TITLE
OLH-4239 Create account processer lambda

### DIFF
--- a/dev/seed-inactive-account-tracker.sh
+++ b/dev/seed-inactive-account-tracker.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Populates the inactive_account_tracker_store DynamoDB table with test data
+# covering all scenarios in query-and-dispatch-inactive-accounts.ts
+#
+# Usage:
+#   ./scripts/seed-inactive-account-tracker.sh [--table-name <name>] [--profile <aws-profile>] [--region <region>]
+#
+# Defaults:
+#   table-name: inactive_account_tracker_store
+#   region: eu-west-2
+
+set -euo pipefail
+
+TABLE_NAME="inactive_account_tracker_store"
+REGION="eu-west-2"
+PROFILE_ARG=""
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --table-name) TABLE_NAME="$2"; shift 2 ;;
+    --profile) PROFILE_ARG="--profile $2"; shift 2 ;;
+    --region) REGION="$2"; shift 2 ;;
+    *) echo "Unknown arg: $1"; exit 1 ;;
+  esac
+done
+
+# Calculate target dates relative to today
+today=$(date -u +%Y-%m-%d)
+in_7_days=$(date -u -v+7d +%Y-%m-%d 2>/dev/null || date -u -d "+7 days" +%Y-%m-%d)
+in_30_days=$(date -u -v+30d +%Y-%m-%d 2>/dev/null || date -u -d "+30 days" +%Y-%m-%d)
+yesterday=$(date -u -v-1d +%Y-%m-%d 2>/dev/null || date -u -d "-1 day" +%Y-%m-%d)
+
+echo "Table: $TABLE_NAME"
+echo "Today (DeleteAccount target): $today"
+echo "In 7 days (Warning7Day target): $in_7_days"
+echo "In 30 days (Warning30Day target): $in_30_days"
+echo "Yesterday (should not be picked up): $yesterday"
+echo ""
+
+put_item() {
+  local date_for_deletion="$1"
+  local common_subject_id="$2"
+  local status="$3"
+  local description="$4"
+
+  echo "  Adding: $description"
+  aws dynamodb put-item $PROFILE_ARG --region "$REGION" \
+    --table-name "$TABLE_NAME" \
+    --item "{
+      \"dateForDeletion\": {\"S\": \"$date_for_deletion\"},
+      \"commonSubjectId\": {\"S\": \"$common_subject_id\"},
+      \"emailAddress\": {\"S\": \"test-${common_subject_id}@example.com\"},
+      \"userLastActive\": {\"S\": \"2025-01-01T00:00:00.000Z\"},
+      \"status\": {\"S\": \"$status\"},
+      \"statusLastUpdated\": {\"S\": \"$(date -u +%Y-%m-%dT%H:%M:%S.000Z)\"}
+    }"
+}
+
+# --- Warning30Day process: daysToDeletion=30, allowedStatuses=["pending"] ---
+echo "=== Warning30Day scenarios (dateForDeletion = $in_30_days) ==="
+put_item "$in_30_days" "user-30day-pending-001" "pending" \
+  "ELIGIBLE: pending status, should be dispatched to 30-day warning queue"
+put_item "$in_30_days" "user-30day-pending-002" "pending" \
+  "ELIGIBLE: another pending account for 30-day warning"
+put_item "$in_30_days" "user-30day-already-warned" "30DayWarningSent" \
+  "FILTERED OUT: already sent 30-day warning, not in allowedStatuses"
+put_item "$in_30_days" "user-30day-7day-warned" "7DayWarningSent" \
+  "FILTERED OUT: 7-day warning already sent, not in allowedStatuses"
+put_item "$in_30_days" "user-30day-deleting" "deleting" \
+  "FILTERED OUT: already in deleting status"
+put_item "$in_30_days" "user-30day-suspended" "permenantSuspension" \
+  "FILTERED OUT: permanently suspended"
+echo ""
+
+# --- Warning7Day process: daysToDeletion=7, allowedStatuses=["pending", "30DayWarningSent"] ---
+echo "=== Warning7Day scenarios (dateForDeletion = $in_7_days) ==="
+put_item "$in_7_days" "user-7day-pending-001" "pending" \
+  "ELIGIBLE: pending status, should be dispatched to 7-day warning queue"
+put_item "$in_7_days" "user-7day-30warned-001" "30DayWarningSent" \
+  "ELIGIBLE: 30-day warning sent, should be dispatched to 7-day warning queue"
+put_item "$in_7_days" "user-7day-already-7warned" "7DayWarningSent" \
+  "FILTERED OUT: 7-day warning already sent, not in allowedStatuses"
+put_item "$in_7_days" "user-7day-deleting" "deleting" \
+  "FILTERED OUT: already in deleting status"
+put_item "$in_7_days" "user-7day-suspended" "permenantSuspension" \
+  "FILTERED OUT: permanently suspended"
+echo ""
+
+# --- DeleteAccount process: daysToDeletion=0, allowedStatuses=["pending", "30DayWarningSent", "7DayWarningSent"] ---
+echo "=== DeleteAccount scenarios (dateForDeletion = $today) ==="
+put_item "$today" "user-delete-pending-001" "pending" \
+  "ELIGIBLE: pending status, should be dispatched to deletion queue"
+put_item "$today" "user-delete-30warned-001" "30DayWarningSent" \
+  "ELIGIBLE: 30-day warning sent, should be dispatched to deletion queue"
+put_item "$today" "user-delete-7warned-001" "7DayWarningSent" \
+  "ELIGIBLE: 7-day warning sent, should be dispatched to deletion queue"
+put_item "$today" "user-delete-deleting" "deleting" \
+  "FILTERED OUT: already in deleting status"
+put_item "$today" "user-delete-suspended" "permenantSuspension" \
+  "FILTERED OUT: permanently suspended"
+echo ""
+
+# --- Edge case: records with a past date should NOT be picked up by any current run ---
+echo "=== Edge case: past date (dateForDeletion = $yesterday) ==="
+put_item "$yesterday" "user-past-pending" "pending" \
+  "NOT QUERIED: date is in the past, won't match any calculateTargetDate()"
+echo ""
+
+echo "Done. Seeded $(echo 6+5+5+1 | bc) records into $TABLE_NAME."

--- a/dev/seed-inactive-account-tracker.sh
+++ b/dev/seed-inactive-account-tracker.sh
@@ -39,7 +39,7 @@ done
 status_pending="pending"
 status_30day_warned="30DayWarningSent"
 status_7day_warned="7DayWarningSent"
-status_permanently_suspended="permenantSuspension"
+status_permanently_suspended="permanentSuspension"
 status_deleting="deleting"
 
 # Calculate target dates relative to today

--- a/dev/seed-inactive-account-tracker.sh
+++ b/dev/seed-inactive-account-tracker.sh
@@ -17,12 +17,30 @@ PROFILE_ARG=""
 
 while [[ $# -gt 0 ]]; do
   case $1 in
-    --table-name) TABLE_NAME="$2"; shift 2 ;;
-    --profile) PROFILE_ARG="--profile $2"; shift 2 ;;
-    --region) REGION="$2"; shift 2 ;;
-    *) echo "Unknown arg: $1"; exit 1 ;;
+  --table-name)
+    TABLE_NAME="$2"
+    shift 2
+    ;;
+  --profile)
+    PROFILE_ARG="--profile $2"
+    shift 2
+    ;;
+  --region)
+    REGION="$2"
+    shift 2
+    ;;
+  *)
+    echo "Unknown arg: $1"
+    exit 1
+    ;;
   esac
 done
+
+status_pending="pending"
+status_30day_warned="30DayWarningSent"
+status_7day_warned="7DayWarningSent"
+status_permanently_suspended="permenantSuspension"
+status_deleting="deleting"
 
 # Calculate target dates relative to today
 today=$(date -u +%Y-%m-%d)
@@ -58,45 +76,45 @@ put_item() {
 
 # --- Warning30Day process: daysToDeletion=30, allowedStatuses=["pending"] ---
 echo "=== Warning30Day scenarios (dateForDeletion = $in_30_days) ==="
-put_item "$in_30_days" "user-30day-pending-001" "pending" \
+put_item "$in_30_days" "user-30day-pending-001" "$status_pending" \
   "ELIGIBLE: pending status, should be dispatched to 30-day warning queue"
-put_item "$in_30_days" "user-30day-pending-002" "pending" \
+put_item "$in_30_days" "user-30day-pending-002" "$status_pending" \
   "ELIGIBLE: another pending account for 30-day warning"
-put_item "$in_30_days" "user-30day-already-warned" "30DayWarningSent" \
+put_item "$in_30_days" "user-30day-already-warned" "$status_30day_warned" \
   "FILTERED OUT: already sent 30-day warning, not in allowedStatuses"
-put_item "$in_30_days" "user-30day-7day-warned" "7DayWarningSent" \
+put_item "$in_30_days" "user-30day-7day-warned" "$status_7day_warned" \
   "FILTERED OUT: 7-day warning already sent, not in allowedStatuses"
-put_item "$in_30_days" "user-30day-deleting" "deleting" \
+put_item "$in_30_days" "user-30day-deleting" "$status_deleting" \
   "FILTERED OUT: already in deleting status"
-put_item "$in_30_days" "user-30day-suspended" "permenantSuspension" \
+put_item "$in_30_days" "user-30day-suspended" "$status_permanently_suspended" \
   "FILTERED OUT: permanently suspended"
 echo ""
 
 # --- Warning7Day process: daysToDeletion=7, allowedStatuses=["pending", "30DayWarningSent"] ---
 echo "=== Warning7Day scenarios (dateForDeletion = $in_7_days) ==="
-put_item "$in_7_days" "user-7day-pending-001" "pending" \
+put_item "$in_7_days" "user-7day-pending-001" "$status_pending" \
   "ELIGIBLE: pending status, should be dispatched to 7-day warning queue"
-put_item "$in_7_days" "user-7day-30warned-001" "30DayWarningSent" \
+put_item "$in_7_days" "user-7day-30warned-001" "$status_30day_warned" \
   "ELIGIBLE: 30-day warning sent, should be dispatched to 7-day warning queue"
-put_item "$in_7_days" "user-7day-already-7warned" "7DayWarningSent" \
+put_item "$in_7_days" "user-7day-already-7warned" "$status_7day_warned" \
   "FILTERED OUT: 7-day warning already sent, not in allowedStatuses"
-put_item "$in_7_days" "user-7day-deleting" "deleting" \
+put_item "$in_7_days" "user-7day-deleting" "$status_deleting" \
   "FILTERED OUT: already in deleting status"
-put_item "$in_7_days" "user-7day-suspended" "permenantSuspension" \
+put_item "$in_7_days" "user-7day-suspended" "$status_permanently_suspended" \
   "FILTERED OUT: permanently suspended"
 echo ""
 
 # --- DeleteAccount process: daysToDeletion=0, allowedStatuses=["pending", "30DayWarningSent", "7DayWarningSent"] ---
 echo "=== DeleteAccount scenarios (dateForDeletion = $today) ==="
-put_item "$today" "user-delete-pending-001" "pending" \
+put_item "$today" "user-delete-pending-001" "$status_pending" \
   "ELIGIBLE: pending status, should be dispatched to deletion queue"
-put_item "$today" "user-delete-30warned-001" "30DayWarningSent" \
+put_item "$today" "user-delete-30warned-001" "$status_30day_warned" \
   "ELIGIBLE: 30-day warning sent, should be dispatched to deletion queue"
-put_item "$today" "user-delete-7warned-001" "7DayWarningSent" \
+put_item "$today" "user-delete-7warned-001" "$status_7day_warned" \
   "ELIGIBLE: 7-day warning sent, should be dispatched to deletion queue"
-put_item "$today" "user-delete-deleting" "deleting" \
+put_item "$today" "user-delete-deleting" "$status_deleting" \
   "FILTERED OUT: already in deleting status"
-put_item "$today" "user-delete-suspended" "permenantSuspension" \
+put_item "$today" "user-delete-suspended" "$status_permanently_suspended" \
   "FILTERED OUT: permanently suspended"
 echo ""
 

--- a/src/common/model.ts
+++ b/src/common/model.ts
@@ -210,7 +210,7 @@ export interface Personalisation {
   timeCy: string;
 }
 
-export type InactiveAccountStatus = "pending" | "deleting" | "30DayWarningSent" | "7DayWarningSent" | "permenantSuspension"
+export type InactiveAccountStatus = "pending" | "deleting" | "30DayWarningSent" | "7DayWarningSent" | "permanentSuspension"
 
 export interface InactiveAccountTrackerRecord {
   dateForDeletion: string;

--- a/src/common/model.ts
+++ b/src/common/model.ts
@@ -210,7 +210,7 @@ export interface Personalisation {
   timeCy: string;
 }
 
-type InactiveAccountStatus = "pending" | "deleting"
+export type InactiveAccountStatus = "pending" | "deleting" | "30DayWarningSent" | "7DayWarningSent" | "permenantSuspension"
 
 export interface InactiveAccountTrackerRecord {
   dateForDeletion: string;

--- a/src/query-and-dispatch-inactive-accounts.ts
+++ b/src/query-and-dispatch-inactive-accounts.ts
@@ -12,12 +12,13 @@ const dynamoDocClient = DynamoDBDocumentClient.from(dynamoClient);
 const sqsClient = new SQSClient({});
 
 export interface QueryAndDispatchEvent {
-  daysToDeletion: number;
   processName: string;
 }
 
-export const processConfig: Record<string, { queueUrlEnvVar: string }> = {
-  Warning30Day: { queueUrlEnvVar: "WARNING_30_DAY_NOTIFICATION_QUEUE_URL" },
+export const processConfig: Record<string, { queueUrlEnvVar: string; daysToDeletion: number[] }> = {
+  Warning30Day: { queueUrlEnvVar: "WARNING_30_DAY_NOTIFICATION_QUEUE_URL", daysToDeletion: [30] },
+  Warning7Day: { queueUrlEnvVar: "WARNING_8_DAY_NOTIFICATION_QUEUE_URL", daysToDeletion: [7] },
+  DeleteAccount: { queueUrlEnvVar: "ACCOUNT_DELETION_QUEUE_URL", daysToDeletion: [0] },
 };
 
 export const calculateTargetDate = (daysToDeletion: number): string => {
@@ -27,11 +28,6 @@ export const calculateTargetDate = (daysToDeletion: number): string => {
 };
 
 export const validateEvent = (event: QueryAndDispatchEvent): void => {
-  if (
-    !Number.isInteger(event.daysToDeletion)
-  ) {
-    throw new TypeError(`Error triggering ${event.processName}, daysToDeletion must be an integer, received: ${event.daysToDeletion}`);
-  }
   if (!event.processName || !processConfig[event.processName]) {
     throw new Error(`Unknown processName: ${event.processName}`);
   }
@@ -73,17 +69,19 @@ export const handler = async (
 
   const tableName = getEnvironmentVariable("TABLE_NAME");
 
-  const queueUrl = getEnvironmentVariable(
-    processConfig[event.processName].queueUrlEnvVar
-  );
+  const { queueUrlEnvVar, daysToDeletion } = processConfig[event.processName];
+  const queueUrl = getEnvironmentVariable(queueUrlEnvVar);
 
-  const targetDate = calculateTargetDate(event.daysToDeletion);
-  logger.info(`Querying accounts for deletion date: ${targetDate}`);
-
-  const records = await queryAccountsByDate(tableName, targetDate);
+  const records: InactiveAccountTrackerRecord[] = [];
+  for (const days of daysToDeletion) {
+    const targetDate = calculateTargetDate(days);
+    logger.info(`Querying accounts for deletion date: ${targetDate}`);
+    const result = await queryAccountsByDate(tableName, targetDate);
+    records.push(...result);
+  }
 
   if (records.length === 0) {
-    logger.info("No accounts found for target date");
+    logger.info("No accounts found for target dates");
     return;
   }
 

--- a/src/query-and-dispatch-inactive-accounts.ts
+++ b/src/query-and-dispatch-inactive-accounts.ts
@@ -1,0 +1,101 @@
+import { Context } from "aws-lambda";
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { DynamoDBDocumentClient, QueryCommand } from "@aws-sdk/lib-dynamodb";
+import { SQSClient, SendMessageCommand } from "@aws-sdk/client-sqs";
+import { Logger } from "@aws-lambda-powertools/logger";
+import { getEnvironmentVariable } from "./common/utils.js";
+import type { InactiveAccountTrackerRecord } from "./common/model.js";
+
+const logger = new Logger();
+const dynamoClient = new DynamoDBClient({});
+const dynamoDocClient = DynamoDBDocumentClient.from(dynamoClient);
+const sqsClient = new SQSClient({});
+
+export interface QueryAndDispatchEvent {
+  daysToDeletion: number;
+  processName: string;
+}
+
+export const processConfig: Record<string, { queueUrlEnvVar: string }> = {
+  sendNotification: { queueUrlEnvVar: "SEND_NOTIFICATION_QUEUE_URL" },
+};
+
+export const calculateTargetDate = (daysToDeletion: number): string => {
+  const date = new Date();
+  date.setDate(date.getDate() + daysToDeletion);
+  return date.toISOString().split("T")[0];
+};
+
+export const validateEvent = (event: QueryAndDispatchEvent): void => {
+  if (
+    !Number.isInteger(event.daysToDeletion) ||
+    event.daysToDeletion < 0
+  ) {
+    throw new Error(`Error triggering ${event.processName}, daysToDeletion must be a non-negative integer, received: ${event.daysToDeletion}`);
+  }
+  if (!event.processName || !processConfig[event.processName]) {
+    throw new Error(`Unknown processName: ${event.processName}`);
+  }
+};
+
+export const queryAccountsByDate = async (
+  tableName: string,
+  dateForDeletion: string
+): Promise<InactiveAccountTrackerRecord[]> => {
+  const results: InactiveAccountTrackerRecord[] = [];
+  let lastEvaluatedKey: Record<string, unknown> | undefined;
+
+  do {
+    const response = await dynamoDocClient.send(
+      new QueryCommand({
+        TableName: tableName,
+        KeyConditionExpression: "dateForDeletion = :date",
+        ExpressionAttributeValues: { ":date": dateForDeletion },
+        ExclusiveStartKey: lastEvaluatedKey,
+      })
+    );
+
+    if (response.Items) {
+      results.push(...(response.Items as InactiveAccountTrackerRecord[]));
+    }
+    lastEvaluatedKey = response.LastEvaluatedKey ?? undefined;
+  } while (lastEvaluatedKey);
+
+  return results;
+};
+
+export const handler = async (
+  event: QueryAndDispatchEvent,
+  context: Context
+): Promise<void> => {
+  logger.addContext(context);
+
+  validateEvent(event);
+
+  const tableName = getEnvironmentVariable("TABLE_NAME");
+
+  const queueUrl = getEnvironmentVariable(
+    processConfig[event.processName].queueUrlEnvVar
+  );
+
+  const targetDate = calculateTargetDate(event.daysToDeletion);
+  logger.info(`Querying accounts for deletion date: ${targetDate}`);
+
+  const records = await queryAccountsByDate(tableName, targetDate);
+
+  if (records.length === 0) {
+    logger.info("No accounts found for target date");
+    return;
+  }
+
+  for (const record of records) {
+    await sqsClient.send(
+      new SendMessageCommand({
+        QueueUrl: queueUrl,
+        MessageBody: JSON.stringify(record),
+      })
+    );
+  }
+
+  logger.info(`Dispatched ${records.length} accounts to ${event.processName}`);
+};

--- a/src/query-and-dispatch-inactive-accounts.ts
+++ b/src/query-and-dispatch-inactive-accounts.ts
@@ -17,7 +17,7 @@ export interface QueryAndDispatchEvent {
 }
 
 export const processConfig: Record<string, { queueUrlEnvVar: string }> = {
-  sendNotification: { queueUrlEnvVar: "SEND_NOTIFICATION_QUEUE_URL" },
+  Warning30Day: { queueUrlEnvVar: "WARNING_30_DAY_NOTIFICATION_QUEUE_URL" },
 };
 
 export const calculateTargetDate = (daysToDeletion: number): string => {

--- a/src/query-and-dispatch-inactive-accounts.ts
+++ b/src/query-and-dispatch-inactive-accounts.ts
@@ -28,10 +28,9 @@ export const calculateTargetDate = (daysToDeletion: number): string => {
 
 export const validateEvent = (event: QueryAndDispatchEvent): void => {
   if (
-    !Number.isInteger(event.daysToDeletion) ||
-    event.daysToDeletion < 0
+    !Number.isInteger(event.daysToDeletion)
   ) {
-    throw new Error(`Error triggering ${event.processName}, daysToDeletion must be a non-negative integer, received: ${event.daysToDeletion}`);
+    throw new Error(`Error triggering ${event.processName}, daysToDeletion must be an integer, received: ${event.daysToDeletion}`);
   }
   if (!event.processName || !processConfig[event.processName]) {
     throw new Error(`Unknown processName: ${event.processName}`);

--- a/src/query-and-dispatch-inactive-accounts.ts
+++ b/src/query-and-dispatch-inactive-accounts.ts
@@ -30,7 +30,7 @@ export const validateEvent = (event: QueryAndDispatchEvent): void => {
   if (
     !Number.isInteger(event.daysToDeletion)
   ) {
-    throw new Error(`Error triggering ${event.processName}, daysToDeletion must be an integer, received: ${event.daysToDeletion}`);
+    throw new TypeError(`Error triggering ${event.processName}, daysToDeletion must be an integer, received: ${event.daysToDeletion}`);
   }
   if (!event.processName || !processConfig[event.processName]) {
     throw new Error(`Unknown processName: ${event.processName}`);

--- a/src/query-and-dispatch-inactive-accounts.ts
+++ b/src/query-and-dispatch-inactive-accounts.ts
@@ -4,7 +4,7 @@ import { DynamoDBDocumentClient, QueryCommand } from "@aws-sdk/lib-dynamodb";
 import { SQSClient, SendMessageCommand } from "@aws-sdk/client-sqs";
 import { Logger } from "@aws-lambda-powertools/logger";
 import { getEnvironmentVariable } from "./common/utils.js";
-import type { InactiveAccountTrackerRecord } from "./common/model.js";
+import type { InactiveAccountStatus, InactiveAccountTrackerRecord } from "./common/model.js";
 
 const logger = new Logger();
 const dynamoClient = new DynamoDBClient({});
@@ -15,10 +15,12 @@ export interface QueryAndDispatchEvent {
   processName: string;
 }
 
-export const processConfig: Record<string, { queueUrlEnvVar: string; daysToDeletion: number[] }> = {
-  Warning30Day: { queueUrlEnvVar: "WARNING_30_DAY_NOTIFICATION_QUEUE_URL", daysToDeletion: [30] },
-  Warning7Day: { queueUrlEnvVar: "WARNING_8_DAY_NOTIFICATION_QUEUE_URL", daysToDeletion: [7] },
-  DeleteAccount: { queueUrlEnvVar: "ACCOUNT_DELETION_QUEUE_URL", daysToDeletion: [0] },
+type ProcessConfig = Record<string, { queueUrlEnvVar: string; daysToDeletion: number[]; allowedStatuses: InactiveAccountStatus[] }>
+
+export const processConfig: ProcessConfig = {
+  Warning30Day: { queueUrlEnvVar: "WARNING_30_DAY_NOTIFICATION_QUEUE_URL", daysToDeletion: [30], allowedStatuses: ["pending"] },
+  Warning7Day: { queueUrlEnvVar: "WARNING_7_DAY_NOTIFICATION_QUEUE_URL", daysToDeletion: [7], allowedStatuses: ["pending", "30DayWarningSent"] },
+  DeleteAccount: { queueUrlEnvVar: "ACCOUNT_DELETION_QUEUE_URL", daysToDeletion: [0], allowedStatuses: ["pending", "30DayWarningSent", "7DayWarningSent"] },
 };
 
 export const calculateTargetDate = (daysToDeletion: number): string => {
@@ -69,7 +71,7 @@ export const handler = async (
 
   const tableName = getEnvironmentVariable("TABLE_NAME");
 
-  const { queueUrlEnvVar, daysToDeletion } = processConfig[event.processName];
+  const { queueUrlEnvVar, daysToDeletion, allowedStatuses } = processConfig[event.processName];
   const queueUrl = getEnvironmentVariable(queueUrlEnvVar);
 
   const records: InactiveAccountTrackerRecord[] = [];
@@ -80,12 +82,14 @@ export const handler = async (
     records.push(...result);
   }
 
-  if (records.length === 0) {
-    logger.info("No accounts found for target dates");
+  const eligibleRecords = records.filter((record) => allowedStatuses.includes(record.status));
+
+  if (eligibleRecords.length === 0) {
+    logger.info("No eligible accounts found for target dates");
     return;
   }
 
-  for (const record of records) {
+  for (const record of eligibleRecords) {
     await sqsClient.send(
       new SendMessageCommand({
         QueueUrl: queueUrl,
@@ -94,5 +98,5 @@ export const handler = async (
     );
   }
 
-  logger.info(`Dispatched ${records.length} accounts to ${event.processName}`);
+  logger.info(`Dispatched ${eligibleRecords.length} accounts to ${event.processName}`);
 };

--- a/src/tests/query-and-dispatch-inactive-accounts.test.ts
+++ b/src/tests/query-and-dispatch-inactive-accounts.test.ts
@@ -95,38 +95,6 @@ describe("handler", () => {
     vi.clearAllMocks();
   });
 
-  test("queries DynamoDB for each daysToDeletion and dispatches records to SQS", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-06-17T12:00:00.000Z"));
-
-    dynamoMock.on(QueryCommand).resolves({ Items: [mockRecord] });
-    sqsMock.on(SendMessageCommand).resolves({});
-
-    await handler({ processName: "Warning30Day" }, {} as Context);
-
-    // processConfig has daysToDeletion: [29, 30, 31], so 3 queries
-    expect(dynamoMock.commandCalls(QueryCommand)).toHaveLength(3);
-    expect(dynamoMock.commandCalls(QueryCommand)[0].args[0].input).toMatchObject({
-      TableName: "inactive-accounts-table",
-      KeyConditionExpression: "dateForDeletion = :date",
-      ExpressionAttributeValues: { ":date": "2026-07-16" },
-    });
-    expect(dynamoMock.commandCalls(QueryCommand)[1].args[0].input).toMatchObject({
-      ExpressionAttributeValues: { ":date": "2026-07-17" },
-    });
-    expect(dynamoMock.commandCalls(QueryCommand)[2].args[0].input).toMatchObject({
-      ExpressionAttributeValues: { ":date": "2026-07-18" },
-    });
-    // 1 record per query = 3 SQS messages
-    expect(sqsMock.commandCalls(SendMessageCommand)).toHaveLength(3);
-    expect(sqsMock.commandCalls(SendMessageCommand)[0].args[0].input).toMatchObject({
-      QueueUrl: "https://sqs.eu-west-2.amazonaws.com/123/queue",
-      MessageBody: JSON.stringify(mockRecord),
-    });
-
-    vi.useRealTimers();
-  });
-
   test("does not send messages when no records found", async () => {
     dynamoMock.on(QueryCommand).resolves({ Items: [] });
 

--- a/src/tests/query-and-dispatch-inactive-accounts.test.ts
+++ b/src/tests/query-and-dispatch-inactive-accounts.test.ts
@@ -25,14 +25,12 @@ const mockRecord = {
 describe("validateEvent", () => {
   test("throws when daysToDeletion is not an integer", () => {
     expect(() => validateEvent({ daysToDeletion: 1.5, processName: "sendNotification" })).toThrow(
-      "daysToDeletion must be a non-negative integer"
+      "daysToDeletion must be an integer"
     );
   });
 
-  test("throws when daysToDeletion is negative", () => {
-    expect(() => validateEvent({ daysToDeletion: -1, processName: "sendNotification" })).toThrow(
-      "daysToDeletion must be a non-negative integer"
-    );
+  test("does not throw when daysToDeletion is negative", () => {
+    expect(() => validateEvent({ daysToDeletion: -1, processName: "Warning30Day" })).not.toThrow();
   });
 
   test("throws when processName is unknown", () => {
@@ -53,6 +51,7 @@ describe("calculateTargetDate", () => {
 
     expect(calculateTargetDate(3)).toBe("2026-06-20");
     expect(calculateTargetDate(0)).toBe("2026-06-17");
+    expect(calculateTargetDate(-3)).toBe("2026-06-14");
 
     vi.useRealTimers();
   });
@@ -132,10 +131,27 @@ describe("handler", () => {
     expect(sqsMock.commandCalls(SendMessageCommand)).toHaveLength(0);
   });
 
+  test("handles negative daysToDeletion correctly", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-17T12:00:00.000Z"));
+
+    dynamoMock.on(QueryCommand).resolves({ Items: [mockRecord] });
+    sqsMock.on(SendMessageCommand).resolves({});
+
+    await handler({ daysToDeletion: -3, processName: "Warning30Day" }, {} as Context);
+
+    expect(dynamoMock.commandCalls(QueryCommand)[0].args[0].input).toMatchObject({
+      ExpressionAttributeValues: { ":date": "2026-06-14" },
+    });
+    expect(sqsMock.commandCalls(SendMessageCommand)).toHaveLength(1);
+
+    vi.useRealTimers();
+  });
+
   test("throws on invalid input", async () => {
     await expect(
-      handler({ daysToDeletion: -1, processName: "Warning30Day" }, {} as Context)
-    ).rejects.toThrow("daysToDeletion must be a non-negative integer");
+      handler({ daysToDeletion: 1.5, processName: "Warning30Day" }, {} as Context)
+    ).rejects.toThrow("daysToDeletion must be an integer");
   });
 
   test("propagates SQS errors", async () => {

--- a/src/tests/query-and-dispatch-inactive-accounts.test.ts
+++ b/src/tests/query-and-dispatch-inactive-accounts.test.ts
@@ -23,24 +23,20 @@ const mockRecord = {
 };
 
 describe("validateEvent", () => {
-  test("throws when daysToDeletion is not an integer", () => {
-    expect(() => validateEvent({ daysToDeletion: 1.5, processName: "sendNotification" })).toThrow(
-      "daysToDeletion must be an integer"
-    );
-  });
-
-  test("does not throw when daysToDeletion is negative", () => {
-    expect(() => validateEvent({ daysToDeletion: -1, processName: "Warning30Day" })).not.toThrow();
-  });
-
   test("throws when processName is unknown", () => {
-    expect(() => validateEvent({ daysToDeletion: 3, processName: "unknown" })).toThrow(
+    expect(() => validateEvent({ processName: "unknown" })).toThrow(
       "Unknown processName: unknown"
     );
   });
 
+  test("throws when processName is empty", () => {
+    expect(() => validateEvent({ processName: "" })).toThrow(
+      "Unknown processName:"
+    );
+  });
+
   test("does not throw for valid input", () => {
-    expect(() => validateEvent({ daysToDeletion: 3, processName: "Warning30Day" })).not.toThrow();
+    expect(() => validateEvent({ processName: "Warning30Day" })).not.toThrow();
   });
 });
 
@@ -99,22 +95,30 @@ describe("handler", () => {
     vi.clearAllMocks();
   });
 
-  test("queries DynamoDB and dispatches each record to SQS", async () => {
+  test("queries DynamoDB for each daysToDeletion and dispatches records to SQS", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-06-17T12:00:00.000Z"));
 
-    dynamoMock.on(QueryCommand).resolves({ Items: [mockRecord, { ...mockRecord, commonSubjectId: "user-2" }] });
+    dynamoMock.on(QueryCommand).resolves({ Items: [mockRecord] });
     sqsMock.on(SendMessageCommand).resolves({});
 
-    await handler({ daysToDeletion: 3, processName: "Warning30Day" }, {} as Context);
+    await handler({ processName: "Warning30Day" }, {} as Context);
 
-    expect(dynamoMock.commandCalls(QueryCommand)).toHaveLength(1);
+    // processConfig has daysToDeletion: [29, 30, 31], so 3 queries
+    expect(dynamoMock.commandCalls(QueryCommand)).toHaveLength(3);
     expect(dynamoMock.commandCalls(QueryCommand)[0].args[0].input).toMatchObject({
       TableName: "inactive-accounts-table",
       KeyConditionExpression: "dateForDeletion = :date",
-      ExpressionAttributeValues: { ":date": "2026-06-20" },
+      ExpressionAttributeValues: { ":date": "2026-07-16" },
     });
-    expect(sqsMock.commandCalls(SendMessageCommand)).toHaveLength(2);
+    expect(dynamoMock.commandCalls(QueryCommand)[1].args[0].input).toMatchObject({
+      ExpressionAttributeValues: { ":date": "2026-07-17" },
+    });
+    expect(dynamoMock.commandCalls(QueryCommand)[2].args[0].input).toMatchObject({
+      ExpressionAttributeValues: { ":date": "2026-07-18" },
+    });
+    // 1 record per query = 3 SQS messages
+    expect(sqsMock.commandCalls(SendMessageCommand)).toHaveLength(3);
     expect(sqsMock.commandCalls(SendMessageCommand)[0].args[0].input).toMatchObject({
       QueueUrl: "https://sqs.eu-west-2.amazonaws.com/123/queue",
       MessageBody: JSON.stringify(mockRecord),
@@ -126,32 +130,15 @@ describe("handler", () => {
   test("does not send messages when no records found", async () => {
     dynamoMock.on(QueryCommand).resolves({ Items: [] });
 
-    await handler({ daysToDeletion: 3, processName: "Warning30Day" }, {} as Context);
+    await handler({ processName: "Warning30Day" }, {} as Context);
 
     expect(sqsMock.commandCalls(SendMessageCommand)).toHaveLength(0);
   });
 
-  test("handles negative daysToDeletion correctly", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-06-17T12:00:00.000Z"));
-
-    dynamoMock.on(QueryCommand).resolves({ Items: [mockRecord] });
-    sqsMock.on(SendMessageCommand).resolves({});
-
-    await handler({ daysToDeletion: -3, processName: "Warning30Day" }, {} as Context);
-
-    expect(dynamoMock.commandCalls(QueryCommand)[0].args[0].input).toMatchObject({
-      ExpressionAttributeValues: { ":date": "2026-06-14" },
-    });
-    expect(sqsMock.commandCalls(SendMessageCommand)).toHaveLength(1);
-
-    vi.useRealTimers();
-  });
-
-  test("throws on invalid input", async () => {
+  test("throws on invalid processName", async () => {
     await expect(
-      handler({ daysToDeletion: 1.5, processName: "Warning30Day" }, {} as Context)
-    ).rejects.toThrow("daysToDeletion must be an integer");
+      handler({ processName: "unknown" }, {} as Context)
+    ).rejects.toThrow("Unknown processName: unknown");
   });
 
   test("propagates SQS errors", async () => {
@@ -159,7 +146,7 @@ describe("handler", () => {
     sqsMock.on(SendMessageCommand).rejects(new Error("SQS failure"));
 
     await expect(
-      handler({ daysToDeletion: 3, processName: "Warning30Day" }, {} as Context)
+      handler({ processName: "Warning30Day" }, {} as Context)
     ).rejects.toThrow("SQS failure");
   });
 });

--- a/src/tests/query-and-dispatch-inactive-accounts.test.ts
+++ b/src/tests/query-and-dispatch-inactive-accounts.test.ts
@@ -1,0 +1,149 @@
+import { vi, describe, test, expect, beforeEach, afterEach } from "vitest";
+import { DynamoDBDocumentClient, QueryCommand } from "@aws-sdk/lib-dynamodb";
+import { SQSClient, SendMessageCommand } from "@aws-sdk/client-sqs";
+import { mockClient } from "aws-sdk-client-mock";
+import {
+  handler,
+  validateEvent,
+  calculateTargetDate,
+  queryAccountsByDate,
+} from "../query-and-dispatch-inactive-accounts.js";
+import type { Context } from "aws-lambda";
+
+const dynamoMock = mockClient(DynamoDBDocumentClient);
+const sqsMock = mockClient(SQSClient);
+
+const mockRecord = {
+  dateForDeletion: "2026-06-20",
+  commonSubjectId: "user-1",
+  emailAddress: "test@example.com",
+  userLastActive: "2021-06-20T00:00:00.000Z",
+  status: "pending",
+  statusLastUpdated: "2026-01-01T00:00:00.000Z",
+};
+
+describe("validateEvent", () => {
+  test("throws when daysToDeletion is not an integer", () => {
+    expect(() => validateEvent({ daysToDeletion: 1.5, processName: "sendNotification" })).toThrow(
+      "daysToDeletion must be a non-negative integer"
+    );
+  });
+
+  test("throws when daysToDeletion is negative", () => {
+    expect(() => validateEvent({ daysToDeletion: -1, processName: "sendNotification" })).toThrow(
+      "daysToDeletion must be a non-negative integer"
+    );
+  });
+
+  test("throws when processName is unknown", () => {
+    expect(() => validateEvent({ daysToDeletion: 3, processName: "unknown" })).toThrow(
+      "Unknown processName: unknown"
+    );
+  });
+
+  test("does not throw for valid input", () => {
+    expect(() => validateEvent({ daysToDeletion: 3, processName: "sendNotification" })).not.toThrow();
+  });
+});
+
+describe("calculateTargetDate", () => {
+  test("returns date in YYYY-MM-DD format offset by daysToDeletion", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-17T12:00:00.000Z"));
+
+    expect(calculateTargetDate(3)).toBe("2026-06-20");
+    expect(calculateTargetDate(0)).toBe("2026-06-17");
+
+    vi.useRealTimers();
+  });
+});
+
+describe("queryAccountsByDate", () => {
+  beforeEach(() => {
+    dynamoMock.reset();
+  });
+
+  test("paginates through all results", async () => {
+    dynamoMock
+      .on(QueryCommand)
+      .resolvesOnce({
+        Items: [mockRecord],
+        LastEvaluatedKey: { dateForDeletion: "2026-06-20", commonSubjectId: "user-1" },
+      })
+      .resolvesOnce({
+        Items: [{ ...mockRecord, commonSubjectId: "user-2" }],
+        LastEvaluatedKey: undefined,
+      });
+
+    const results = await queryAccountsByDate("table", "2026-06-20");
+    expect(results).toHaveLength(2);
+    expect(dynamoMock.commandCalls(QueryCommand)).toHaveLength(2);
+  });
+
+  test("returns empty array when no results", async () => {
+    dynamoMock.on(QueryCommand).resolves({ Items: [] });
+
+    const results = await queryAccountsByDate("table", "2026-06-20");
+    expect(results).toHaveLength(0);
+  });
+});
+
+describe("handler", () => {
+  beforeEach(() => {
+    dynamoMock.reset();
+    sqsMock.reset();
+    process.env.TABLE_NAME = "inactive-accounts-table";
+    process.env.SEND_NOTIFICATION_QUEUE_URL = "https://sqs.eu-west-2.amazonaws.com/123/queue";
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("queries DynamoDB and dispatches each record to SQS", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-17T12:00:00.000Z"));
+
+    dynamoMock.on(QueryCommand).resolves({ Items: [mockRecord, { ...mockRecord, commonSubjectId: "user-2" }] });
+    sqsMock.on(SendMessageCommand).resolves({});
+
+    await handler({ daysToDeletion: 3, processName: "sendNotification" }, {} as Context);
+
+    expect(dynamoMock.commandCalls(QueryCommand)).toHaveLength(1);
+    expect(dynamoMock.commandCalls(QueryCommand)[0].args[0].input).toMatchObject({
+      TableName: "inactive-accounts-table",
+      KeyConditionExpression: "dateForDeletion = :date",
+      ExpressionAttributeValues: { ":date": "2026-06-20" },
+    });
+    expect(sqsMock.commandCalls(SendMessageCommand)).toHaveLength(2);
+    expect(sqsMock.commandCalls(SendMessageCommand)[0].args[0].input).toMatchObject({
+      QueueUrl: "https://sqs.eu-west-2.amazonaws.com/123/queue",
+      MessageBody: JSON.stringify(mockRecord),
+    });
+
+    vi.useRealTimers();
+  });
+
+  test("does not send messages when no records found", async () => {
+    dynamoMock.on(QueryCommand).resolves({ Items: [] });
+
+    await handler({ daysToDeletion: 3, processName: "sendNotification" }, {} as Context);
+
+    expect(sqsMock.commandCalls(SendMessageCommand)).toHaveLength(0);
+  });
+
+  test("throws on invalid input", async () => {
+    await expect(
+      handler({ daysToDeletion: -1, processName: "sendNotification" }, {} as Context)
+    ).rejects.toThrow("daysToDeletion must be a non-negative integer");
+  });
+
+  test("propagates SQS errors", async () => {
+    dynamoMock.on(QueryCommand).resolves({ Items: [mockRecord] });
+    sqsMock.on(SendMessageCommand).rejects(new Error("SQS failure"));
+
+    await expect(
+      handler({ daysToDeletion: 3, processName: "sendNotification" }, {} as Context)
+    ).rejects.toThrow("SQS failure");
+  });
+});

--- a/src/tests/query-and-dispatch-inactive-accounts.test.ts
+++ b/src/tests/query-and-dispatch-inactive-accounts.test.ts
@@ -42,7 +42,7 @@ describe("validateEvent", () => {
   });
 
   test("does not throw for valid input", () => {
-    expect(() => validateEvent({ daysToDeletion: 3, processName: "sendNotification" })).not.toThrow();
+    expect(() => validateEvent({ daysToDeletion: 3, processName: "Warning30Day" })).not.toThrow();
   });
 });
 
@@ -93,7 +93,7 @@ describe("handler", () => {
     dynamoMock.reset();
     sqsMock.reset();
     process.env.TABLE_NAME = "inactive-accounts-table";
-    process.env.SEND_NOTIFICATION_QUEUE_URL = "https://sqs.eu-west-2.amazonaws.com/123/queue";
+    process.env.WARNING_30_DAY_NOTIFICATION_QUEUE_URL = "https://sqs.eu-west-2.amazonaws.com/123/queue";
   });
 
   afterEach(() => {
@@ -107,7 +107,7 @@ describe("handler", () => {
     dynamoMock.on(QueryCommand).resolves({ Items: [mockRecord, { ...mockRecord, commonSubjectId: "user-2" }] });
     sqsMock.on(SendMessageCommand).resolves({});
 
-    await handler({ daysToDeletion: 3, processName: "sendNotification" }, {} as Context);
+    await handler({ daysToDeletion: 3, processName: "Warning30Day" }, {} as Context);
 
     expect(dynamoMock.commandCalls(QueryCommand)).toHaveLength(1);
     expect(dynamoMock.commandCalls(QueryCommand)[0].args[0].input).toMatchObject({
@@ -127,14 +127,14 @@ describe("handler", () => {
   test("does not send messages when no records found", async () => {
     dynamoMock.on(QueryCommand).resolves({ Items: [] });
 
-    await handler({ daysToDeletion: 3, processName: "sendNotification" }, {} as Context);
+    await handler({ daysToDeletion: 3, processName: "Warning30Day" }, {} as Context);
 
     expect(sqsMock.commandCalls(SendMessageCommand)).toHaveLength(0);
   });
 
   test("throws on invalid input", async () => {
     await expect(
-      handler({ daysToDeletion: -1, processName: "sendNotification" }, {} as Context)
+      handler({ daysToDeletion: -1, processName: "Warning30Day" }, {} as Context)
     ).rejects.toThrow("daysToDeletion must be a non-negative integer");
   });
 
@@ -143,7 +143,7 @@ describe("handler", () => {
     sqsMock.on(SendMessageCommand).rejects(new Error("SQS failure"));
 
     await expect(
-      handler({ daysToDeletion: 3, processName: "sendNotification" }, {} as Context)
+      handler({ daysToDeletion: 3, processName: "Warning30Day" }, {} as Context)
     ).rejects.toThrow("SQS failure");
   });
 });

--- a/template.yaml
+++ b/template.yaml
@@ -3168,6 +3168,13 @@ Resources:
     DeletionPolicy: Delete
     UpdateReplacePolicy: Delete
 
+  30DayNotificationQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      KmsMasterKeyId: !GetAtt QueueKmsKey.Arn
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+
   AccountSavedNotificationQueueOldestMessageAgeAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
@@ -5978,7 +5985,7 @@ Resources:
       Environment:
         Variables:
           TABLE_NAME: !Ref InactveAccountTrackerStoreTableName
-          SEND_NOTIFICATION_QUEUE_URL: !Ref AccountSavedNotificationQueue
+          WARNING_30_DAY_NOTIFICATION_QUEUE_URL: !Ref 30DayNotificationQueue
           NODE_OPTIONS: --enable-source-maps
       DeploymentPreference:
         Alarms:
@@ -6033,6 +6040,7 @@ Resources:
             Resource:
               - !GetAtt QueryAndDispatchInactiveAccountsDeadLetterQueue.Arn
               - !GetAtt AccountSavedNotificationQueue.Arn
+              - !GetAtt 30DayNotificationQueue.Arn
           - Effect: Allow
             Action:
               - dynamodb:Query

--- a/template.yaml
+++ b/template.yaml
@@ -3175,6 +3175,20 @@ Resources:
     DeletionPolicy: Delete
     UpdateReplacePolicy: Delete
 
+  7DayNotificationQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      KmsMasterKeyId: !GetAtt QueueKmsKey.Arn
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+
+  AccountDeletionQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      KmsMasterKeyId: !GetAtt QueueKmsKey.Arn
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+
   AccountSavedNotificationQueueOldestMessageAgeAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
@@ -5986,6 +6000,8 @@ Resources:
         Variables:
           TABLE_NAME: !Ref InactveAccountTrackerStoreTableName
           WARNING_30_DAY_NOTIFICATION_QUEUE_URL: !Ref 30DayNotificationQueue
+          WARNING_7_DAY_NOTIFICATION_QUEUE_URL: !Ref 7DayNotificationQueue
+          ACCOUNT_DELETION_QUEUE_URL: !Ref AccountDeletionQueue
           NODE_OPTIONS: --enable-source-maps
       DeploymentPreference:
         Alarms:
@@ -6041,6 +6057,8 @@ Resources:
               - !GetAtt QueryAndDispatchInactiveAccountsDeadLetterQueue.Arn
               - !GetAtt AccountSavedNotificationQueue.Arn
               - !GetAtt 30DayNotificationQueue.Arn
+              - !GetAtt 7DayNotificationQueue.Arn
+              - !GetAtt AccountDeletionQueue.Arn
           - Effect: Allow
             Action:
               - dynamodb:Query

--- a/template.yaml
+++ b/template.yaml
@@ -5950,6 +5950,225 @@ Resources:
       RetentionInDays: 30
       KmsKeyId: !GetAtt LoggingKmsKey.Arn
 
+  ################################################
+  # Query and Dispatch Inactive Accounts
+  ################################################
+
+  QueryAndDispatchInactiveAccountsFunction:
+    Type: AWS::Serverless::Function
+    DependsOn:
+      - QueryAndDispatchInactiveAccountsFunctionLogGroup
+    Properties:
+      FunctionName: !Sub ${Environment}-${AWS::StackName}-query-and-dispatch-inactive-accounts
+      CodeUri: src
+      PackageType: Zip
+      Timeout: 60
+      Events:
+        ScheduleEvent:
+          Type: Schedule
+          Properties:
+            Schedule: "rate(1 day)"
+            Input: '{"daysToDeletion": 30, "processName": "sendNotification"}'
+            Enabled: !If [IsNotDevelopmentOrDemo, true, false]
+      DeadLetterQueue:
+        Type: SQS
+        TargetArn: !GetAtt QueryAndDispatchInactiveAccountsDeadLetterQueue.Arn
+      Handler: query-and-dispatch-inactive-accounts.handler
+      Role: !GetAtt QueryAndDispatchInactiveAccountsRole.Arn
+      Environment:
+        Variables:
+          TABLE_NAME: !Ref InactveAccountTrackerStoreTableName
+          SEND_NOTIFICATION_QUEUE_URL: !Ref AccountSavedNotificationQueue
+          NODE_OPTIONS: --enable-source-maps
+      DeploymentPreference:
+        Alarms:
+          Fn::If:
+            - IsNotDevelopmentOrDemo
+            - - !Ref QueryAndDispatchInactiveAccountsFunctionSuccessRate
+            - - !Ref AWS::NoValue
+    Metadata:
+      BuildMethod: esbuild
+      BuildProperties:
+        Minify: true
+        Format: "esm"
+        OutExtension:
+          - .js=.mjs
+        Target: "es2022"
+        Sourcemap: true
+        EntryPoints:
+          - query-and-dispatch-inactive-accounts.ts
+        Banner:
+          - js=import { createRequire } from 'module'; const require = createRequire(import.meta.url);
+
+  QueryAndDispatchInactiveAccountsRole:
+    Type: AWS::IAM::Role
+    Properties:
+      PermissionsBoundary: !If
+        - UsePermissionsBoundary
+        - !Ref PermissionsBoundary
+        - !Ref AWS::NoValue
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
+        - !Ref QueryAndDispatchInactiveAccountsPolicy
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - "sts:AssumeRole"
+
+  QueryAndDispatchInactiveAccountsPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - sqs:SendMessage
+            Resource:
+              - !GetAtt QueryAndDispatchInactiveAccountsDeadLetterQueue.Arn
+              - !GetAtt AccountSavedNotificationQueue.Arn
+          - Effect: Allow
+            Action:
+              - dynamodb:Query
+            Resource:
+              - !GetAtt InactiveAccountTrackerStore.Arn
+          - Effect: Allow
+            Action:
+              - kms:Decrypt
+            Resource:
+              - !GetAtt DatabaseKmsKey.Arn
+          - Effect: Allow
+            Action:
+              - kms:GenerateDataKey*
+            Resource:
+              - !GetAtt QueueKmsKey.Arn
+
+  QueryAndDispatchInactiveAccountsFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/${Environment}-${AWS::StackName}-query-and-dispatch-inactive-accounts"
+      RetentionInDays: 30
+      KmsKeyId: !GetAtt LoggingKmsKey.Arn
+
+  QueryAndDispatchInactiveAccountsCSLSSubscription:
+    Condition: ExportLogsToSplunk
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn: !Sub "{{resolve:ssm:/${Environment}/Platform/Logs/Subscription/CSLS/ARN}}"
+      FilterPattern: ""
+      LogGroupName: !Ref QueryAndDispatchInactiveAccountsFunctionLogGroup
+
+  QueryAndDispatchInactiveAccountsDeadLetterQueue:
+    Type: AWS::SQS::Queue
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Properties:
+      MessageRetentionPeriod: 1209600
+      KmsMasterKeyId: !GetAtt QueueKmsKey.Arn
+
+  QueryAndDispatchInactiveAccountsDeadLetterQueueAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName:
+        !Join [
+          "-",
+          [
+            !Ref AWS::StackName,
+            !Ref Environment,
+            QueryAndDispatchInactiveAccountsDeadLetterQueueAlarm,
+          ],
+        ]
+      AlarmDescription: More than 1 query and dispatch of inactive accounts failed in the last 5 minutes.
+      Namespace: "AWS/SQS"
+      MetricName: "ApproximateNumberOfMessagesVisible"
+      Dimensions:
+        - Name: "QueueName"
+          Value: !GetAtt QueryAndDispatchInactiveAccountsDeadLetterQueue.QueueName
+      Statistic: "Sum"
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: "GreaterThanOrEqualToThreshold"
+      AlarmActions:
+        - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/LowAlertNotificationTopic/ARN}}"
+      ActionsEnabled: true
+
+  QueryAndDispatchInactiveAccountsDeadLetterQueueOldestMessageAgeAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName:
+        !Join [
+          "-",
+          [
+            !Ref AWS::StackName,
+            !Ref Environment,
+            QueryAndDispatchInactiveAccountsDeadLetterQueueOldestMessageAgeAlarm,
+          ],
+        ]
+      MetricName: ApproximateAgeOfOldestMessage
+      Namespace: AWS/SQS
+      Statistic: Maximum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 300
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Dimensions:
+        - Name: QueueName
+          Value: !GetAtt QueryAndDispatchInactiveAccountsDeadLetterQueue.QueueName
+      AlarmActions:
+        - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/LowAlertNotificationTopic/ARN}}"
+
+  QueryAndDispatchInactiveAccountsFunctionSuccessRate:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName:
+        !Join [
+          "-",
+          [
+            !Ref AWS::StackName,
+            !Ref Environment,
+            QueryAndDispatchInactiveAccountsFunctionSuccessRate,
+          ],
+        ]
+      Metrics:
+        - Id: errors
+          MetricStat:
+            Metric:
+              Namespace: AWS/Lambda
+              MetricName: Errors
+              Dimensions:
+                - Name: FunctionName
+                  Value: !Ref QueryAndDispatchInactiveAccountsFunction
+            Period: 300
+            Stat: Sum
+          ReturnData: false
+        - Id: invocations
+          MetricStat:
+            Metric:
+              Namespace: AWS/Lambda
+              MetricName: Invocations
+              Dimensions:
+                - Name: FunctionName
+                  Value: !Ref QueryAndDispatchInactiveAccountsFunction
+            Period: 300
+            Stat: Sum
+          ReturnData: false
+        - Id: successRate
+          Expression: "1 - (errors / invocations)"
+          Label: "Success Rate"
+          ReturnData: true
+      Threshold: 0.95
+      ComparisonOperator: LessThanThreshold
+      EvaluationPeriods: 1
+      AlarmActions:
+        - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/LowAlertNotificationTopic/ARN}}"
+
 Outputs:
   GeneratorKey:
     Description: A generator key for generating a plaintext data key


### PR DESCRIPTION
Introduces a new scheduled Lambda — QueryAndDispatchInactiveAccounts — that queries a DynamoDB table for inactive accounts due for deletion and dispatches them to SQS queues for downstream processing (notifications/deletion).