### PR TITLE
BAU: Bump rp registry to most recent version including NPQ

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3950,8 +3950,7 @@
     },
     "node_modules/di-account-management-rp-registry": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/govuk-one-login/di-account-management-rp-registry.git#ccbfbaeda8322c427d585b6f38c5f1e5df80bd9d",
-      "integrity": "sha512-lF5m0TrhxT6UhE1yMYZgf3EZtvqJGHehHdF9WtK6AAy9Tr/Du2vHo75K31SLTntN6sI9w2IKZ6aLqmRKup9SdA==",
+      "resolved": "git+ssh://git@github.com/govuk-one-login/di-account-management-rp-registry.git#f0fbf2cb7a33c90d7d08ce531ccf0da8febd5612",
       "license": "ISC"
     },
     "node_modules/diff": {


### PR DESCRIPTION
Bump rp registry to most recent version including the details for the new "Register for a national professional qualification" service which went live yesterday