### PR TITLE
OLH-4455: Publish daily deletion forecast metrics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -505,7 +505,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1081.0.tgz",
       "integrity": "sha512-rPLag4HuZYW/vCUMGZ19zFWgi8Uw/rARgxSLmPpX2ua9h1ysXX+KBwf4/o74uJO5qanVPHJv59aZ03/WBVrQKw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/core": "^3.974.29",
         "@aws-sdk/credential-provider-node": "^3.972.64",
@@ -1090,6 +1089,31 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -2999,7 +3023,6 @@
       "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
       "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -3307,7 +3330,6 @@
       "integrity": "sha512-gwh4gvvlaVDKKxyfxMG+Gnu1u9X0OQBwyGLkbwB65dIzBKnxeRiJlNFqlI3zwVhNXJIs6qV7mlFCn/BIajlVig==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.63.0",
         "@typescript-eslint/types": "8.63.0",
@@ -3512,7 +3534,6 @@
       "integrity": "sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.10",
@@ -3655,7 +3676,6 @@
       "version": "8.16.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3780,7 +3800,6 @@
       "version": "4.1.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/sinon": "^17.0.3",
         "sinon": "^18.0.1",
@@ -3810,7 +3829,6 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
       "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
@@ -4100,7 +4118,6 @@
       "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -4153,7 +4170,6 @@
       "integrity": "sha512-6lVbcqSodALYo+4ELD0heG6lFiFxnLMuLkiMi2qV8LMp54N8tE8FT1GMH+ev4Ti00nFjNze2+Su6DsV5OQW3Dg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -4211,7 +4227,6 @@
       "version": "10.1.8",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -5774,7 +5789,6 @@
       "integrity": "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -6201,7 +6215,6 @@
       "version": "6.0.3",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6317,7 +6330,6 @@
       "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.5",
@@ -6396,7 +6408,6 @@
       "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.10",
         "@vitest/mocker": "4.1.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@aws-lambda-powertools/logger": "^2.33.1",
         "@aws-lambda-powertools/metrics": "^2.33.1",
         "@aws-lambda-powertools/parameters": "^2.33.1",
-        "@aws-sdk/client-cloudwatch": "^3.1091.0",
         "@aws-sdk/client-dynamodb": "^3.1081.0",
         "@aws-sdk/client-lambda": "^3.1081.0",
         "@aws-sdk/client-secrets-manager": "^3.1081.0",
@@ -413,26 +412,6 @@
         }
       }
     },
-    "node_modules/@aws-sdk/client-cloudwatch": {
-      "version": "3.1091.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch/-/client-cloudwatch-3.1091.0.tgz",
-      "integrity": "sha512-Wr3R0cQrVjUyIrECavdQYcvm480KWgckdvn2etpntVha6/q7+//m8O5GRVxSgXuJXLhTIrNUaIfRW0FNsYQAVg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.975.3",
-        "@aws-sdk/credential-provider-node": "^3.972.70",
-        "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.4",
-        "@smithy/fetch-http-handler": "^5.6.6",
-        "@smithy/middleware-compression": "^4.5.9",
-        "@smithy/node-http-handler": "^4.9.6",
-        "@smithy/types": "^4.16.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
     "node_modules/@aws-sdk/client-dynamodb": {
       "version": "3.1081.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1081.0.tgz",
@@ -526,6 +505,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1081.0.tgz",
       "integrity": "sha512-rPLag4HuZYW/vCUMGZ19zFWgi8Uw/rARgxSLmPpX2ua9h1ysXX+KBwf4/o74uJO5qanVPHJv59aZ03/WBVrQKw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/core": "^3.974.29",
         "@aws-sdk/credential-provider-node": "^3.972.64",
@@ -1110,31 +1090,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
-      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
-      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -2856,21 +2811,6 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@smithy/middleware-compression": {
-      "version": "4.5.11",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-compression/-/middleware-compression-4.5.11.tgz",
-      "integrity": "sha512-mKhwQDoaj3Y3Ym7bEzy4oOyzmB9NM4wxX55Fg0nHWn7BdqZjBvAZ7aGsW07q1Ttu5mCq+ZG09nD1tShXhFGaOQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.29.6",
-        "@smithy/types": "^4.16.1",
-        "fflate": "0.8.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@smithy/middleware-content-length": {
       "version": "4.2.14",
       "license": "Apache-2.0",
@@ -3059,6 +2999,7 @@
       "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
       "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -3366,6 +3307,7 @@
       "integrity": "sha512-gwh4gvvlaVDKKxyfxMG+Gnu1u9X0OQBwyGLkbwB65dIzBKnxeRiJlNFqlI3zwVhNXJIs6qV7mlFCn/BIajlVig==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.63.0",
         "@typescript-eslint/types": "8.63.0",
@@ -3570,6 +3512,7 @@
       "integrity": "sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.10",
@@ -3712,6 +3655,7 @@
       "version": "8.16.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3836,6 +3780,7 @@
       "version": "4.1.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/sinon": "^17.0.3",
         "sinon": "^18.0.1",
@@ -3865,6 +3810,7 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
       "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
@@ -4154,6 +4100,7 @@
       "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -4206,6 +4153,7 @@
       "integrity": "sha512-6lVbcqSodALYo+4ELD0heG6lFiFxnLMuLkiMi2qV8LMp54N8tE8FT1GMH+ev4Ti00nFjNze2+Su6DsV5OQW3Dg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -4263,6 +4211,7 @@
       "version": "10.1.8",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -4482,12 +4431,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/fflate": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.1.tgz",
-      "integrity": "sha512-/exOvEuc+/iaUm105QIiOt4LpBdMTWsXxqR0HDF35vx3fmaKzw7354gTilCh5rkzEt8WYyG//ku3h3nRmd7CHQ==",
-      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -5831,6 +5774,7 @@
       "integrity": "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -6257,6 +6201,7 @@
       "version": "6.0.3",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6372,6 +6317,7 @@
       "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.5",
@@ -6450,6 +6396,7 @@
       "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.10",
         "@vitest/mocker": "4.1.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@aws-lambda-powertools/logger": "^2.33.1",
         "@aws-lambda-powertools/metrics": "^2.33.1",
         "@aws-lambda-powertools/parameters": "^2.33.1",
+        "@aws-sdk/client-cloudwatch": "^3.1091.0",
         "@aws-sdk/client-dynamodb": "^3.1081.0",
         "@aws-sdk/client-lambda": "^3.1081.0",
         "@aws-sdk/client-secrets-manager": "^3.1081.0",
@@ -412,6 +413,26 @@
         }
       }
     },
