### PR TITLE
BAU: ignore AUTH_TOKEN_SENT_TO_ORCHESTRATION events in save-raw-events handler

### DIFF
--- a/src/save-raw-events.ts
+++ b/src/save-raw-events.ts
@@ -77,6 +77,15 @@ export const handler = async (
     event.Records.map(async (record) => {
       try {
         const txmaEvent: TxmaEvent = JSON.parse(record.body);
+
+        // TODO: Remove once AUTH_TOKEN_SENT_TO_ORCHESTRATION backlog is cleared
+        if (txmaEvent.event_name === "AUTH_TOKEN_SENT_TO_ORCHESTRATION") {
+          logger.info(
+            "Ignoring AUTH_TOKEN_SENT_TO_ORCHESTRATION event - temporary measure to clear backlog"
+          );
+          return;
+        }
+
         validateTxmaEventBody(txmaEvent);
         await writeRawTxmaEvent(txmaEvent);
       } catch (error) {

--- a/src/tests/save-raw-events.test.ts
+++ b/src/tests/save-raw-events.test.ts
@@ -4,6 +4,18 @@ import { SendMessageCommand, SQSClient } from "@aws-sdk/client-sqs";
 import { DynamoDBDocumentClient, PutCommand } from "@aws-sdk/lib-dynamodb";
 import { mockClient } from "aws-sdk-client-mock";
 
+const mockLogger = vi.hoisted(() => ({
+  info: vi.fn(),
+  addContext: vi.fn(),
+}));
+
+vi.mock("@aws-lambda-powertools/logger", () => ({
+  Logger: class {
+    info = mockLogger.info;
+    addContext = mockLogger.addContext;
+  },
+}));
+
 import {
   handler,
   validateTxmaEventBody,
@@ -264,6 +276,65 @@ describe("handler", () => {
         remove_at: 2878106,
       },
     });
+  });
+});
+
+describe("handler ignores AUTH_TOKEN_SENT_TO_ORCHESTRATION events", () => {
+  beforeEach(() => {
+    dynamoMock.reset();
+    process.env.TABLE_NAME = "TABLE_NAME";
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("does not write to DynamoDB and logs info when event_name is AUTH_TOKEN_SENT_TO_ORCHESTRATION", async () => {
+    const ignoredEvent: SQSEvent = {
+      Records: [
+        {
+          ...TEST_SQS_RECORD,
+          body: JSON.stringify({
+            ...makeTxmaEvent(),
+            event_name: "AUTH_TOKEN_SENT_TO_ORCHESTRATION",
+          }),
+        },
+      ],
+    };
+    await handler(ignoredEvent, {} as Context);
+    expect(dynamoMock.commandCalls(PutCommand).length).toEqual(0);
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      "Ignoring AUTH_TOKEN_SENT_TO_ORCHESTRATION event - temporary measure to clear backlog"
+    );
+  });
+
+  test("processes other events normally alongside ignored events", async () => {
+    vi.spyOn(Date, "now").mockImplementation(() => TIMESTAMP);
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    vi.spyOn(crypto, "randomUUID").mockImplementation(() => UUID);
+
+    const mixedEvent: SQSEvent = {
+      Records: [
+        {
+          ...TEST_SQS_RECORD,
+          body: JSON.stringify({
+            ...makeTxmaEvent(),
+            event_name: "AUTH_TOKEN_SENT_TO_ORCHESTRATION",
+          }),
+        },
+        {
+          ...TEST_SQS_RECORD,
+          body: JSON.stringify(makeTxmaEvent()),
+        },
+      ],
+    };
+    await handler(mixedEvent, {} as Context);
+    expect(dynamoMock.commandCalls(PutCommand).length).toEqual(1);
+    expect(mockLogger.info).toHaveBeenCalledTimes(1);
+
+    vi.spyOn(Date, "now").mockRestore();
+    vi.spyOn(crypto, "randomUUID").mockRestore();
   });
 });
 


### PR DESCRIPTION
## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->

### What changed

Ignore the event that cannot yet be processed due to a validation error.

### Why did it change

We need to clear the backlog of events due to INC0019632.

### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists

<!-- Merging this PR deploys to production. Please answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Added parameters to Cloudformation template
- [ ] Added new secret or systems manager parameter
- [ ] Added new environment variable

### Permissions

- [ ] This PR adds or changes permissions

### Monitoring

- [x] This PR includes changes that need to be monitored in production as the scope of the change could cause issues

## Testing

<!-- Provide a summary of any manual testing you've done, for example deploying the branch to dev -->

## How to review

<!-- Describe any non-standard steps to review this work, or highlight any areas that you'd like the reviewer's opinion on -->
