### PR TITLE
OLH-4471: Retry on delete email subscriptions failure

### DIFF
--- a/src/common/retry-function.ts
+++ b/src/common/retry-function.ts
@@ -1,0 +1,31 @@
+import { Logger } from "@aws-lambda-powertools/logger";
+
+const logger = new Logger();
+
+interface RetryFunctionOptions {
+  retries?: number,
+  delay?: number,
+  functionName: string
+}
+export const retryFunction = async <T>(
+  fn: () => Promise<T>,
+  {
+    retries = 3,
+    delay = 300,
+    functionName
+  }: RetryFunctionOptions 
+): Promise<T> => {
+  for (let attempt = 1; attempt <= retries; attempt++) {
+    try {
+      return await fn();
+    } catch (error) {
+      logger.warn(`${functionName} failed (attempt ${attempt} out of ${retries}).`);
+      if (attempt === retries) {
+        throw error;
+      }
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    }
+  }
+  throw new Error("Unexpected error");
+};
+

--- a/src/delete-email-subscriptions.ts
+++ b/src/delete-email-subscriptions.ts
@@ -8,6 +8,24 @@ import {
 
 const logger = new Logger();
 
+const retryDeleteEmailSubscription = async (
+  userData: UserData
+): Promise<void> => {
+  const retries = 3;
+  for (let attempt = 1; attempt <= retries; attempt++) {
+    try {
+      await deleteEmailSubscription(userData);
+      return;
+    } catch (error) {
+      if (attempt === retries) {
+        throw error;
+      }
+      logger.warn("Attempt to delete email subscription has failed. Retrying");
+      await new Promise((resolve) => setTimeout(resolve, 300));
+    }
+  }
+};
+
 export const handler = async (
   event: SNSEvent,
   context: Context
@@ -21,7 +39,7 @@ export const handler = async (
         );
         const userData: UserData = JSON.parse(record.Sns.Message);
         validateUserData(userData);
-        await deleteEmailSubscription(userData);
+        await retryDeleteEmailSubscription(userData);
         logger.info(
           `finished processing message with ID: ${record.Sns.MessageId}`
         );

--- a/src/delete-email-subscriptions.ts
+++ b/src/delete-email-subscriptions.ts
@@ -5,26 +5,9 @@ import {
   deleteEmailSubscription,
   validateUserData,
 } from "./delete-email-subscriptions-utils.js";
+import { retryFunction } from "./common/retry-function.js";
 
 const logger = new Logger();
-
-const retryDeleteEmailSubscription = async (
-  userData: UserData
-): Promise<void> => {
-  const retries = 3;
-  for (let attempt = 1; attempt <= retries; attempt++) {
-    try {
-      await deleteEmailSubscription(userData);
-      return;
-    } catch (error) {
-      if (attempt === retries) {
-        throw error;
-      }
-      logger.warn("Attempt to delete email subscription has failed. Retrying");
-      await new Promise((resolve) => setTimeout(resolve, 300));
-    }
-  }
-};
 
 export const handler = async (
   event: SNSEvent,
@@ -39,7 +22,10 @@ export const handler = async (
         );
         const userData: UserData = JSON.parse(record.Sns.Message);
         validateUserData(userData);
-        await retryDeleteEmailSubscription(userData);
+        await retryFunction(
+          () => deleteEmailSubscription(userData),
+          { functionName: "deleteEmailSubscription" }
+        );
         logger.info(
           `finished processing message with ID: ${record.Sns.MessageId}`
         );

--- a/src/tests/delete-email-subscriptions.test.ts
+++ b/src/tests/delete-email-subscriptions.test.ts
@@ -80,7 +80,15 @@ describe("handler", () => {
     await expect(handler(TEST_SNS_EVENT, {} as Context)).rejects.toThrow("deleteEmailSubscription FAIL");
     expect(deleteEmailSubscriptionMock).toHaveBeenCalledTimes(3);
     expect(mockLogger.warn).toHaveBeenCalledWith(
-      "Attempt to delete email subscription has failed. Retrying"
+      "deleteEmailSubscription failed (attempt 1 out of 3)."
+    );
+
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      "deleteEmailSubscription failed (attempt 2 out of 3)."
+    );
+
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      "deleteEmailSubscription failed (attempt 3 out of 3)."
     );
   });
 });

