### PR TITLE
OLH-4413: Added metadata to inactive account tracker

### DIFF
--- a/src/common/model.ts
+++ b/src/common/model.ts
@@ -219,6 +219,8 @@ export interface InactiveAccountTrackerRecord {
   userLastActive: string;
   status: InactiveAccountStatus;
   statusLastUpdated: string;
+  source: string;
+  sourceId?: string;
 }
 
 export class DroppedEventError extends Error {

--- a/src/query-and-dispatch-inactive-accounts.ts
+++ b/src/query-and-dispatch-inactive-accounts.ts
@@ -17,7 +17,7 @@ export interface QueryAndDispatchEvent {
 
 type ProcessConfig = Record<string, { queueUrlEnvVar: string; daysToDeletion: number[]; allowedStatuses: InactiveAccountStatus[] }>
 
-export const processConfig: ProcessConfig = {
+const processConfig: ProcessConfig = {
   Warning30Day: { queueUrlEnvVar: "WARNING_30_DAY_NOTIFICATION_QUEUE_URL", daysToDeletion: [30], allowedStatuses: ["pending"] },
   Warning7Day: { queueUrlEnvVar: "WARNING_7_DAY_NOTIFICATION_QUEUE_URL", daysToDeletion: [7], allowedStatuses: ["pending", "30DayWarningSent"] },
   DeleteAccount: { queueUrlEnvVar: "ACCOUNT_DELETION_QUEUE_URL", daysToDeletion: [0], allowedStatuses: ["pending", "30DayWarningSent", "7DayWarningSent"] },

--- a/src/tests/update-inactive-account-tracker.test.ts
+++ b/src/tests/update-inactive-account-tracker.test.ts
@@ -55,7 +55,7 @@ describe("UpdateInactiveAccountTracker handler", () => {
         expect.objectContaining({
           Put: expect.objectContaining({
             TableName: "test-table",
-            Item: expect.objectContaining({ commonSubjectId: "qwerty", status: "pending" }),
+            Item: expect.objectContaining({ commonSubjectId: "qwerty", status: "pending", source: "txma_audit_event", sourceId: "event_id" }),
           }),
         }),
       ]),

--- a/src/update-inactive-account-tracker.ts
+++ b/src/update-inactive-account-tracker.ts
@@ -78,6 +78,8 @@ export const handler = async (
       emailAddress: 'unknown',
       status: 'pending',
       statusLastUpdated: new Date().toISOString(),
+      source: "txma_audit_event",
+      sourceId: txmaEvent.event_id,
     }
 
     const transactionItems: TransactionItems = [


### PR DESCRIPTION
## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->

### What changed

Added two new fields to the `InactiveAccountTrackerRecord` interface

> `source: string`
> `sourceId?: string`

And when building the newItem to write to DynamoDB, two new properties are set:

> source: "txma_audit_event" — hardcoded string indicating this record came from a TxMA audit event
> sourceId: txmaEvent.event_id — the event_id from the incoming TxMA event

Also since knip was failing due to export processConfig not being used outside of the file `query-and-dispatch-inactive-accounts.ts` 

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists

<!-- Merging this PR deploys to production. Please answer accurately. -->

### Environment variables or secrets

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Added parameters to Cloudformation template
- [ ] Added new secret or systems manager parameter
- [ ] Added new environment variable

### Permissions

- [ ] This PR adds or changes permissions

### Monitoring

- [ ] This PR includes changes that need to be monitored in production as the scope of the change could cause issues

## Testing

<!-- Provide a summary of any manual testing you've done, for example deploying the branch to dev -->

## How to review

<!-- Describe any non-standard steps to review this work, or highlight any areas that you'd like the reviewer's opinion on -->
