### PR TITLE
BAU: temporarily remove canary alarm

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -614,7 +614,7 @@ Resources:
           Projection:
             ProjectionType: ALL
       BillingMode: PAY_PER_REQUEST
-      TableName: !Ref InactveAccountTrackerStoreTableName      
+      TableName: !Ref InactveAccountTrackerStoreTableName
       KeySchema:
         - AttributeName: dateForDeletion
           KeyType: HASH
@@ -889,7 +889,7 @@ Resources:
         Alarms:
           Fn::If:
             - IsNotDevelopmentOrDemo
-            - - !Ref SaveRawEventsFunctionSuccessRate
+            - - !Ref AWS::NoValue
             - - !Ref AWS::NoValue
     Metadata:
       BuildMethod: esbuild
@@ -3178,11 +3178,7 @@ Resources:
           INACTIVE_ACCOUNT_TRACKER_TABLE_NAME: !Ref InactveAccountTrackerStoreTableName
           USER_NOTIFICATIONS_TABLE_NAME: !Ref UserNotificationsTableName
           OLH_CLIENT_ID:
-            !FindInMap [
-              EnvironmentVariables,
-              !Ref Environment,
-              OLHCLIENTID,
-            ]
+            !FindInMap [EnvironmentVariables, !Ref Environment, OLHCLIENTID]
       DeploymentPreference:
         Alarms:
           Fn::If:
@@ -4203,7 +4199,8 @@ Resources:
       Principal: sns.amazonaws.com
       SourceArn:
         Ref: UserAccountDeletionTopic
-      FunctionName: !Join [":", [!GetAtt DeleteUserNotificationsFunction.Arn, live]]
+      FunctionName:
+        !Join [":", [!GetAtt DeleteUserNotificationsFunction.Arn, live]]
 
   DeleteUserNotificationsRole:
     Type: AWS::IAM::Role
@@ -4451,7 +4448,8 @@ Resources:
     DependsOn: DeleteInactiveAccountTrackerFunctionAliaslive
     Type: AWS::SNS::Subscription
     Properties:
-      Endpoint: !Join [":", [!GetAtt DeleteInactiveAccountTrackerFunction.Arn, live]]
+      Endpoint:
+        !Join [":", [!GetAtt DeleteInactiveAccountTrackerFunction.Arn, live]]
       Protocol: lambda
       RedrivePolicy:
         deadLetterTargetArn: !GetAtt DeleteInactiveAccountTrackerSubscriptionDeadLetterQueue.Arn
@@ -4526,7 +4524,8 @@ Resources:
       Principal: sns.amazonaws.com
       SourceArn:
         Ref: UserAccountDeletionTopic
-      FunctionName: !Join [":", [!GetAtt DeleteInactiveAccountTrackerFunction.Arn, live]]
+      FunctionName:
+        !Join [":", [!GetAtt DeleteInactiveAccountTrackerFunction.Arn, live]]
 
   DeleteInactiveAccountTrackerRole:
     Type: AWS::IAM::Role
@@ -7230,7 +7229,6 @@ Resources:
     Properties:
       MessageRetentionPeriod: 1209600
       KmsMasterKeyId: !GetAtt QueueKmsKey.Arn
-
 
 Outputs:
   GeneratorKey:


### PR DESCRIPTION
Temporarily remove canary alarm from the save raw events function to unblock the pipeline. Will be restored later