### PR TITLE
OLH-4461: allowlist zizmor adhoc-packages for global esbuild install

### DIFF
--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -88,7 +88,7 @@ jobs:
           node-version-file: ".nvmrc"
 
       - name: Install ESbuild
-        run: npm install -g esbuild@0.23.1
+        run: npm install -g esbuild@0.23.1 # zizmor: ignore[adhoc-packages]
 
       - name: Set up Python 3.9
         uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435 # pin@v4

--- a/.github/workflows/publish-to-demo.yaml
+++ b/.github/workflows/publish-to-demo.yaml
@@ -64,7 +64,7 @@ jobs:
           node-version-file: ".nvmrc"
 
       - name: Install ESbuild
-        run: npm install -g esbuild@0.23.1
+        run: npm install -g esbuild@0.23.1 # zizmor: ignore[adhoc-packages]
 
       - name: Set up Python 3.9
         uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435 # pin@v4

--- a/.github/workflows/publish-to-dev.yaml
+++ b/.github/workflows/publish-to-dev.yaml
@@ -58,7 +58,7 @@ jobs:
           node-version-file: ".nvmrc"
 
       - name: Install ESbuild
-        run: npm install -g esbuild@0.23.1
+        run: npm install -g esbuild@0.23.1 # zizmor: ignore[adhoc-packages]
 
       - name: Set up Python 3.9
         uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435 # pin@v4

--- a/.github/workflows/sam-app-post-merge-actions.yaml
+++ b/.github/workflows/sam-app-post-merge-actions.yaml
@@ -30,7 +30,7 @@ jobs:
           node-version-file: ".nvmrc"
 
       - name: Install ESbuild
-        run: npm install -g esbuild@0.23.1
+        run: npm install -g esbuild@0.23.1 # zizmor: ignore[adhoc-packages]
 
       - name: Test
         run: npm ci && npm test


### PR DESCRIPTION
## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->

### What changed

Add inline zizmor ignore comments to the 4 workflows that install esbuild globally at a pinned version for SAM builds. Later work could remove the need to install esbuild globally like this.

### Why did it change

This means we can then turn on pre-commit in GHA.

### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists

<!-- Merging this PR deploys to production. Please answer accurately. -->

### Environment variables or secrets

- [ ] No environment variables or secrets were added or changed


### Permissions

- [ ] This PR adds or changes permissions

### Monitoring

- [ ] This PR includes changes that need to be monitored in production as the scope of the change could cause issues