+    "node_modules/@aws-sdk/client-cloudwatch": {
+      "version": "3.1091.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch/-/client-cloudwatch-3.1091.0.tgz",
+      "integrity": "sha512-Wr3R0cQrVjUyIrECavdQYcvm480KWgckdvn2etpntVha6/q7+//m8O5GRVxSgXuJXLhTIrNUaIfRW0FNsYQAVg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/credential-provider-node": "^3.972.70",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/fetch-http-handler": "^5.6.6",
+        "@smithy/middleware-compression": "^4.5.9",
+        "@smithy/node-http-handler": "^4.9.6",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-dynamodb": {
       "version": "3.1081.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1081.0.tgz",
@@ -578,16 +599,16 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.975.2",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.975.2.tgz",
-      "integrity": "sha512-iyeXwziyjJpixq5OmhsIyrSWx8vwcI7gDo4yRUC3EP7NQtOo9iAJiIEc3G+/HkhtNXqOhofiCK7Lc34Sq+fJWg==",
+      "version": "3.975.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.975.3.tgz",
+      "integrity": "sha512-7ur3kCKuvPLqlsZ2XlvnNBVQ7KkpSu6Y6dOTwSPHLrFpTEfZM8isLBJc4cgv96WB7GifeVM436mpycwxBd2vEA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.974.1",
-        "@aws-sdk/xml-builder": "^3.972.35",
+        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/xml-builder": "^3.972.36",
         "@aws/lambda-invoke-store": "^0.3.0",
-        "@smithy/core": "^3.29.3",
-        "@smithy/signature-v4": "^5.6.3",
+        "@smithy/core": "^3.29.4",
+        "@smithy/signature-v4": "^5.6.5",
         "@smithy/types": "^4.16.1",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
@@ -606,14 +627,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.58",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.58.tgz",
-      "integrity": "sha512-vyGtvK1rY940eq7JT0yIGKuZ+2kpPSJcHibSvGlit5oiMFDamzC7cxBGLl4FLnd6suihMXDI2FSF2dL6TmBqPA==",
+      "version": "3.972.59",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.59.tgz",
+      "integrity": "sha512-Ny5e4Mfh3QPmiAc0AiUe+cbTXDlxkU3Rc+EpWOfyWeWEy6yp7Fa1KmfNeCc+1a8by9zQ9gtohmiQUkMPScF3ng==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.2",
-        "@aws-sdk/types": "^3.974.1",
-        "@smithy/core": "^3.29.3",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -622,16 +643,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.60",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.60.tgz",
-      "integrity": "sha512-g9b9YzDrD5pcKiPBJfCSXRfFMrA39eR0guUhZ5SRm+7vMAVc43+effxbcamxBjSd5bUhrdKo5te/yQuWurLXLA==",
+      "version": "3.972.61",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.61.tgz",
+      "integrity": "sha512-8jAjgStl5Ytq4+HF3X/9f+EmRinaRbGRRtQGktlPfBRVx73H+R1y48vIeXerQtYGFaUqkEp3fT6jP854rVO2yQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.2",
-        "@aws-sdk/types": "^3.974.1",
-        "@smithy/core": "^3.29.3",
-        "@smithy/fetch-http-handler": "^5.6.5",
-        "@smithy/node-http-handler": "^4.9.5",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/fetch-http-handler": "^5.6.6",
+        "@smithy/node-http-handler": "^4.9.6",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -640,22 +661,22 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.973.2",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.2.tgz",
-      "integrity": "sha512-Yr7yxNyQ8aHt9Ww0RPFUZx+xiem+vl7vuwhP0tniTijoesJNV5jou9HCgVpI0GEPAF+89TkOvilE5uRrZJnjaw==",
+      "version": "3.973.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.4.tgz",
+      "integrity": "sha512-e6ZvVsj90aRALf1kHP+J4iqC1496ZpVgqI/+u0LJ5HL7q7ATauGy4gdDvRCP13L1pN/fMiZLah162PGIYkbUVQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.2",
-        "@aws-sdk/credential-provider-env": "^3.972.58",
-        "@aws-sdk/credential-provider-http": "^3.972.60",
-        "@aws-sdk/credential-provider-login": "^3.972.64",
-        "@aws-sdk/credential-provider-process": "^3.972.58",
-        "@aws-sdk/credential-provider-sso": "^3.973.2",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.64",
-        "@aws-sdk/nested-clients": "^3.997.32",
-        "@aws-sdk/types": "^3.974.1",
-        "@smithy/core": "^3.29.3",
-        "@smithy/credential-provider-imds": "^4.4.7",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/credential-provider-env": "^3.972.59",
+        "@aws-sdk/credential-provider-http": "^3.972.61",
+        "@aws-sdk/credential-provider-login": "^3.972.66",
+        "@aws-sdk/credential-provider-process": "^3.972.59",
+        "@aws-sdk/credential-provider-sso": "^3.973.3",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.65",
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/credential-provider-imds": "^4.4.9",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -664,15 +685,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.64",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.64.tgz",
-      "integrity": "sha512-YQoSI4d6kXvoenoG/0Jv/PqaAuukHzGmGXGyHBQYeEUNsYovlNAn/Sw1wp/WQbhcQ3HsEMGgjEahvD3igz6ecQ==",
+      "version": "3.972.66",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.66.tgz",
+      "integrity": "sha512-g2fsqm87r/nKthLZ0VkkDBElkGg0PvSa8d97HQ6EilMbJTZ6hxa8FxkSZyJfgPfFdZn0TTmkOffQmTSUcAHIng==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.2",
-        "@aws-sdk/nested-clients": "^3.997.32",
-        "@aws-sdk/types": "^3.974.1",
-        "@smithy/core": "^3.29.3",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -681,20 +702,20 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.68",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.68.tgz",
-      "integrity": "sha512-4akjzW9CjorByYfqXBXmYUh/h7Io3U4DtVgGGh9TQraZ7ZlyJqNyHwDRGiUFnHD+BTOeTbCesCa4sJaK7BGZ7A==",
+      "version": "3.972.70",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.70.tgz",
+      "integrity": "sha512-3xzvkGdykBunxqh8WudmUpSyLWvIhfI6aBQo1b5rb3mDO5mNLadK+0hiI0qBQBMVynJbfLO+Ajy9dztMwy9O8w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.58",
-        "@aws-sdk/credential-provider-http": "^3.972.60",
-        "@aws-sdk/credential-provider-ini": "^3.973.2",
-        "@aws-sdk/credential-provider-process": "^3.972.58",
-        "@aws-sdk/credential-provider-sso": "^3.973.2",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.64",
-        "@aws-sdk/types": "^3.974.1",
-        "@smithy/core": "^3.29.3",
-        "@smithy/credential-provider-imds": "^4.4.7",
+        "@aws-sdk/credential-provider-env": "^3.972.59",
+        "@aws-sdk/credential-provider-http": "^3.972.61",
+        "@aws-sdk/credential-provider-ini": "^3.973.4",
+        "@aws-sdk/credential-provider-process": "^3.972.59",
+        "@aws-sdk/credential-provider-sso": "^3.973.3",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.65",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/credential-provider-imds": "^4.4.9",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -703,14 +724,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.58",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.58.tgz",
-      "integrity": "sha512-1nYitRCaDmXWUrpBJt6WlcGjLx1JVsMY8rlYuHHsTYTSaYikbixYdQSyINN2VYq1F798uTO9qHAzytL25M8g3A==",
+      "version": "3.972.59",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.59.tgz",
+      "integrity": "sha512-DlZF2/MhLlatDdlrIy3CUCpfdbLrKx+3SMjVo+WyHnPpwzkc/M3vwAHw4OVJf7DMvO+4vfRqSCMc/E9I1auN0g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.2",
-        "@aws-sdk/types": "^3.974.1",
-        "@smithy/core": "^3.29.3",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -719,16 +740,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.973.2",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.2.tgz",
-      "integrity": "sha512-pjMLaLU/JZi5lVfmR14V1OZqRBTuMHf6AwGNZA0K9hK+JKtO3jcLBarfD8iq5oc8cSowvc/9R32sqMVXZPo6xQ==",
+      "version": "3.973.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.3.tgz",
+      "integrity": "sha512-hmdDHoy2G5Es2e8IgelNMYUuSQI6uCIAKZMJ2u2PdKDhxvbk1uWD/g4+R7R5c/tJfKEB1+KjjWiaoCr/S+ZTiQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.2",
-        "@aws-sdk/nested-clients": "^3.997.32",
-        "@aws-sdk/token-providers": "3.1087.0",
-        "@aws-sdk/types": "^3.974.1",
-        "@smithy/core": "^3.29.3",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/token-providers": "3.1088.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -737,15 +758,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.64",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.64.tgz",
-      "integrity": "sha512-7Buc7p0OvDHW7iBsu4b+YdS0WnaFBDGKDfbVQqaac9dkWiSiUtIoarBDsA1RmOVXZijaZJDoHJFIQiicQvWRlQ==",
+      "version": "3.972.65",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.65.tgz",
+      "integrity": "sha512-gHQb/Kt0chjk/JQDa/GJDqmAvEuVn8n7z10wK2h0LFM9TUDRkohgOO4aEF+s2sBLM0br7Cl5W6P7phgjrrJvLQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.2",
-        "@aws-sdk/nested-clients": "^3.997.32",
-        "@aws-sdk/types": "^3.974.1",
-        "@smithy/core": "^3.29.3",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -883,17 +904,17 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.32",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.32.tgz",
-      "integrity": "sha512-6Yj2fr9XF67cndITea48rchTdVr3VGx6PN47bIKNinJAjLkmaIlz/4EBPCgJ8UmhVopiXmeAuPLI3+DXDDbMhQ==",
+      "version": "3.997.33",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.33.tgz",
+      "integrity": "sha512-dVZOroI/r3/ENvqNGgjMPul+jjlz9GddfVusgTXlVjfZj5isibOxecLkGQbRPp8XOuX+RAfjXLFgPkD1JS5xrw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.2",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.40",
-        "@aws-sdk/types": "^3.974.1",
-        "@smithy/core": "^3.29.3",
-        "@smithy/fetch-http-handler": "^5.6.5",
-        "@smithy/node-http-handler": "^4.9.5",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.41",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/fetch-http-handler": "^5.6.6",
+        "@smithy/node-http-handler": "^4.9.6",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -915,13 +936,13 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.40",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.40.tgz",
-      "integrity": "sha512-wrGZ/authosokclY1DXsiWT/1WjfCI22FuZGgdcilF+XLTXs5dCjAtiFYSPsEToZkbm3Lj2YP8PoWg0yoMNu0g==",
+      "version": "3.996.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.41.tgz",
+      "integrity": "sha512-QMUytg+FQMGouc8gHS00KoYih3+N6cqmVI/pQGOIo7Nr7OpQaiXjSYOuL+vsPZ1tymY4LAQ8MYcHJmws5LRxng==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.974.1",
-        "@smithy/signature-v4": "^5.6.3",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/signature-v4": "^5.6.5",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -930,15 +951,15 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1087.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1087.0.tgz",
-      "integrity": "sha512-umM+qNq16f2fH+VLM5MqXW4ORNQAjk+TOSto73xbUHcKaU41L48j786r3UWQYlejeJk37NlvRYgxBT+MBkfaYQ==",
+      "version": "3.1088.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1088.0.tgz",
+      "integrity": "sha512-4ObatWt2qpJg5FBk4LOOKrTQYzaqeewAtdO3r9ZO8lH9YqLtpTzLyIdy0mJ+nVdfYOnqISkKNfmzP22bNDhwyw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.2",
-        "@aws-sdk/nested-clients": "^3.997.32",
-        "@aws-sdk/types": "^3.974.1",
-        "@smithy/core": "^3.29.3",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -947,9 +968,9 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.974.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.1.tgz",
-      "integrity": "sha512-W0IQZR0eaBqlBFIIofMapaWkw1W0U+Xi4dvW+BqwmCEMd8Ng2U6IhkxuPSjMVnR8klLjfuS9PeZWUl1N6UaZdg==",
+      "version": "3.974.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.2.tgz",
+      "integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.16.1",
@@ -1022,9 +1043,9 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.35",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.35.tgz",
-      "integrity": "sha512-pXzaWe3evZhjxDXAlMnqISe/XefTCGwBJG4nFTXaWSgAnMkqPEhxEPqJNhhpGesEvKFhvNpnozJJ4GTL11bRYw==",
+      "version": "3.972.36",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.36.tgz",
+      "integrity": "sha512-RdGmS1GLrtaTOLE1ElSluMldNrpk9Emq6uYs8SS8iHlu5xTAmM9rRkM91o48+rIRryBtyO9t+uLYCoMG6jVMVA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.16.1",
@@ -1092,24 +1113,26 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1868,9 +1891,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1888,9 +1908,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1908,9 +1925,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1928,9 +1942,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1948,9 +1959,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1968,9 +1976,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1988,9 +1993,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2008,9 +2010,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2054,6 +2053,29 @@
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@oxc-parser/binding-win32-arm64-msvc": {
@@ -2223,9 +2245,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2240,9 +2259,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2257,9 +2273,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2274,9 +2287,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2291,9 +2301,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2308,9 +2315,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2325,9 +2329,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2342,9 +2343,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2541,9 +2539,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2561,9 +2556,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2581,9 +2573,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2601,9 +2590,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2621,9 +2607,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2641,9 +2624,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2687,6 +2667,29 @@
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
@@ -2779,9 +2782,9 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.29.4",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.4.tgz",
-      "integrity": "sha512-G1GRglAabzEhqghJMBAd54FkRS7SAFGHEwbhcI9r+O+LIMuFsLyXkLZkCoFSgAglRu8s/URVXJB0hglq3ZipIg==",
+      "version": "3.29.6",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.6.tgz",
+      "integrity": "sha512-TO3w25cdGWBeYqKNDaqH3v4O3jjMPpKwf39YlG5X5xhqWfpOWJbi5gQi1lrllukuwohdhY0TPB8jBEv6UC50Vg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.16.1",
@@ -2847,6 +2850,21 @@
       "version": "4.2.2",
       "license": "Apache-2.0",
       "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-compression": {
+      "version": "4.5.11",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-compression/-/middleware-compression-4.5.11.tgz",
+      "integrity": "sha512-mKhwQDoaj3Y3Ym7bEzy4oOyzmB9NM4wxX55Fg0nHWn7BdqZjBvAZ7aGsW07q1Ttu5mCq+ZG09nD1tShXhFGaOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.6",
+        "@smithy/types": "^4.16.1",
+        "fflate": "0.8.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4465,6 +4483,12 @@
         }
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.1.tgz",
+      "integrity": "sha512-/exOvEuc+/iaUm105QIiOt4LpBdMTWsXxqR0HDF35vx3fmaKzw7354gTilCh5rkzEt8WYyG//ku3h3nRmd7CHQ==",
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "dev": true,
@@ -5117,9 +5141,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5141,9 +5162,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5165,9 +5183,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5189,9 +5204,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "@aws-lambda-powertools/logger": "^2.33.1",
     "@aws-lambda-powertools/metrics": "^2.33.1",
     "@aws-lambda-powertools/parameters": "^2.33.1",
-    "@aws-sdk/client-cloudwatch": "^3.1091.0",
     "@aws-sdk/client-dynamodb": "^3.1081.0",
     "@aws-sdk/client-lambda": "^3.1081.0",
     "@aws-sdk/client-secrets-manager": "^3.1081.0",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@aws-lambda-powertools/logger": "^2.33.1",
     "@aws-lambda-powertools/metrics": "^2.33.1",
     "@aws-lambda-powertools/parameters": "^2.33.1",
+    "@aws-sdk/client-cloudwatch": "^3.1091.0",
     "@aws-sdk/client-dynamodb": "^3.1081.0",
     "@aws-sdk/client-lambda": "^3.1081.0",
     "@aws-sdk/client-secrets-manager": "^3.1081.0",

--- a/src/inactive-account-deletion-forecast.ts
+++ b/src/inactive-account-deletion-forecast.ts
@@ -1,0 +1,84 @@
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { DynamoDBDocumentClient, QueryCommand } from "@aws-sdk/lib-dynamodb";
+import {
+  CloudWatchClient,
+  PutMetricDataCommand,
+  type MetricDatum,
+} from "@aws-sdk/client-cloudwatch";
+import { Logger } from "@aws-lambda-powertools/logger";
+import { getEnvironmentVariable } from "./common/utils.js";
+
+const logger = new Logger();
+const dynamoClient = new DynamoDBClient({});
+const dynamoDocClient = DynamoDBDocumentClient.from(dynamoClient);
+const cloudWatchClient = new CloudWatchClient({});
+
+const FORECAST_DAYS = 180;
+const CW_BATCH_SIZE = 20;
+const METRIC_NAMESPACE = "account-management-backend";
+const METRIC_NAME = "InactiveAccountsScheduledForDeletion";
+
+export const buildDates = (fromDate: Date, days: number): string[] =>
+  Array.from({ length: days }, (_, i) => {
+    const d = new Date(fromDate);
+    d.setDate(d.getDate() + i + 1);
+    return d.toISOString().split("T")[0];
+  });
+
+export const countAccountsForDate = async (
+  tableName: string,
+  dateForDeletion: string
+): Promise<number> => {
+  let count = 0;
+  let lastEvaluatedKey: Record<string, unknown> | undefined;
+
+  do {
+    const response = await dynamoDocClient.send(
+      new QueryCommand({
+        TableName: tableName,
+        KeyConditionExpression: "dateForDeletion = :date",
+        ExpressionAttributeValues: { ":date": dateForDeletion },
+        Select: "COUNT",
+        ConsistentRead: false,
+        ExclusiveStartKey: lastEvaluatedKey,
+      })
+    );
+    count += response.Count ?? 0;
+    lastEvaluatedKey = response.LastEvaluatedKey ?? undefined;
+  } while (lastEvaluatedKey);
+
+  return count;
+};
+
+export const publishMetrics = async (
+  metrics: MetricDatum[]
+): Promise<void> => {
+  for (let i = 0; i < metrics.length; i += CW_BATCH_SIZE) {
+    await cloudWatchClient.send(
+      new PutMetricDataCommand({
+        Namespace: METRIC_NAMESPACE,
+        MetricData: metrics.slice(i, i + CW_BATCH_SIZE),
+      })
+    );
+  }
+};
+
+export const handler = async (): Promise<void> => {
+  const tableName = getEnvironmentVariable("TABLE_NAME");
+  const dates = buildDates(new Date(), FORECAST_DAYS);
+
+  const counts = await Promise.all(
+    dates.map((date) => countAccountsForDate(tableName, date))
+  );
+
+  const metrics: MetricDatum[] = dates.map((date, i) => ({
+    MetricName: METRIC_NAME,
+    Dimensions: [{ Name: "DateForDeletion", Value: date }],
+    Value: counts[i],
+    Unit: "Count",
+  }));
+
+  await publishMetrics(metrics);
+
+  logger.info(`Published deletion forecast for ${dates.length} dates`);
+};

--- a/src/inactive-account-deletion-forecast.ts
+++ b/src/inactive-account-deletion-forecast.ts
@@ -1,21 +1,16 @@
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocumentClient, QueryCommand } from "@aws-sdk/lib-dynamodb";
-import {
-  CloudWatchClient,
-  PutMetricDataCommand,
-  type MetricDatum,
-} from "@aws-sdk/client-cloudwatch";
 import { Logger } from "@aws-lambda-powertools/logger";
