### PR TITLE
OLH-4550: Only save events on an allowlist

### DIFF
--- a/src/save-raw-events.ts
+++ b/src/save-raw-events.ts
@@ -21,6 +21,12 @@ const dynamoDocClient = DynamoDBDocumentClient.from(
 );
 const logger = new Logger();
 
+const ALLOWED_EVENT_NAMES = new Set([
+  "AUTH_AUTH_CODE_ISSUED",
+  "AUTH_IPV_AUTHORISATION_REQUESTED",
+  "AUTH_IPV_SUCCESSFUL_IDENTITY_RESPONSE_RECEIVED",
+]);
+
 const getEventId = (): string => {
   return crypto.randomUUID();
 };
@@ -89,10 +95,9 @@ export const handler = async (
       try {
         const txmaEvent: TxmaEvent = JSON.parse(record.body);
 
-        // TODO: Remove once backlog of failing events is cleared
-        if (txmaEvent.event_name === "AUTH_TOKEN_SENT_TO_ORCHESTRATION" || txmaEvent.event_name === "AUTH_DELETE_ACCOUNT" || txmaEvent.event_name === "AUTH_UPDATE_EMAIL")  {
+        if (!ALLOWED_EVENT_NAMES.has(txmaEvent.event_name as string)) {
           logger.info(
-            `Ignoring ${txmaEvent.event_name} event - temporary measure to clear backlog`
+            `Ignoring ${txmaEvent.event_name} event - not in allowlist`
           );
           return;
         }

--- a/src/tests/save-raw-events.test.ts
+++ b/src/tests/save-raw-events.test.ts
@@ -279,7 +279,7 @@ describe("handler", () => {
   });
 });
 
-describe("handler ignores events which are temporarily skipped", () => {
+describe("handler only saves allowlisted events", () => {
   beforeEach(() => {
     dynamoMock.reset();
     process.env.TABLE_NAME = "TABLE_NAME";
@@ -289,7 +289,32 @@ describe("handler ignores events which are temporarily skipped", () => {
     vi.clearAllMocks();
   });
 
-  test("does not write to DynamoDB and logs info when event_name is AUTH_TOKEN_SENT_TO_ORCHESTRATION", async () => {
+  test.each([
+    "AUTH_AUTH_CODE_ISSUED",
+    "AUTH_IPV_AUTHORISATION_REQUESTED",
+    "AUTH_IPV_SUCCESSFUL_IDENTITY_RESPONSE_RECEIVED",
+  ])("writes to DynamoDB when event_name is %s", async (allowedEventName) => {
+    vi.spyOn(Date, "now").mockImplementation(() => TIMESTAMP);
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    vi.spyOn(crypto, "randomUUID").mockImplementation(() => UUID);
+
+    const allowedEvent: SQSEvent = {
+      Records: [
+        {
+          ...TEST_SQS_RECORD,
+          body: JSON.stringify({
+            ...makeTxmaEvent(),
+            event_name: allowedEventName,
+          }),
+        },
+      ],
+    };
+    await handler(allowedEvent, {} as Context);
+    expect(dynamoMock.commandCalls(PutCommand).length).toEqual(1);
+  });
+
+  test("does not write to DynamoDB and logs info when event_name is not in the allowlist", async () => {
     const ignoredEvent: SQSEvent = {
       Records: [
         {
@@ -304,18 +329,18 @@ describe("handler ignores events which are temporarily skipped", () => {
     await handler(ignoredEvent, {} as Context);
     expect(dynamoMock.commandCalls(PutCommand).length).toEqual(0);
     expect(mockLogger.info).toHaveBeenCalledWith(
-      "Ignoring AUTH_TOKEN_SENT_TO_ORCHESTRATION event - temporary measure to clear backlog"
+      "Ignoring AUTH_TOKEN_SENT_TO_ORCHESTRATION event - not in allowlist"
     );
   });
 
-  test("does not write to DynamoDB and logs info when event_name is AUTH_DELETE_ACCOUNT", async () => {
+  test("does not write to DynamoDB and logs info when event_name is missing", async () => {
     const ignoredEvent: SQSEvent = {
       Records: [
         {
           ...TEST_SQS_RECORD,
           body: JSON.stringify({
             ...makeTxmaEvent(),
-            event_name: "AUTH_DELETE_ACCOUNT",
+            event_name: undefined,
           }),
         },
       ],
@@ -323,30 +348,11 @@ describe("handler ignores events which are temporarily skipped", () => {
     await handler(ignoredEvent, {} as Context);
     expect(dynamoMock.commandCalls(PutCommand).length).toEqual(0);
     expect(mockLogger.info).toHaveBeenCalledWith(
-      "Ignoring AUTH_DELETE_ACCOUNT event - temporary measure to clear backlog"
+      "Ignoring undefined event - not in allowlist"
     );
   });
 
-  test("does not write to DynamoDB and logs info when event_name is AUTH_UPDATE_EMAIL", async () => {
-    const ignoredEvent: SQSEvent = {
-      Records: [
-        {
-          ...TEST_SQS_RECORD,
-          body: JSON.stringify({
-            ...makeTxmaEvent(),
-            event_name: "AUTH_UPDATE_EMAIL",
-          }),
-        },
-      ],
-    };
-    await handler(ignoredEvent, {} as Context);
-    expect(dynamoMock.commandCalls(PutCommand).length).toEqual(0);
-    expect(mockLogger.info).toHaveBeenCalledWith(
-      "Ignoring AUTH_UPDATE_EMAIL event - temporary measure to clear backlog"
-    );
-  });
-
-  test("processes other events normally alongside ignored events", async () => {
+  test("processes allowlisted events normally alongside dropped events", async () => {
     vi.spyOn(Date, "now").mockImplementation(() => TIMESTAMP);
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-expect-error
@@ -370,9 +376,6 @@ describe("handler ignores events which are temporarily skipped", () => {
     await handler(mixedEvent, {} as Context);
     expect(dynamoMock.commandCalls(PutCommand).length).toEqual(1);
     expect(mockLogger.info).toHaveBeenCalledTimes(1);
-
-    vi.spyOn(Date, "now").mockRestore();
-    vi.spyOn(crypto, "randomUUID").mockRestore();
   });
 });
 


### PR DESCRIPTION

## Proposed changes

### What changed

Only allow events with an `event_name` on an allowlist through to validation and the rest of the event processing pipelines. All other events are dropped.

### Why did it change

We're being sent some events without an event_name due to a mistake in the consumer config. That means our previous fix to drop events we know don't have a client_id didn't work as it couldn't handle a missing event name. Switch to an explicit allow list and drop all events that aren't on it. This will handle the missing event names now, and also mean we can safely make changes to the consumer config in the future without needing to update this lambda first.

### Related links

https://github.com/govuk-one-login/di-account-management-backend/pull/1114

## Checklists

<!-- Merging this PR deploys to production. Please answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed
