### PR TITLE
OLH-4412: Include user email in inactive account tracker record

### DIFF
--- a/src/tests/format-activity-log.test.ts
+++ b/src/tests/format-activity-log.test.ts
@@ -8,7 +8,7 @@ import {
 } from "../format-activity-log.js";
 import {
   ERROR_DYNAMODB_STREAM_EVENT,
-  generateDynamoSteamRecord,
+  generateDynamoStreamRecord,
   messageId,
   MUCKY_DYNAMODB_STREAM_EVENT,
   MUTABLE_ACTIVITY_LOG_ENTRY,
@@ -78,7 +78,7 @@ describe("handler", () => {
     const client_id = "EMGmY82k-92QSakDl_9keKDFmZY"; //home non prod ID
 
     const TEST_HMRC_EVENT: DynamoDBStreamEvent = {
-      Records: [generateDynamoSteamRecord(client_id)],
+      Records: [generateDynamoStreamRecord(client_id)],
     };
     Logger.prototype.warn = vi.fn();
     await handler(TEST_HMRC_EVENT, {} as Context);
@@ -89,7 +89,7 @@ describe("handler", () => {
     const client_id = "UNKNOWN";
 
     const TEST_HMRC_EVENT: DynamoDBStreamEvent = {
-      Records: [generateDynamoSteamRecord(client_id)],
+      Records: [generateDynamoStreamRecord(client_id)],
     };
     Logger.prototype.warn = vi.fn();
     await handler(TEST_HMRC_EVENT, {} as Context);
@@ -105,7 +105,7 @@ describe("handler", () => {
     const client_id = "EMGmY82k-92QSakDl_9keKDFmZY"; //home non prod ID
 
     const TEST_EVENT: DynamoDBStreamEvent = {
-      Records: [generateDynamoSteamRecord(client_id)],
+      Records: [generateDynamoStreamRecord(client_id)],
     };
     await handler(TEST_EVENT, {} as Context);
     expect(mockMetrics.addMetric).not.toHaveBeenCalled();
@@ -141,8 +141,8 @@ describe("handler", () => {
 
       const TEST_HMRC_EVENT: DynamoDBStreamEvent = {
         Records: [
-          generateDynamoSteamRecord(hmrc_client_id),
-          generateDynamoSteamRecord(hmrc_client_id),
+          generateDynamoStreamRecord(hmrc_client_id),
+          generateDynamoStreamRecord(hmrc_client_id),
         ],
       };
       Logger.prototype.info = vi.fn();

--- a/src/tests/query-user-services.test.ts
+++ b/src/tests/query-user-services.test.ts
@@ -41,7 +41,7 @@ const generateTestTxmaEvent = (
   user,
 });
 
-const generateDynamoSteamRecord = (
+const generateDynamoStreamRecord = (
   txmaEventName = "AUTH_AUTH_CODE_ISSUED"
 ): DynamoDBRecord => ({
   eventID: "1234567",
@@ -82,14 +82,14 @@ const generateDynamoSteamRecord = (
 });
 
 export const TEST_DYNAMO_STREAM_EVENT: DynamoDBStreamEvent = {
-  Records: [generateDynamoSteamRecord(), generateDynamoSteamRecord()],
+  Records: [generateDynamoStreamRecord(), generateDynamoStreamRecord()],
 };
 
 export const MUCKY_DYNAMODB_STREAM_EVENT: DynamoDBStreamEvent = {
   Records: [
-    generateDynamoSteamRecord("AUTH_IPV_AUTHORISATION_REQUESTED"),
-    generateDynamoSteamRecord(),
-    generateDynamoSteamRecord("AUTH_OTHER_RANDOM_EVENT"),
+    generateDynamoStreamRecord("AUTH_IPV_AUTHORISATION_REQUESTED"),
+    generateDynamoStreamRecord(),
+    generateDynamoStreamRecord("AUTH_OTHER_RANDOM_EVENT"),
   ],
 };
 

--- a/src/tests/testFixtures.ts
+++ b/src/tests/testFixtures.ts
@@ -184,7 +184,7 @@ export const MUTABLE_ACTIVITY_LOG_ENTRY: ActivityLogEntry = {
 };
 
 // TODO: This would be better placed in testUtils but fails to be imported as a function when moved there.
-export const generateDynamoSteamRecord = (
+export const generateDynamoStreamRecord = (
   customClientId?: string,
   txmaEventName = "AUTH_AUTH_CODE_ISSUED"
 ): DynamoDBRecord => ({
@@ -206,6 +206,7 @@ export const generateDynamoSteamRecord = (
             M: {
               user_id: { S: userId },
               session_id: { S: sessionId },
+              email: { S: "foo@bar.com" } 
             },
           },
           client_id: { S: customClientId ?? clientId },
@@ -218,11 +219,11 @@ export const generateDynamoSteamRecord = (
 });
 
 export const TEST_DYNAMO_STREAM_EVENT: DynamoDBStreamEvent = {
-  Records: [generateDynamoSteamRecord(), generateDynamoSteamRecord()],
+  Records: [generateDynamoStreamRecord(), generateDynamoStreamRecord()],
 };
 
 export const MUCKY_DYNAMODB_STREAM_EVENT: DynamoDBStreamEvent = {
-  Records: [generateDynamoSteamRecord(undefined, randomEventType)],
+  Records: [generateDynamoStreamRecord(undefined, randomEventType)],
 };
 
 export const ERROR_DYNAMODB_STREAM_EVENT: DynamoDBStreamEvent = {

--- a/src/tests/update-inactive-account-tracker.test.ts
+++ b/src/tests/update-inactive-account-tracker.test.ts
@@ -183,7 +183,47 @@ describe("UpdateInactiveAccountTracker handler", () => {
     );
   });
 
-  test("throws an error when email is missing from the event", async () => {
+  test("includes email and does not log warning when email exists on the event", async () => {
+    dynamoMock.on(QueryCommand).resolves({
+      Items: [{ commonSubjectId: "qwerty", dateForDeletion: "1978-11-29", userLastActive: "1970-01-01T00:00:00.000Z", status: "pending", statusLastUpdated: "" }],
+    });
+    const recordWithEmail = {
+      dynamodb: {
+        NewImage: {
+          event: {
+            M: {
+              client_id: { S: "test-client" },
+              user: {
+                M: {
+                  user_id: { S: "qwerty" },
+                  email: { S: "email@exists.uk" }
+                }
+              }
+            }
+          }
+        }
+      }
+    };
+
+    const event: DynamoDBStreamEvent = { Records: [recordWithEmail as DynamoDBRecord] };
+    await handler(event, {} as Context);
+    expect(dynamoMock).toHaveReceivedCommandWith(TransactWriteCommand, {
+      TransactItems: expect.arrayContaining([
+        expect.objectContaining({
+          Put: expect.objectContaining({
+            TableName: "test-table",
+            Item: expect.objectContaining({ emailAddress: "email@exists.uk" }),
+          }),
+        }),
+      ]),
+    });
+    expect(loggerWarnMock).not.toHaveBeenCalled();
+  });
+
+  test("logs warning when email is missing from the event and from pre-existing record", async () => {
+    dynamoMock.on(QueryCommand).resolves({
+      Items: [{ commonSubjectId: "qwerty", dateForDeletion: "1978-11-29", userLastActive: "1970-01-01T00:00:00.000Z", status: "pending", statusLastUpdated: "" }],
+    });
     const invalidRecord = {
       dynamodb: {
         NewImage: {
@@ -200,12 +240,53 @@ describe("UpdateInactiveAccountTracker handler", () => {
         }
       }
     };
-
     const event: DynamoDBStreamEvent = { Records: [invalidRecord as DynamoDBRecord] };
-
-    await expect(handler(event, {} as Context)).rejects.toThrow(
-      "email is undefined in the event"
-    );
+    await handler(event, {} as Context);
+    expect(dynamoMock).toHaveReceivedCommandWith(TransactWriteCommand, {
+      TransactItems: expect.arrayContaining([
+        expect.objectContaining({
+          Put: expect.objectContaining({
+            TableName: "test-table",
+            Item: expect.objectContaining({ commonSubjectId: "qwerty", emailAddress: "" }),
+          }),
+        }),
+      ]),
+    });
+    expect(loggerWarnMock).toHaveBeenCalledWith("AUTH_EVENT_NO_EMAIL for userId qwerty");
   });
 
+  test("logs warning when email is missing from the event but is present in pre-existing record", async () => {
+    dynamoMock.on(QueryCommand).resolves({
+      Items: [{ commonSubjectId: "qwerty", dateForDeletion: "1978-11-29", userLastActive: "1970-01-01T00:00:00.000Z", emailAddress: "testing-warning@test.co", status: "pending", statusLastUpdated: "" }],
+    });
+    const invalidRecord = {
+      dynamodb: {
+        NewImage: {
+          event: {
+            M: {
+              client_id: { S: "test-client" },
+              user: {
+                M: {
+                  user_id: { S: "qwerty" }
+                }
+              }
+            }
+          }
+        }
+      }
+    };
+    const event: DynamoDBStreamEvent = { Records: [invalidRecord as DynamoDBRecord] };
+    await handler(event, {} as Context);
+    expect(dynamoMock).toHaveReceivedCommandWith(TransactWriteCommand, {
+      TransactItems: expect.arrayContaining([
+        expect.objectContaining({
+          Put: expect.objectContaining({
+            TableName: "test-table",
+            Item: expect.objectContaining({ commonSubjectId: "qwerty", emailAddress: "testing-warning@test.co" }),
+          }),
+        }),
+      ]),
+    });
+    expect(loggerWarnMock).toHaveBeenCalledWith("AUTH_EVENT_NO_EMAIL for userId qwerty");
+  });
 });

--- a/src/tests/update-inactive-account-tracker.test.ts
+++ b/src/tests/update-inactive-account-tracker.test.ts
@@ -1,10 +1,10 @@
 import { vi, describe, test, expect, afterEach, beforeEach } from "vitest";
-import { Context, DynamoDBStreamEvent } from "aws-lambda";
+import { DynamoDBRecord, Context, DynamoDBStreamEvent } from "aws-lambda";
 import { Logger } from "@aws-lambda-powertools/logger";
 import { mockClient } from "aws-sdk-client-mock";
 import { DynamoDBDocumentClient, GetCommand, QueryCommand, TransactWriteCommand } from "@aws-sdk/lib-dynamodb";
 import { handler } from "../update-inactive-account-tracker.js";
-import { generateDynamoSteamRecord } from "./testFixtures.js";
+import { generateDynamoStreamRecord } from "./testFixtures.js";
 
 const dynamoMock = mockClient(DynamoDBDocumentClient);
 
@@ -35,7 +35,7 @@ describe("UpdateInactiveAccountTracker handler", () => {
 
     dynamoMock.on(QueryCommand).resolves({ Items: [] });
     dynamoMock.on(TransactWriteCommand).resolves({});
-    const event: DynamoDBStreamEvent = { Records: [generateDynamoSteamRecord("test-client")] };
+    const event: DynamoDBStreamEvent = { Records: [generateDynamoStreamRecord("test-client")] };
     await handler(event, {} as Context);
     expect(dynamoMock).toHaveReceivedCommandWith(QueryCommand, {
       TableName: "test-table",
@@ -48,7 +48,7 @@ describe("UpdateInactiveAccountTracker handler", () => {
   test("writes new tracker record via transaction when no existing record", async () => {
     dynamoMock.on(QueryCommand).resolves({ Items: [] });
     dynamoMock.on(TransactWriteCommand).resolves({});
-    const event: DynamoDBStreamEvent = { Records: [generateDynamoSteamRecord("test-client")] };
+    const event: DynamoDBStreamEvent = { Records: [generateDynamoStreamRecord("test-client")] };
     await handler(event, {} as Context);
     expect(dynamoMock).toHaveReceivedCommandWith(TransactWriteCommand, {
       TransactItems: expect.arrayContaining([
@@ -72,7 +72,7 @@ describe("UpdateInactiveAccountTracker handler", () => {
   test("uses event timestamp as latestDate when no existing record", async () => {
     dynamoMock.on(QueryCommand).resolves({ Items: [] });
     dynamoMock.on(TransactWriteCommand).resolves({});
-    const event: DynamoDBStreamEvent = { Records: [generateDynamoSteamRecord("test-client")] };
+    const event: DynamoDBStreamEvent = { Records: [generateDynamoStreamRecord("test-client")] };
     await handler(event, {} as Context);
     expect(dynamoMock).toHaveReceivedCommandWith(TransactWriteCommand, {
       TransactItems: expect.arrayContaining([
@@ -91,7 +91,7 @@ describe("UpdateInactiveAccountTracker handler", () => {
       Items: [{ commonSubjectId: "qwerty", dateForDeletion: "2099-01-01", userLastActive: futureDate, status: "active", emailAddress: "x", statusLastUpdated: "" }],
     });
     dynamoMock.on(TransactWriteCommand).resolves({});
-    const event: DynamoDBStreamEvent = { Records: [generateDynamoSteamRecord("test-client")] };
+    const event: DynamoDBStreamEvent = { Records: [generateDynamoStreamRecord("test-client")] };
     await handler(event, {} as Context);
     expect(dynamoMock).toHaveReceivedCommandWith(TransactWriteCommand, {
       TransactItems: expect.arrayContaining([
@@ -114,7 +114,7 @@ describe("UpdateInactiveAccountTracker handler", () => {
     dynamoMock.on(QueryCommand).resolves({
       Items: [{ commonSubjectId: "qwerty", dateForDeletion: "2026-01-01", userLastActive: "2026-01-01T00:00:00.000Z", status: "deleting", emailAddress: "x", statusLastUpdated: "" }],
     });
-    const event: DynamoDBStreamEvent = { Records: [generateDynamoSteamRecord("test-client")] };
+    const event: DynamoDBStreamEvent = { Records: [generateDynamoStreamRecord("test-client")] };
     await handler(event, {} as Context);
     expect(loggerWarnMock).toHaveBeenCalledWith("AUTH_EVENT_ON_DELETING_ACCOUNT qwerty");
     expect(dynamoMock).not.toHaveReceivedCommand(TransactWriteCommand);
@@ -127,7 +127,7 @@ describe("UpdateInactiveAccountTracker handler", () => {
         { commonSubjectId: "qwerty", dateForDeletion: "2026-01-02", userLastActive: "2026-01-02T00:00:00.000Z", status: "pending", emailAddress: "x", statusLastUpdated: "" },
       ],
     });
-    const event: DynamoDBStreamEvent = { Records: [generateDynamoSteamRecord("test-client")] };
+    const event: DynamoDBStreamEvent = { Records: [generateDynamoStreamRecord("test-client")] };
     await expect(handler(event, {} as Context)).rejects.toThrow("found more than one inactivity tracker record for qwerty");
   });
 
@@ -137,7 +137,7 @@ describe("UpdateInactiveAccountTracker handler", () => {
     });
     dynamoMock.on(GetCommand).resolves({ Item: undefined });
     dynamoMock.on(TransactWriteCommand).resolves({});
-    const event: DynamoDBStreamEvent = { Records: [generateDynamoSteamRecord("test-client")] };
+    const event: DynamoDBStreamEvent = { Records: [generateDynamoStreamRecord("test-client")] };
     await handler(event, {} as Context);
     expect(dynamoMock).toHaveReceivedCommandWith(TransactWriteCommand, {
       TransactItems: expect.not.arrayContaining([
@@ -153,7 +153,7 @@ describe("UpdateInactiveAccountTracker handler", () => {
       Items: [{ commonSubjectId: "qwerty", dateForDeletion: "2026-01-01", userLastActive: "2020-01-01T00:00:00.000Z", status: "active", emailAddress: "x", statusLastUpdated: "" }],
     });
     dynamoMock.on(TransactWriteCommand).resolves({});
-    const event: DynamoDBStreamEvent = { Records: [generateDynamoSteamRecord("test-client")] };
+    const event: DynamoDBStreamEvent = { Records: [generateDynamoStreamRecord("test-client")] };
     await handler(event, {} as Context);
     expect(dynamoMock).not.toHaveReceivedCommand(GetCommand);
   });
@@ -163,7 +163,7 @@ describe("UpdateInactiveAccountTracker handler", () => {
       Items: [{ commonSubjectId: "qwerty", dateForDeletion: "1978-11-29", userLastActive: "1970-01-01T00:00:00.000Z", status: "pending", emailAddress: "x", statusLastUpdated: "" }],
     });
     dynamoMock.on(TransactWriteCommand).resolves({});
-    const event: DynamoDBStreamEvent = { Records: [generateDynamoSteamRecord("test-client")] };
+    const event: DynamoDBStreamEvent = { Records: [generateDynamoStreamRecord("test-client")] };
     await handler(event, {} as Context);
     expect(dynamoMock).toHaveReceivedCommandWith(TransactWriteCommand, {
       TransactItems: expect.not.arrayContaining([
@@ -177,9 +177,35 @@ describe("UpdateInactiveAccountTracker handler", () => {
   test("throws error when transaction fails", async () => {
     dynamoMock.on(QueryCommand).resolves({ Items: [] });
     dynamoMock.on(TransactWriteCommand).rejects(new Error("TransactionCanceledException"));
-    const event: DynamoDBStreamEvent = { Records: [generateDynamoSteamRecord("test-client")] };
+    const event: DynamoDBStreamEvent = { Records: [generateDynamoStreamRecord("test-client")] };
     await expect(handler(event, {} as Context)).rejects.toThrow(
       "Failed to update inactive account tracker for user qwerty"
     );
   });
+
+  test("throws an error when email is missing from the event", async () => {
+    const invalidRecord = {
+      dynamodb: {
+        NewImage: {
+          event: {
+            M: {
+              client_id: { S: "test-client" },
+              user: {
+                M: {
+                  user_id: { S: "qwerty" }
+                }
+              }
+            }
+          }
+        }
+      }
+    };
+
+    const event: DynamoDBStreamEvent = { Records: [invalidRecord as DynamoDBRecord] };
+
+    await expect(handler(event, {} as Context)).rejects.toThrow(
+      "email is undefined in the event"
+    );
+  });
+
 });

--- a/src/update-inactive-account-tracker.ts
+++ b/src/update-inactive-account-tracker.ts
@@ -59,13 +59,15 @@ export const handler = async (
     const txmaEvent = unmarshall(
       record.dynamodb?.NewImage?.event.M as Record<string, AttributeValue>
     ) as TxmaEvent;
-
+    
     const userId = txmaEvent.user?.user_id;
-    const email = txmaEvent.user?.email;
     assert(userId !== undefined, "user_id is undefined in the event");
-    assert(email !== undefined, "email is undefined in the event");
-
+    if (txmaEvent.user?.email === undefined) {
+      logger.warn(`AUTH_EVENT_NO_EMAIL for userId ${userId}`)
+    }
+    
     const currentTrackerRecord = await getCurrentRecordForUser(userId, tableName);
+    const email = txmaEvent.user?.email ?? currentTrackerRecord?.emailAddress ?? "";
     const latestDate = getLatestDate(txmaEvent, currentTrackerRecord);
 
     if (currentTrackerRecord?.status === 'deleting') {

--- a/src/update-inactive-account-tracker.ts
+++ b/src/update-inactive-account-tracker.ts
@@ -61,7 +61,9 @@ export const handler = async (
     ) as TxmaEvent;
 
     const userId = txmaEvent.user?.user_id;
+    const email = txmaEvent.user?.email;
     assert(userId !== undefined, "user_id is undefined in the event");
+    assert(email !== undefined, "email is undefined in the event");
 
     const currentTrackerRecord = await getCurrentRecordForUser(userId, tableName);
     const latestDate = getLatestDate(txmaEvent, currentTrackerRecord);
@@ -75,7 +77,7 @@ export const handler = async (
       commonSubjectId: userId,
       userLastActive: latestDate.toISOString(),
       dateForDeletion: getDateForDeletion(latestDate),
-      emailAddress: 'unknown',
+      emailAddress: email,
       status: 'pending',
       statusLastUpdated: new Date().toISOString(),
       source: "txma_audit_event",

--- a/template.yaml
+++ b/template.yaml
@@ -3337,6 +3337,17 @@ Resources:
       FilterPattern: ""
       LogGroupName: !Ref UpdateInactiveAccountTrackerFunctionLogGroup
 
+  AuthEventTriggeredOnMissingEmailFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      FilterPattern: "AUTH_EVENT_NO_EMAIL for userId"
+      LogGroupName: !Ref UpdateInactiveAccountTrackerFunctionLogGroup
+      MetricTransformations:
+        - MetricName: AuthEventTriggeredOnMissingEmailCount
+          MetricNamespace: !Ref SystemTagValue
+          MetricValue: 1
+          Unit: Count
+
   AuthEventTriggeredOnAlreadyDeletingAccountFilter:
     Type: AWS::Logs::MetricFilter
     Properties:
@@ -3347,6 +3358,31 @@ Resources:
           MetricNamespace: !Ref SystemTagValue
           MetricValue: 1
           Unit: Count
+
+  AuthEventTriggeredOnMissingEmailAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName:
+        !Join [
+          "-",
+          [
+            !Ref AWS::StackName,
+            !Ref Environment,
+            AuthEventTriggeredOnMissingEmailAlarm,
+          ],
+        ]
+      AlarmDescription: Triggers when an auth event is processed without an email address.
+      MetricName: AuthEventTriggeredOnMissingEmailCount
+      Namespace: !Ref SystemTagValue
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+      ActionsEnabled: true
+      AlarmActions:
+        - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/LowAlertNotificationTopic/ARN}}"
 
   AuthEventTriggeredOnAlreadyDeletingAccountAlarm:
     Type: AWS::CloudWatch::Alarm


### PR DESCRIPTION
## Proposed changes

Update the inactive account tracker lambda to include the user's email with inactive account tracker record.