+import { MetricUnit } from "@aws-lambda-powertools/metrics";
+import { initMetrics } from "./common/metrics.js";
 import { getEnvironmentVariable } from "./common/utils.js";
 
 const logger = new Logger();
+const metrics = initMetrics("inactive-account-deletion-forecast");
 const dynamoClient = new DynamoDBClient({});
 const dynamoDocClient = DynamoDBDocumentClient.from(dynamoClient);
-const cloudWatchClient = new CloudWatchClient({});
 
 const FORECAST_DAYS = 180;
-const CW_BATCH_SIZE = 20;
-const METRIC_NAMESPACE = "account-management-backend";
 const METRIC_NAME = "InactiveAccountsScheduledForDeletion";
 
 export const buildDates = (fromDate: Date, days: number): string[] =>
@@ -50,19 +45,6 @@ export const countAccountsForDate = async (
   return count;
 };
 
-export const publishMetrics = async (
-  metrics: MetricDatum[]
-): Promise<void> => {
-  for (let i = 0; i < metrics.length; i += CW_BATCH_SIZE) {
-    await cloudWatchClient.send(
-      new PutMetricDataCommand({
-        Namespace: METRIC_NAMESPACE,
-        MetricData: metrics.slice(i, i + CW_BATCH_SIZE),
-      })
-    );
-  }
-};
-
 export const handler = async (): Promise<void> => {
   const tableName = getEnvironmentVariable("TABLE_NAME");
   const dates = buildDates(new Date(), FORECAST_DAYS);
@@ -71,14 +53,11 @@ export const handler = async (): Promise<void> => {
     dates.map((date) => countAccountsForDate(tableName, date))
   );
 
-  const metrics: MetricDatum[] = dates.map((date, i) => ({
-    MetricName: METRIC_NAME,
-    Dimensions: [{ Name: "DateForDeletion", Value: date }],
-    Value: counts[i],
-    Unit: "Count",
-  }));
-
-  await publishMetrics(metrics);
+  dates.forEach((date, i) => {
+    const singleMetric = metrics.singleMetric();
+    singleMetric.addDimension("DateForDeletion", date);
+    singleMetric.addMetric(METRIC_NAME, MetricUnit.Count, counts[i]);
+  });
 
   logger.info(`Published deletion forecast for ${dates.length} dates`);
 };

