### PR TITLE
OLH-4461: Switch to official zizmor-pre-commit hook, add cfn-lint to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,16 +36,10 @@ repos:
         pass_filenames: false
         stages: [pre-commit]
 
-  - repo: local
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: e3eebf65325ccc992422292cb7a4baee967cf815 # pragma: allowlist secret
     hooks:
-      - id: check-gh-actions
-        name: Check GitHub Actions
-        entry: npm run check-gh-actions
-        language: system
-        exclude: .*
-        always_run: true
-        pass_filenames: false
-        stages: [pre-commit]
+      - id: zizmor
 
   - repo: local
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -76,6 +76,17 @@ repos:
 
   - repo: local
     hooks:
+      - id: cfnlint
+        name: Lint CloudFormation
+        entry: cfn-lint template.yaml -r eu-west-2
+        language: system
+        exclude: .*
+        always_run: true
+        pass_filenames: false
+        stages: [pre-commit]
+
+  - repo: local
+    hooks:
       - id: test
         name: Test
         entry: npm run test


### PR DESCRIPTION
 ## What changed:
  
1. Replaced language: system zizmor hook with official zizmorcore/zizmor-pre-commit managed hook
2. Added cfn-lint as a local pre-commit hook (cfn-lint template.yaml -r eu-west-2)
  
##  Why did it change:
  
1. The official zizmor hook makes pre-commit self-contained - no Brewfile dependency needed for CI. Matches the updated account-components pattern.
2. account-components already has cfn-lint in pre-commit. Adding it here gives developers local feedback and prepares for running pre-commit in CI (next PR), which will replace the standalone lint-cloudformation.yaml workflow.
  
No CI changes in this PR - purely pre-commit config improvements.

This is part of a process to standardise our linting and GitHub actions setup across Home owned repos.