### PR TITLE
BAU: Bump format alarm thresolds

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -1660,7 +1660,7 @@ Resources:
       Statistic: Sum
       Period: 300
       EvaluationPeriods: 1
-      Threshold: 20
+      Threshold: 40
       ComparisonOperator: GreaterThanOrEqualToThreshold
       TreatMissingData: notBreaching
       ActionsEnabled: true
@@ -3122,7 +3122,7 @@ Resources:
       Statistic: Sum
       Period: 300
       EvaluationPeriods: 1
-      Threshold: 20
+      Threshold: 40
       ComparisonOperator: GreaterThanOrEqualToThreshold
       TreatMissingData: notBreaching
       ActionsEnabled: true


### PR DESCRIPTION
### What changed

Changed alarm thresholds from 20 to 40.

### Why did it change

Our `FormatActivityLogConsoleWarningsAlarm` and `FormatUserServicesConsoleWarningsAlarm` are firing alarms for "expected" activity.

We have some RPs that start in prod before we are able to onboard them into our Home team RP registry for a variety of reasons.

This further de-noises our notifications channel but also keeps the alarm in place should we have an incident with higher than expected warnings.