### PR TITLE
BAU: log structured error details on fetch failure

### DIFF
--- a/src/delete-email-subscriptions-utils.ts
+++ b/src/delete-email-subscriptions-utils.ts
@@ -50,7 +50,19 @@ export const deleteEmailSubscription = async (userData: UserData) => {
   const deleteUrl = getDeleteUrl(GOV_ACCOUNTS_PUBLISHING_API_URL, userData);
   const config = getRequestConfig(GOV_ACCOUNTS_PUBLISHING_API_TOKEN);
 
-  const response = await fetch(deleteUrl, config);
+  let response: Response;
+  try {
+    response = await fetch(deleteUrl, config);
+  } catch (err) {
+    const error = err as Error;
+    logger.error("Failed to fetch GOV.UK API", {
+      errorName: error.name,
+      errorMessage: error.message,
+      errorCauseCode: (error.cause as { code?: string })?.code ?? "",
+    });
+    throw error;
+  }
+
   if (response.status === 404) {
     // We are logging a 404 as is an appropriate reponse when the user does not have an email subscription .
     logger.info(`Received a 404 response from GOV.UK API for URL`);

--- a/src/tests/delete-email-subscriptions.test.ts
+++ b/src/tests/delete-email-subscriptions.test.ts
@@ -178,6 +178,26 @@ describe("deleteEmailSubscription", () => {
     );
   });
 
+  test("logs structured error details when fetch fails", async () => {
+    const cause = new Error("connect ETIMEDOUT") as Error & { code?: string };
+    cause.code = "ETIMEDOUT";
+    const fetchError = new TypeError("fetch failed");
+    fetchError.cause = cause;
+    mockFetch.mockRejectedValue(fetchError);
+
+    await expect(deleteEmailSubscription(TEST_USER_DATA)).rejects.toThrow(
+      "fetch failed"
+    );
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      "Failed to fetch GOV.UK API",
+      {
+        errorName: "TypeError",
+        errorMessage: "fetch failed",
+        errorCauseCode: "ETIMEDOUT",
+      }
+    );
+  });
+
   test("constructs URL without legacy_subject_id when not present", async () => {
     const userData = { ...TEST_USER_DATA, legacy_subject_id: undefined };
     mockFetch.mockResolvedValue({ ok: true, status: 200 });


### PR DESCRIPTION
## Proposed changes

### What changed

- Added a try/catch around the `fetch` call in `deleteEmailSubscription` that logs structured error details (errorName, errorMessage, errorCause, errorCauseCode) when the network request fails

### Why did it change

We've observed transient "fetch failed" errors from this lambda with no detail on the underlying cause. The existing catch block in the handler only surfaces the generic "fetch failed" message. This gives us observability of the root cause (DNS failure vs timeout vs connection refused) before deciding what improvements to make.

### Related links

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Permissions

- [ ] This PR adds or changes permissions

### Monitoring

- [ ] This PR includes changes that need to be monitored in production as the scope of the change could cause issues