### PR TITLE
OLH-3313: update Dynatrace lambda layer to the latest version

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -203,7 +203,7 @@ Globals:
       - !Ref PermissionsBoundary
       - !Ref AWS::NoValue
     Layers:
-      - arn:aws:lambda:eu-west-2:216552277552:layer:Dynatrace_OneAgent_1_313_2_20250404-043044_with_collector_nodejs:1
+      - arn:aws:lambda:eu-west-2:216552277552:layer:Dynatrace_OneAgent_1_329_73_20260123-140641_with_collector_nodejs_arm:1
     AutoPublishAlias: live
     DeploymentPreference:
       Type: !Ref LambdaDeploymentPreference


### PR DESCRIPTION
Updates the Dynatrace lambda layer to the latest version. This has been successfully deployed to dev.