### PR TITLE
OLH-4462: Update the inactive account tracker

### DIFF
--- a/src/common/model.ts
+++ b/src/common/model.ts
@@ -215,6 +215,7 @@ export type InactiveAccountStatus = "pending" | "deleting" | "30DayWarningSent" 
 export interface InactiveAccountTrackerRecord {
   dateForDeletion: string;
   commonSubjectId: string;
+  publicSubjectId?: string;
   emailAddress: string;
   userLastActive: string;
   status: InactiveAccountStatus;

--- a/src/tests/update-inactive-account-tracker.test.ts
+++ b/src/tests/update-inactive-account-tracker.test.ts
@@ -4,7 +4,7 @@ import { Logger } from "@aws-lambda-powertools/logger";
 import { mockClient } from "aws-sdk-client-mock";
 import { DynamoDBDocumentClient, GetCommand, QueryCommand, TransactWriteCommand } from "@aws-sdk/lib-dynamodb";
 import { handler } from "../update-inactive-account-tracker.js";
-import { generateDynamoStreamRecord } from "./testFixtures.js";
+import { generateDynamoStreamRecord, timestamp } from "./testFixtures.js";
 
 const dynamoMock = mockClient(DynamoDBDocumentClient);
 

--- a/src/tests/update-inactive-account-tracker.test.ts
+++ b/src/tests/update-inactive-account-tracker.test.ts
@@ -255,6 +255,103 @@ describe("UpdateInactiveAccountTracker handler", () => {
     expect(loggerWarnMock).toHaveBeenCalledWith("AUTH_EVENT_NO_EMAIL for userId qwerty");
   });
 
+  test("stores publicSubjectId from event when present", async () => {
+    dynamoMock.on(QueryCommand).resolves({ Items: [] });
+    dynamoMock.on(TransactWriteCommand).resolves({});
+    const recordWithPublicSubjectId = {
+      dynamodb: {
+        NewImage: {
+          event: {
+            M: {
+              event_id: { S: "event_id" },
+              client_id: { S: "test-client" },
+              timestamp: { N: `${timestamp}` },
+              user: {
+                M: {
+                  user_id: { S: "qwerty" },
+                  public_subject_id: { S: "public-subject-123" },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    const event: DynamoDBStreamEvent = { Records: [recordWithPublicSubjectId as DynamoDBRecord] };
+    await handler(event, {} as Context);
+    expect(dynamoMock).toHaveReceivedCommandWith(TransactWriteCommand, {
+      TransactItems: expect.arrayContaining([
+        expect.objectContaining({
+          Put: expect.objectContaining({
+            Item: expect.objectContaining({ publicSubjectId: "public-subject-123" }),
+          }),
+        }),
+      ]),
+    });
+  });
+
+  test("falls back to publicSubjectId from existing tracker record when not on event", async () => {
+    dynamoMock.on(QueryCommand).resolves({
+      Items: [{ commonSubjectId: "qwerty", dateForDeletion: "1978-11-29", userLastActive: "1970-01-01T00:00:00.000Z", emailAddress: "x", publicSubjectId: "public-subject-from-record", status: "pending", statusLastUpdated: "" }],
+    });
+    dynamoMock.on(TransactWriteCommand).resolves({});
+    const recordWithoutPublicSubjectId = {
+      dynamodb: {
+        NewImage: {
+          event: {
+            M: {
+              event_id: { S: "event_id" },
+              client_id: { S: "test-client" },
+              timestamp: { N: `${timestamp}` },
+              user: { M: { user_id: { S: "qwerty" } } },
+            },
+          },
+        },
+      },
+    };
+    const event: DynamoDBStreamEvent = { Records: [recordWithoutPublicSubjectId as DynamoDBRecord] };
+    await handler(event, {} as Context);
+    expect(dynamoMock).toHaveReceivedCommandWith(TransactWriteCommand, {
+      TransactItems: expect.arrayContaining([
+        expect.objectContaining({
+          Put: expect.objectContaining({
+            Item: expect.objectContaining({ publicSubjectId: "public-subject-from-record" }),
+          }),
+        }),
+      ]),
+    });
+  });
+
+  test("omits publicSubjectId from tracker record when absent from both event and existing record", async () => {
+    dynamoMock.on(QueryCommand).resolves({ Items: [] });
+    dynamoMock.on(TransactWriteCommand).resolves({});
+    const recordWithoutPublicSubjectId = {
+      dynamodb: {
+        NewImage: {
+          event: {
+            M: {
+              event_id: { S: "event_id" },
+              client_id: { S: "test-client" },
+              timestamp: { N: `${timestamp}` },
+              user: { M: { user_id: { S: "qwerty" } } },
+            },
+          },
+        },
+      },
+    };
+    const event: DynamoDBStreamEvent = { Records: [recordWithoutPublicSubjectId as DynamoDBRecord] };
+    await handler(event, {} as Context);
+    expect(dynamoMock).toHaveReceivedCommandWith(TransactWriteCommand, {
+      TransactItems: expect.arrayContaining([
+        expect.objectContaining({
+          Put: expect.objectContaining({
+            Item: expect.not.objectContaining({ publicSubjectId: expect.anything() }),
+          }),
+        }),
+      ]),
+    });
+  });
+
   test("logs warning when email is missing from the event but is present in pre-existing record", async () => {
     dynamoMock.on(QueryCommand).resolves({
       Items: [{ commonSubjectId: "qwerty", dateForDeletion: "1978-11-29", userLastActive: "1970-01-01T00:00:00.000Z", emailAddress: "testing-warning@test.co", status: "pending", statusLastUpdated: "" }],

--- a/src/update-inactive-account-tracker.ts
+++ b/src/update-inactive-account-tracker.ts
@@ -75,8 +75,11 @@ export const handler = async (
       return;
     }
 
+    const publicSubjectId = txmaEvent.user?.public_subject_id ?? currentTrackerRecord?.publicSubjectId;
+
     const newItem: InactiveAccountTrackerRecord = {
       commonSubjectId: userId,
+      ...(publicSubjectId && { publicSubjectId }),
       userLastActive: latestDate.toISOString(),
       dateForDeletion: getDateForDeletion(latestDate),
       emailAddress: email,


### PR DESCRIPTION
## Proposed changes

<!-- Provide a summary of your changes in the title above -->
[OLH-4462]: Update the inactive account tracker

### What changed

- Added publicSubjectId to InactiveAccountTrackerRecord
- Extracted public_subject_id from the TxMA event's user data (falling back to the existing tracker record's value if not present on the event), and store it alongside commonSubjectId in the tracker record

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists

<!-- Merging this PR deploys to production. Please answer accurately. -->

### Environment variables or secrets

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Added parameters to Cloudformation template
- [ ] Added new secret or systems manager parameter
- [ ] Added new environment variable

### Permissions

- [ ] This PR adds or changes permissions

### Monitoring

- [ ] This PR includes changes that need to be monitored in production as the scope of the change could cause issues

## Testing

<!-- Provide a summary of any manual testing you've done, for example deploying the branch to dev -->

## How to review

<!-- Describe any non-standard steps to review this work, or highlight any areas that you'd like the reviewer's opinion on -->


[OLH-4462]: https://govukverify.atlassian.net/browse/OLH-4462?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