### PR TITLE
OLH-4550: Temporarily ignore events with no client ID

### DIFF
--- a/src/save-raw-events.ts
+++ b/src/save-raw-events.ts
@@ -89,10 +89,10 @@ export const handler = async (
       try {
         const txmaEvent: TxmaEvent = JSON.parse(record.body);
 
-        // TODO: Remove once AUTH_TOKEN_SENT_TO_ORCHESTRATION backlog is cleared
-        if (txmaEvent.event_name === "AUTH_TOKEN_SENT_TO_ORCHESTRATION") {
+        // TODO: Remove once backlog of failing events is cleared
+        if (txmaEvent.event_name === "AUTH_TOKEN_SENT_TO_ORCHESTRATION" || txmaEvent.event_name === "AUTH_DELETE_ACCOUNT" || txmaEvent.event_name === "AUTH_UPDATE_EMAIL")  {
           logger.info(
-            "Ignoring AUTH_TOKEN_SENT_TO_ORCHESTRATION event - temporary measure to clear backlog"
+            `Ignoring ${txmaEvent.event_name} event - temporary measure to clear backlog`
           );
           return;
         }

--- a/src/tests/save-raw-events.test.ts
+++ b/src/tests/save-raw-events.test.ts
@@ -279,7 +279,7 @@ describe("handler", () => {
   });
 });
 
-describe("handler ignores AUTH_TOKEN_SENT_TO_ORCHESTRATION events", () => {
+describe("handler ignores events which are temporarily skipped", () => {
   beforeEach(() => {
     dynamoMock.reset();
     process.env.TABLE_NAME = "TABLE_NAME";
@@ -305,6 +305,44 @@ describe("handler ignores AUTH_TOKEN_SENT_TO_ORCHESTRATION events", () => {
     expect(dynamoMock.commandCalls(PutCommand).length).toEqual(0);
     expect(mockLogger.info).toHaveBeenCalledWith(
       "Ignoring AUTH_TOKEN_SENT_TO_ORCHESTRATION event - temporary measure to clear backlog"
+    );
+  });
+
+  test("does not write to DynamoDB and logs info when event_name is AUTH_DELETE_ACCOUNT", async () => {
+    const ignoredEvent: SQSEvent = {
+      Records: [
+        {
+          ...TEST_SQS_RECORD,
+          body: JSON.stringify({
+            ...makeTxmaEvent(),
+            event_name: "AUTH_DELETE_ACCOUNT",
+          }),
+        },
+      ],
+    };
+    await handler(ignoredEvent, {} as Context);
+    expect(dynamoMock.commandCalls(PutCommand).length).toEqual(0);
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      "Ignoring AUTH_DELETE_ACCOUNT event - temporary measure to clear backlog"
+    );
+  });
+
+  test("does not write to DynamoDB and logs info when event_name is AUTH_UPDATE_EMAIL", async () => {
+    const ignoredEvent: SQSEvent = {
+      Records: [
+        {
+          ...TEST_SQS_RECORD,
+          body: JSON.stringify({
+            ...makeTxmaEvent(),
+            event_name: "AUTH_UPDATE_EMAIL",
+          }),
+        },
+      ],
+    };
+    await handler(ignoredEvent, {} as Context);
+    expect(dynamoMock.commandCalls(PutCommand).length).toEqual(0);
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      "Ignoring AUTH_UPDATE_EMAIL event - temporary measure to clear backlog"
     );
   });
 


### PR DESCRIPTION

## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->

### What changed

Temporarily ignore events with no client ID.

### Why did it change

We've subscribed to these events for IAD, but at the moment they're failing validation and causing Lambda errors and filling up the DLQ.

We don't need to save them at the moment as IAD isn't live, so skip over them for now to let us clear the DLQ. We'll then come back and update the validation rules to handle them.

### Related links

https://github.com/govuk-one-login/di-account-management-backend/pull/1110

## Checklists

<!-- Merging this PR deploys to production. Please answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