--- a/src/tests/inactive-account-deletion-forecast.test.ts
+++ b/src/tests/inactive-account-deletion-forecast.test.ts
@@ -1,0 +1,173 @@
+import { vi, describe, test, expect, beforeEach, afterEach } from "vitest";
+import { DynamoDBDocumentClient, QueryCommand } from "@aws-sdk/lib-dynamodb";
+import {
+  CloudWatchClient,
+  PutMetricDataCommand,
+} from "@aws-sdk/client-cloudwatch";
+import { mockClient } from "aws-sdk-client-mock";
+import {
+  buildDates,
+  countAccountsForDate,
+  publishMetrics,
+  handler,
+} from "../inactive-account-deletion-forecast.js";
+
+const dynamoMock = mockClient(DynamoDBDocumentClient);
+const cloudWatchMock = mockClient(CloudWatchClient);
+
+describe("buildDates", () => {
+  test("returns the correct number of dates starting from tomorrow", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+
+    const dates = buildDates(new Date(), 3);
+    expect(dates).toEqual(["2026-01-02", "2026-01-03", "2026-01-04"]);
+
+    vi.useRealTimers();
+  });
+
+  test("returns 180 dates for the full forecast window", () => {
+    const dates = buildDates(new Date(), 180);
+    expect(dates).toHaveLength(180);
+  });
+});
+
+describe("countAccountsForDate", () => {
+  beforeEach(() => {
+    dynamoMock.reset();
+  });
+
+  test("returns the count from a single page", async () => {
+    dynamoMock.on(QueryCommand).resolves({ Count: 42 });
+
+    const count = await countAccountsForDate("my-table", "2026-06-01");
+    expect(count).toBe(42);
+  });
+
+  test("accumulates counts across paginated responses", async () => {
+    dynamoMock
+      .on(QueryCommand)
+      .resolvesOnce({
+        Count: 100,
+        LastEvaluatedKey: { dateForDeletion: "2026-06-01", commonSubjectId: "x" },
+      })
+      .resolvesOnce({ Count: 50 });
+
+    const count = await countAccountsForDate("my-table", "2026-06-01");
+    expect(count).toBe(150);
+    expect(dynamoMock.commandCalls(QueryCommand)).toHaveLength(2);
+  });
+
+  test("returns 0 when Count is undefined", async () => {
+    dynamoMock.on(QueryCommand).resolves({});
+
+    const count = await countAccountsForDate("my-table", "2026-06-01");
+    expect(count).toBe(0);
+  });
+
+  test("throws on DynamoDB error", async () => {
+    dynamoMock.on(QueryCommand).rejects(new Error("DynamoDB failure"));
+
+    await expect(countAccountsForDate("my-table", "2026-06-01")).rejects.toThrow(
+      "DynamoDB failure"
+    );
+  });
+});
+
+describe("publishMetrics", () => {
+  beforeEach(() => {
+    cloudWatchMock.reset();
+  });
+
+  test("sends a single batch when metrics <= 20", async () => {
+    cloudWatchMock.on(PutMetricDataCommand).resolves({});
+
+    const metrics = Array.from({ length: 20 }, (_, i) => ({
+      MetricName: "InactiveAccountsScheduledForDeletion",
+      Dimensions: [{ Name: "DateForDeletion", Value: `2026-0${(i % 9) + 1}-01` }],
+      Value: i,
+      Unit: "Count" as const,
+    }));
+
+    await publishMetrics(metrics);
+    expect(cloudWatchMock.commandCalls(PutMetricDataCommand)).toHaveLength(1);
+  });
+
+  test("batches metrics in groups of 20", async () => {
+    cloudWatchMock.on(PutMetricDataCommand).resolves({});
+
+    const metrics = Array.from({ length: 45 }, (_, i) => ({
+      MetricName: "InactiveAccountsScheduledForDeletion",
+      Dimensions: [{ Name: "DateForDeletion", Value: `2026-01-${String(i + 1).padStart(2, "0")}` }],
+      Value: i,
+      Unit: "Count" as const,
+    }));
+
+    await publishMetrics(metrics);
+    expect(cloudWatchMock.commandCalls(PutMetricDataCommand)).toHaveLength(3);
+  });
+
+  test("throws on CloudWatch error", async () => {
+    cloudWatchMock.on(PutMetricDataCommand).rejects(new Error("CW failure"));
+
+    await expect(
+      publishMetrics([
+        {
+          MetricName: "InactiveAccountsScheduledForDeletion",
+          Dimensions: [{ Name: "DateForDeletion", Value: "2026-06-01" }],
+          Value: 1,
+          Unit: "Count",
+        },
+      ])
+    ).rejects.toThrow("CW failure");
+  });
+});
+
+describe("handler", () => {
+  beforeEach(() => {
+    dynamoMock.reset();
+    cloudWatchMock.reset();
+    process.env.TABLE_NAME = "inactive-accounts-table";
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    delete process.env.TABLE_NAME;
+  });
+
+  test("queries 180 dates and publishes metrics in batches", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+
+    dynamoMock.on(QueryCommand).resolves({ Count: 10 });
+    cloudWatchMock.on(PutMetricDataCommand).resolves({});
+
+    await handler();
+
+    expect(dynamoMock.commandCalls(QueryCommand)).toHaveLength(180);
+    expect(cloudWatchMock.commandCalls(PutMetricDataCommand)).toHaveLength(9); // ceil(180/20)
+
+    vi.useRealTimers();
+  });
+
+  test("throws when TABLE_NAME is not set", async () => {
+    delete process.env.TABLE_NAME;
+
+    await expect(handler()).rejects.toThrow(
+      'Environment variable "TABLE_NAME" is not set.'
+    );
+  });
+
+  test("throws loudly on DynamoDB error", async () => {
+    dynamoMock.on(QueryCommand).rejects(new Error("DynamoDB down"));
+
+    await expect(handler()).rejects.toThrow("DynamoDB down");
+  });
+
+  test("throws loudly on CloudWatch error", async () => {
+    dynamoMock.on(QueryCommand).resolves({ Count: 5 });
+    cloudWatchMock.on(PutMetricDataCommand).rejects(new Error("CW down"));
+
+    await expect(handler()).rejects.toThrow("CW down");
+  });
+});

