### PR TITLE
OLH-4461: Add dependency-review and standardise workflow naming

### DIFF
--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -1,0 +1,20 @@
+name: "Dependency Review"
+on:
+  pull_request:
+  merge_group:
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Dependency Review
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          fail-on-severity: moderate

--- a/.github/workflows/deployed-tests.yaml
+++ b/.github/workflows/deployed-tests.yaml
@@ -1,4 +1,4 @@
-name: Pre Merge Check
+name: Deployed tests
 
 on:
   workflow_call:
@@ -88,7 +88,7 @@ jobs:
           node-version-file: ".nvmrc"
 
       - name: Install ESbuild
-        run: npm install -g esbuild@0.23.1 # zizmor: ignore[adhoc-packages]
+        run: npm install -g --ignore-scripts esbuild@0.23.1 # zizmor: ignore[adhoc-packages]
 
       - name: Set up Python 3.9
         uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435 # pin@v4
@@ -146,7 +146,7 @@ jobs:
           stack-name: home-backend
           gh-polling-role: ${{ secrets.DEMO_TESTING_ROLE_ARN }}
 
-  test:
+  deployed-tests:
     if: ${{ needs.check-if-skipping-pre-merge.outputs.skip_found == 'false' }}
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/deployed-tests.yaml
+++ b/.github/workflows/deployed-tests.yaml
@@ -154,7 +154,6 @@ jobs:
         shell: bash
         working-directory: ./pre-merge-integration-tests
     timeout-minutes: 60
-    name: "Run Pre Merge Test"
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,4 +1,4 @@
-name: Check
+name: Lint
 
 permissions: {}
 
@@ -7,7 +7,7 @@ on:
   merge_group:
 
 jobs:
-  check:
+  lint:
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/local-tests-unit.yaml
+++ b/.github/workflows/local-tests-unit.yaml
@@ -1,4 +1,4 @@
-name: Test lambdas
+name: Local tests (unit)
 
 on:
   workflow_call:
@@ -10,7 +10,7 @@ on:
   pull_request:
 
 jobs:
-  test:
+  local-tests-unit:
     permissions:
       contents: read
     name: di-account-management-backend

--- a/.github/workflows/local-tests-unit.yaml
+++ b/.github/workflows/local-tests-unit.yaml
@@ -14,7 +14,6 @@ jobs:
   local-tests-unit:
     permissions:
       contents: read
-    name: di-account-management-backend
     runs-on: ubuntu-latest
     timeout-minutes: 15
     defaults:

--- a/.github/workflows/local-tests-unit.yaml
+++ b/.github/workflows/local-tests-unit.yaml
@@ -8,6 +8,7 @@ on:
         type: string
         default: ${{ github.ref }}
   pull_request:
+  merge_group:
 
 jobs:
   local-tests-unit:

--- a/.github/workflows/publish-to-demo.yaml
+++ b/.github/workflows/publish-to-demo.yaml
@@ -25,7 +25,7 @@ permissions:
 jobs:
   test_application:
     name: Test Lambdas
-    uses: ./.github/workflows/test-lambdas.yaml
+    uses: ./.github/workflows/local-tests-unit.yaml
     with:
       gitRef: ${{ inputs.gitRef }}
 

--- a/.github/workflows/publish-to-dev.yaml
+++ b/.github/workflows/publish-to-dev.yaml
@@ -25,7 +25,7 @@ permissions:
 jobs:
   test_application:
     name: Test Lambdas
-    uses: ./.github/workflows/test-lambdas.yaml
+    uses: ./.github/workflows/local-tests-unit.yaml
     with:
       gitRef: ${{ inputs.gitRef }}
 

--- a/quality-gate.manifest.json
+++ b/quality-gate.manifest.json
@@ -9,9 +9,9 @@
           "provider": "GitHub",
           "phase": "pre-merge",
           "config": {
-            "file": ".github/workflows/test-lambdas.yaml",
-            "path": "jobs.test",
-            "name": "Test lambdas"
+            "file": ".github/workflows/local-tests-unit.yaml",
+            "path": "jobs.local-tests-unit",
+            "name": "Local tests (unit)"
           }
         },
         {
@@ -24,9 +24,9 @@
           "provider": "GitHub",
           "phase": "pre-merge",
           "config": {
-            "file": ".github/workflows/check.yaml",
-            "path": "jobs.check",
-            "name": "Check"
+            "file": ".github/workflows/lint.yaml",
+            "path": "jobs.lint",
+            "name": "Lint"
           }
         },
         {
@@ -48,9 +48,9 @@
           "provider": "GitHub",
           "phase": "pre-merge",
           "config": {
-            "file": ".github/workflows/pre-merge.yaml",
-            "path": "jobs.test",
-            "name": "Pre Merge Check"
+            "file": ".github/workflows/deployed-tests.yaml",
+            "path": "jobs.deployed-tests",
+            "name": "Deployed tests"
           }
         },
         {


### PR DESCRIPTION
### What changed:
  
1. Added `dependency-review.yaml` workflow (flags PRs introducing vulnerable dependencies at moderate severity or above)
2. Renamed `check.yaml` to `lint.yaml`
3. Renamed test workflows for cross-repo consistency:
    - `test-lambdas.yaml` → `local-tests-unit.yaml`
    - `pre-merge.yaml` → `deployed-tests.yaml`  
4. Updated `quality-gate.manifest.json` to reflect all renames (file, path, name)
  
### Why did it change:
  
Consistent naming conventions across all three Home repos (account-components, backend, frontend). "Local tests" = runs self-contained in the GitHub runner. "Deployed tests" = tests against real AWS infrastructure. `dependency-review` was already on account-components.
  
### Checklists:

- [x] No environment variables or secrets were added or changed
- [ ] This PR includes changes that need to be monitored in production: N/A (CI-only changes, no functional changes)
 