### PR TITLE
OLH-4529: save raw events partial batch processing

### DIFF
--- a/src/save-raw-events.ts
+++ b/src/save-raw-events.ts
@@ -1,4 +1,4 @@
-import { Context, SQSEvent } from "aws-lambda";
+import { Context, SQSBatchResponse, SQSEvent } from "aws-lambda";
 import crypto from "node:crypto";
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import {
@@ -88,8 +88,10 @@ export const writeRawTxmaEvent = async (
 export const handler = async (
   event: SQSEvent,
   context: Context
-): Promise<void> => {
+): Promise<SQSBatchResponse> => {
   logger.addContext(context);
+  const batchItemFailures: { itemIdentifier: string }[] = [];
+
   await Promise.all(
     event.Records.map(async (record) => {
       try {
@@ -105,13 +107,14 @@ export const handler = async (
         validateTxmaEventBody(txmaEvent);
         await writeRawTxmaEvent(txmaEvent);
       } catch (error) {
-        throw new Error(
-          `Unable to save raw events for message with ID: ${record.messageId}, ${
-            (error as Error).message
-          }`,
-          { cause: error }
+        logger.error(
+          `Unable to save raw events for message with ID: ${record.messageId}`,
+          { error }
         );
+        batchItemFailures.push({ itemIdentifier: record.messageId });
       }
     })
   );
+
+  return { batchItemFailures };
 };

--- a/src/tests/save-raw-events.test.ts
+++ b/src/tests/save-raw-events.test.ts
@@ -6,12 +6,14 @@ import { mockClient } from "aws-sdk-client-mock";
 
 const mockLogger = vi.hoisted(() => ({
   info: vi.fn(),
+  error: vi.fn(),
   addContext: vi.fn(),
 }));
 
 vi.mock("@aws-lambda-powertools/logger", () => ({
   Logger: class {
     info = mockLogger.info;
+    error = mockLogger.error;
     addContext = mockLogger.addContext;
   },
 }));
@@ -265,7 +267,7 @@ describe("handler", () => {
   });
 
   test("Adds raw event to the table", async () => {
-    await handler(TEST_SQS_EVENT, {} as Context);
+    const result = await handler(TEST_SQS_EVENT, {} as Context);
     expect(dynamoMock.commandCalls(PutCommand).length).toEqual(1);
     expect(dynamoMock).toHaveReceivedCommandWith(PutCommand, {
       TableName: process.env.TABLE_NAME,
@@ -276,6 +278,7 @@ describe("handler", () => {
         remove_at: 2878106,
       },
     });
+    expect(result).toEqual({ batchItemFailures: [] });
   });
 });
 
@@ -393,15 +396,16 @@ describe("handler error handling", () => {
     vi.clearAllMocks();
   });
 
-  test("logs the error message", async () => {
-    let errorMessage;
-    try {
-      await handler(TEST_SQS_EVENT, {} as Context);
-    } catch (error) {
-      errorMessage = (error as Error).message;
-    }
-    expect(errorMessage).toContain(
-      "Unable to save raw events for message with ID: 19dd0b57-b21e-4ac1-bd88-01bbb068cb78, mock error"
+  test("logs the error and returns the failed message ID in batchItemFailures", async () => {
+    const result = await handler(TEST_SQS_EVENT, {} as Context);
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      "Unable to save raw events for message with ID: 19dd0b57-b21e-4ac1-bd88-01bbb068cb78",
+      expect.objectContaining({ error: expect.anything() })
     );
+    expect(result).toEqual({
+      batchItemFailures: [
+        { itemIdentifier: "19dd0b57-b21e-4ac1-bd88-01bbb068cb78" },
+      ],
+    });
   });
 });

--- a/template.yaml
+++ b/template.yaml
@@ -877,6 +877,7 @@ Resources:
               - !GetAtt TxMAInputDummyQueue.Arn
               - !FindInMap [InputQueue, !Ref Environment, QueueArn]
             BatchSize: 100
+            MaximumBatchingWindowInSeconds: 10
             FunctionResponseTypes:
               - ReportBatchItemFailures
       DeadLetterQueue:

--- a/template.yaml
+++ b/template.yaml
@@ -867,6 +867,7 @@ Resources:
       CodeUri: src
       PackageType: Zip
       MemorySize: 220
+      Timeout: 30
       Events:
         InputQueue:
           Type: SQS
@@ -875,6 +876,9 @@ Resources:
               - UseInternalEvents
               - !GetAtt TxMAInputDummyQueue.Arn
               - !FindInMap [InputQueue, !Ref Environment, QueueArn]
+            BatchSize: 100
+            FunctionResponseTypes:
+              - ReportBatchItemFailures
       DeadLetterQueue:
         Type: SQS
         TargetArn: !GetAtt SaveRawEventsDeadLetterQueue.Arn


### PR DESCRIPTION
Updates the save raw events function to support partial batch processing. This means that only failed messages are retried, not the whole batch.

Increased the batch size to 100 and set the function timeout to 30 seconds.

This has been tested by deploying to dev and manually testing the lambda in the AWS console. I can confirm I have seen successful responses where `batchItemFailures` is an empty array because all messages were processed. I have also seen unsuccessful responses where `batchItemFailures` contains items because there were bad events in the payload.