--- a/src/tests/inactive-account-deletion-forecast.test.ts
+++ b/src/tests/inactive-account-deletion-forecast.test.ts
@@ -1,19 +1,13 @@
 import { vi, describe, test, expect, beforeEach, afterEach } from "vitest";
 import { DynamoDBDocumentClient, QueryCommand } from "@aws-sdk/lib-dynamodb";
-import {
-  CloudWatchClient,
-  PutMetricDataCommand,
-} from "@aws-sdk/client-cloudwatch";
 import { mockClient } from "aws-sdk-client-mock";
 import {
   buildDates,
   countAccountsForDate,
-  publishMetrics,
   handler,
 } from "../inactive-account-deletion-forecast.js";
 
 const dynamoMock = mockClient(DynamoDBDocumentClient);
-const cloudWatchMock = mockClient(CloudWatchClient);
 
 describe("buildDates", () => {
   test("returns the correct number of dates starting from tomorrow", () => {
@@ -74,59 +68,9 @@ describe("countAccountsForDate", () => {
   });
 });
 
-describe("publishMetrics", () => {
-  beforeEach(() => {
-    cloudWatchMock.reset();
-  });
-
-  test("sends a single batch when metrics <= 20", async () => {
-    cloudWatchMock.on(PutMetricDataCommand).resolves({});
-
-    const metrics = Array.from({ length: 20 }, (_, i) => ({
-      MetricName: "InactiveAccountsScheduledForDeletion",
-      Dimensions: [{ Name: "DateForDeletion", Value: `2026-0${(i % 9) + 1}-01` }],
-      Value: i,
-      Unit: "Count" as const,
-    }));
-
-    await publishMetrics(metrics);
-    expect(cloudWatchMock.commandCalls(PutMetricDataCommand)).toHaveLength(1);
-  });
-
-  test("batches metrics in groups of 20", async () => {
-    cloudWatchMock.on(PutMetricDataCommand).resolves({});
-
-    const metrics = Array.from({ length: 45 }, (_, i) => ({
-      MetricName: "InactiveAccountsScheduledForDeletion",
-      Dimensions: [{ Name: "DateForDeletion", Value: `2026-01-${String(i + 1).padStart(2, "0")}` }],
-      Value: i,
-      Unit: "Count" as const,
-    }));
-
-    await publishMetrics(metrics);
-    expect(cloudWatchMock.commandCalls(PutMetricDataCommand)).toHaveLength(3);
-  });
-
-  test("throws on CloudWatch error", async () => {
-    cloudWatchMock.on(PutMetricDataCommand).rejects(new Error("CW failure"));
-
-    await expect(
-      publishMetrics([
-        {
-          MetricName: "InactiveAccountsScheduledForDeletion",
-          Dimensions: [{ Name: "DateForDeletion", Value: "2026-06-01" }],
-          Value: 1,
-          Unit: "Count",
-        },
-      ])
-    ).rejects.toThrow("CW failure");
-  });
-});
-
 describe("handler", () => {
   beforeEach(() => {
     dynamoMock.reset();
-    cloudWatchMock.reset();
     process.env.TABLE_NAME = "inactive-accounts-table";
   });
 
@@ -135,17 +79,15 @@ describe("handler", () => {
     delete process.env.TABLE_NAME;
   });
 
-  test("queries 180 dates and publishes metrics in batches", async () => {
+  test("queries 180 dates and publishes metrics", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
 
     dynamoMock.on(QueryCommand).resolves({ Count: 10 });
-    cloudWatchMock.on(PutMetricDataCommand).resolves({});
 
     await handler();
 
     expect(dynamoMock.commandCalls(QueryCommand)).toHaveLength(180);
-    expect(cloudWatchMock.commandCalls(PutMetricDataCommand)).toHaveLength(9); // ceil(180/20)
 
     vi.useRealTimers();
   });
@@ -162,12 +104,5 @@ describe("handler", () => {
     dynamoMock.on(QueryCommand).rejects(new Error("DynamoDB down"));
 
     await expect(handler()).rejects.toThrow("DynamoDB down");
-  });
-
-  test("throws loudly on CloudWatch error", async () => {
-    dynamoMock.on(QueryCommand).resolves({ Count: 5 });
-    cloudWatchMock.on(PutMetricDataCommand).rejects(new Error("CW down"));
-
-    await expect(handler()).rejects.toThrow("CW down");
   });
 });

--- a/template.yaml
+++ b/template.yaml
@@ -7215,10 +7215,6 @@ Resources:
               - kms:GenerateDataKey*
             Resource:
               - !GetAtt QueueKmsKey.Arn
-          - Effect: Allow
-            Action:
-              - cloudwatch:PutMetricData
-            Resource: "*"
 
   InactiveAccountDeletionForecastFunctionLogGroup:
     Type: AWS::Logs::LogGroup

--- a/template.yaml
+++ b/template.yaml
@@ -7127,6 +7127,123 @@ Resources:
       AlarmActions:
         - !Sub "{{resolve:ssm:/${AlertingStackName}/SNS/LowAlertNotificationTopic/ARN}}"
 
+  #########################################
+  # Inactive Account Deletion Forecast
+  #########################################
+
+  InactiveAccountDeletionForecastFunction:
+    Type: AWS::Serverless::Function
+    DependsOn:
+      - InactiveAccountDeletionForecastFunctionLogGroup
+    Properties:
+      FunctionName: !Sub ${Environment}-${AWS::StackName}-inactive-account-deletion-forecast
+      CodeUri: src
+      PackageType: Zip
+      Timeout: 300
+      Events:
+        DailySchedule:
+          Type: Schedule
+          Properties:
+            Schedule: "cron(0 6 * * ? *)"
+            Enabled: !If [IsDevelopment, true, false]
+      DeadLetterQueue:
+        Type: SQS
+        TargetArn: !GetAtt InactiveAccountDeletionForecastDeadLetterQueue.Arn
+      Handler: inactive-account-deletion-forecast.handler
+      Role: !GetAtt InactiveAccountDeletionForecastRole.Arn
+      Environment:
+        Variables:
+          TABLE_NAME: !Ref InactveAccountTrackerStoreTableName
+          NODE_OPTIONS: --enable-source-maps
+    Metadata:
+      BuildMethod: esbuild
+      BuildProperties:
+        Minify: true
+        Format: "esm"
+        OutExtension:
+          - .js=.mjs
+        Target: "es2022"
+        Sourcemap: true
+        EntryPoints:
+          - inactive-account-deletion-forecast.ts
+        Banner:
+          - js=import { createRequire } from 'module'; const require = createRequire(import.meta.url);
+
+  InactiveAccountDeletionForecastRole:
+    Type: AWS::IAM::Role
+    Properties:
+      PermissionsBoundary: !If
+        - UsePermissionsBoundary
+        - !Ref PermissionsBoundary
+        - !Ref AWS::NoValue
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
+        - !Ref InactiveAccountDeletionForecastPolicy
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - "sts:AssumeRole"
+
+  InactiveAccountDeletionForecastPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - sqs:SendMessage
+            Resource: !GetAtt InactiveAccountDeletionForecastDeadLetterQueue.Arn
+          - Effect: Allow
+            Action:
+              - dynamodb:Query
+            Resource:
+              - !GetAtt InactiveAccountTrackerStore.Arn
+          - Effect: Allow
+            Action:
+              - kms:Decrypt
+            Resource:
+              - !GetAtt DatabaseKmsKey.Arn
+          - Effect: Allow
+            Action:
+              - kms:GenerateDataKey*
+            Resource:
+              - !GetAtt QueueKmsKey.Arn
+          - Effect: Allow
+            Action:
+              - cloudwatch:PutMetricData
+            Resource: "*"
+
+  InactiveAccountDeletionForecastFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/${Environment}-${AWS::StackName}-inactive-account-deletion-forecast"
+      RetentionInDays: 30
+      KmsKeyId: !GetAtt LoggingKmsKey.Arn
+
+  InactiveAccountDeletionForecastCSLSSubscription:
+    Condition: ExportLogsToSplunk
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn: !Sub "{{resolve:ssm:/${Environment}/Platform/Logs/Subscription/CSLS/ARN}}"
+      FilterPattern: ""
+      LogGroupName: !Ref InactiveAccountDeletionForecastFunctionLogGroup
+
+  InactiveAccountDeletionForecastDeadLetterQueue:
+    Type: AWS::SQS::Queue
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Properties:
+      MessageRetentionPeriod: 1209600
+      KmsMasterKeyId: !GetAtt QueueKmsKey.Arn
+
+
 Outputs:
   GeneratorKey:
     Description: A generator key for generating a plaintext data key


### PR DESCRIPTION
## Proposed changes

<!-- Provide a summary of your changes in the title above -->
[OLH-4455]: Publish daily deletion forecast metrics



<!-- Describe the changes in detail - the "what"-->

### What changed?

Created a scheduled Lambda thats fired at 6am each day that queries the InactiveAccountTrackerStore table, counts items in each of the next 180 dateForDeletion partitions, and publishes those counts as a CloudWatch custom metric with a dimension per date.
- Generates array of 180 future dates ["2026-07-22", "2026-07-23", ... "2026-01-17"]
- queries InactiveAccountTrackerStore table for counts for each of the 180 future dates in parallel
- publish metrics Namespace: "account-management-backend"; MetricName: "InactiveAccountsScheduledForDeletion"

### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists

<!-- Merging this PR deploys to production. Please answer accurately. -->

### Environment variables or secrets

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Added parameters to Cloudformation template
- [ ] Added new secret or systems manager parameter
- [ ] Added new environment variable

### Permissions

- [ ] This PR adds or changes permissions

### Monitoring

- [ ] This PR includes changes that need to be monitored in production as the scope of the change could cause issues

## Testing

<!-- Provide a summary of any manual testing you've done, for example deploying the branch to dev -->

## How to review

<!-- Describe any non-standard steps to review this work, or highlight any areas that you'd like the reviewer's opinion on -->


[OLH-4455]: https://govukverify.atlassian.net/browse/OLH-4455?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