### PR TITLE
BAU: add dependabot dependency grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -85,6 +85,11 @@ updates:
       - dependencies
     commit-message:
       prefix: BAU
+    groups:
+      pre-commit-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: pip
     directories:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -106,3 +106,8 @@ updates:
     labels:
       - dependabot
       - dependencies
+    groups:
+      pip-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
Add minor/patch grouping to dependabot ecosystems that were previously ungrouped, reducing the number of individual PRs created per cycle.

Groups added:
- pip: `pip-minor-patch`
- pre-commit: `pre-commit-minor-patch`

Major version bumps are excluded from all groups and will continue to get individual PRs as they are more likely to contain breaking changes.