--- a/src/tests/delete-email-subscriptions.test.ts
+++ b/src/tests/delete-email-subscriptions.test.ts
@@ -5,11 +5,13 @@ import { TEST_SNS_EVENT, TEST_USER_DATA } from "./testFixtures.js";
 const mockLogger = vi.hoisted(() => ({
   error: vi.fn(),
   info: vi.fn(),
+  warn: vi.fn(),
   addContext: vi.fn(),
 }));
 
 vi.mock("@aws-lambda-powertools/logger", () => ({
   Logger: class {
+    warn = mockLogger.warn;
     error = mockLogger.error;
     info = mockLogger.info;
     addContext = mockLogger.addContext;
@@ -69,6 +71,17 @@ describe("handler", () => {
     expect(validateUserDataMock).toHaveBeenCalledWith(TEST_USER_DATA);
     expect(deleteEmailSubscriptionMock).toHaveBeenCalledTimes(1);
     expect(deleteEmailSubscriptionMock).toHaveBeenCalledWith(TEST_USER_DATA);
+  });
+
+  test("that it retries up to 3 times total when deleteEmailSubscription throws error", async () => {
+    vi.mocked(deleteEmailSubscriptionMock).mockRejectedValue(
+      new Error("deleteEmailSubscription FAIL"),
+    );
+    await expect(handler(TEST_SNS_EVENT, {} as Context)).rejects.toThrow("deleteEmailSubscription FAIL");
+    expect(deleteEmailSubscriptionMock).toHaveBeenCalledTimes(3);
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      "Attempt to delete email subscription has failed. Retrying"
+    );
   });
 });
 

--- a/src/tests/retry-function.test.ts
+++ b/src/tests/retry-function.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { retryFunction } from "../common/retry-function.js";
+
+const mockLogger = vi.hoisted(() => ({
+  warn: vi.fn(),
+}));
+
+vi.mock("@aws-lambda-powertools/logger", () => ({
+  Logger: class {
+    warn = mockLogger.warn;
+  },
+}));
+
+describe("retryFunction", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("should resolve immediately if the function succeeds on the first attempt", async () => {
+    const mockFn = vi.fn().mockResolvedValue("Success");
+    const result = await retryFunction(mockFn, { functionName: "test function" });
+    expect(result).toBe("Success");
+    expect(mockFn).toHaveBeenCalledTimes(1);
+    expect(mockLogger.warn).not.toHaveBeenCalled();
+  });
+
+  it("should retry and resolve if an early attempt fails but a later attempt succeeds", async () => {
+    const mockFn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("First Fail"))
+      .mockRejectedValueOnce(new Error("Second Fail"))
+      .mockResolvedValueOnce("Third success");
+
+    const promise = retryFunction(mockFn, { retries: 3, delay: 300, functionName: "test function" });
+
+    await vi.advanceTimersByTimeAsync(300);
+    await vi.advanceTimersByTimeAsync(300);
+
+    const result = await promise;
+
+    expect(result).toBe("Third success");
+    expect(mockFn).toHaveBeenCalledTimes(3);
+    expect(mockLogger.warn).toHaveBeenCalledTimes(2);
+    expect(mockLogger.warn).toHaveBeenNthCalledWith(
+      1,
+      "test function failed (attempt 1 out of 3)."
+    );
+  });
+
+  it("should throw error after exhausting all retries", async () => {
+    const finalError = new Error("Permanent Failure");
+    const mockFn = vi.fn().mockRejectedValue(finalError);
+
+    const promise = retryFunction(mockFn, { retries: 5, delay: 100, functionName: "my test func" });
+
+    const [, errorReason] = await Promise.all([
+      vi.runAllTimersAsync(),
+      promise.catch((err) => err),
+    ]);
+
+    expect(errorReason).toEqual(finalError);
+    expect(mockFn).toHaveBeenCalledTimes(5);
+    expect(mockLogger.warn).toHaveBeenCalledTimes(5);
+    expect(mockLogger.warn).toHaveBeenNthCalledWith(
+      5,
+      "my test func failed (attempt 5 out of 5)."
+    );
+  });
+
+  it("should use default retries and delay when only functionName is provided", async () => {
+    const mockFn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Fail 1"))
+      .mockResolvedValueOnce("Success");
+
+    const promise = retryFunction(mockFn, { functionName: "MyTestOperation" });
+
+    await vi.advanceTimersByTimeAsync(300);
+
+    const result = await promise;
+
+    expect(result).toBe("Success");
+    expect(mockFn).toHaveBeenCalledTimes(2);
+    expect(mockLogger.warn).toHaveBeenNthCalledWith(
+      1,
+      "MyTestOperation failed (attempt 1 out of 3)."
+    );
+  });
+});


### PR DESCRIPTION
## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->

### What changed
Add retries to delete email subscription call before allowing lambda to error.

<!-- Describe the changes in detail - the "what"-->

### Why did it change
Logging has revealed that this method has previously failed a few times, possibly due to GOVUK Api flakiness. This should add a bit more resilience to the email subscription delete lambda.
<!-- Describe the reason these changes were made - the "why" -->
