### PR TITLE
OLH-4504: Updated lambdas to follow the new schema

### DIFF
--- a/src/common/model.ts
+++ b/src/common/model.ts
@@ -215,13 +215,21 @@ export type InactiveAccountStatus = "pending" | "deleting" | "30DayWarningSent" 
 export interface InactiveAccountTrackerRecord {
   dateForDeletion: string;
   commonSubjectId: string;
-  publicSubjectId?: string;
-  emailAddress: string;
-  userLastActive: string;
+  publicSubjectId: string;
+
   status: InactiveAccountStatus;
   statusLastUpdated: string;
-  source: string;
-  sourceId?: string;
+  userLastActive: string;
+  userLastActiveSource: string;
+  userLastActiveSourceId?: string;
+  userLastActiveUpdated: string;
+
+  emailAddress: string;
+  emailAddressLastUpdated: string;
+  emailAddressSource: string;
+  emailAddressSourceId?: string;
+
+  hasSetupMfa: boolean;
 }
 
 export class DroppedEventError extends Error {

--- a/src/tests/query-and-dispatch-inactive-accounts.test.ts
+++ b/src/tests/query-and-dispatch-inactive-accounts.test.ts
@@ -16,10 +16,16 @@ const sqsMock = mockClient(SQSClient);
 const mockRecord = {
   dateForDeletion: "2026-06-20",
   commonSubjectId: "user-1",
+  publicSubjectId: "public-subject-1",
   emailAddress: "test@example.com",
   userLastActive: "2021-06-20T00:00:00.000Z",
+  userLastActiveSource: "AUTH_AUTH_CODE_ISSUED",
+  userLastActiveUpdated: "2026-01-01T00:00:00.000Z",
+  emailAddressSource: "AUTH_AUTH_CODE_ISSUED",
+  emailAddressLastUpdated: "2026-01-01T00:00:00.000Z",
   status: "pending",
   statusLastUpdated: "2026-01-01T00:00:00.000Z",
+  hasSetupMfa: false,
 };
 
 describe("validateEvent", () => {

--- a/src/tests/update-inactive-account-tracker.test.ts
+++ b/src/tests/update-inactive-account-tracker.test.ts
@@ -55,7 +55,7 @@ describe("UpdateInactiveAccountTracker handler", () => {
         expect.objectContaining({
           Put: expect.objectContaining({
             TableName: "test-table",
-            Item: expect.objectContaining({ commonSubjectId: "qwerty", status: "pending", source: "txma_audit_event", sourceId: "event_id" }),
+            Item: expect.objectContaining({ commonSubjectId: "qwerty", status: "pending", userLastActiveSource: "AUTH_AUTH_CODE_ISSUED", userLastActiveSourceId: "event_id", emailAddressSource: "AUTH_AUTH_CODE_ISSUED", emailAddressSourceId: "event_id" }),
           }),
         }),
       ]),
@@ -322,7 +322,7 @@ describe("UpdateInactiveAccountTracker handler", () => {
     });
   });
 
-  test("omits publicSubjectId from tracker record when absent from both event and existing record", async () => {
+  test("sets publicSubjectId to empty string when absent from both event and existing record", async () => {
     dynamoMock.on(QueryCommand).resolves({ Items: [] });
     dynamoMock.on(TransactWriteCommand).resolves({});
     const recordWithoutPublicSubjectId = {
@@ -345,7 +345,7 @@ describe("UpdateInactiveAccountTracker handler", () => {
       TransactItems: expect.arrayContaining([
         expect.objectContaining({
           Put: expect.objectContaining({
-            Item: expect.not.objectContaining({ publicSubjectId: expect.anything() }),
+            Item: expect.objectContaining({ publicSubjectId: "" }),
           }),
         }),
       ]),

--- a/src/update-inactive-account-tracker.ts
+++ b/src/update-inactive-account-tracker.ts
@@ -45,6 +45,95 @@ const getDateForDeletion = (latestDate: Date): string => {
   return deletionDate.toISOString().split("T")[0];
 }
 
+const buildTransactionItems = (
+  tableName: string,
+  userNotificationsTableName: string,
+  olhClientId: string,
+  userId: string,
+  newItem: InactiveAccountTrackerRecord,
+  currentTrackerRecord: InactiveAccountTrackerRecord | null,
+  txmaEvent: TxmaEvent
+): TransactionItems => {
+  const items: TransactionItems = [
+    { Put: { TableName: tableName, Item: newItem as unknown as Record<string, unknown> } },
+  ];
+
+  if (currentTrackerRecord && currentTrackerRecord.dateForDeletion !== newItem.dateForDeletion) {
+    // if the dates are the same, then we don't need to delete the old record as
+    // it would have been updated in place by the Put command
+    items.push({
+      Delete: { TableName: tableName, Key: { dateForDeletion: currentTrackerRecord.dateForDeletion, commonSubjectId: userId } }
+    });
+  }
+
+  if (txmaEvent.client_id !== olhClientId) {
+    // if the user logs in to a different RP, then we won't show them the account kept notificaton
+    // when they log in to Home
+    items.push({
+      Delete: {
+        TableName: userNotificationsTableName,
+        Key: { internalCommonSubjectId: userId },
+      },
+    });
+  }
+
+  return items;
+};
+
+const processRecord = async (
+  txmaEvent: TxmaEvent,
+  tableName: string,
+  userNotificationsTableName: string,
+  olhClientId: string
+): Promise<void> => {
+  const userId = txmaEvent.user?.user_id;
+  assert(userId !== undefined, "user_id is undefined in the event");
+
+  if (txmaEvent.user?.email === undefined) {
+    logger.warn(`AUTH_EVENT_NO_EMAIL for userId ${userId}`);
+  }
+
+  const currentTrackerRecord = await getCurrentRecordForUser(userId, tableName);
+
+  if (currentTrackerRecord?.status === 'deleting') {
+    logger.warn(`AUTH_EVENT_ON_DELETING_ACCOUNT ${userId}`);
+    return;
+  }
+
+  const email = txmaEvent.user?.email ?? currentTrackerRecord?.emailAddress ?? "";
+  const latestDate = getLatestDate(txmaEvent, currentTrackerRecord);
+  const publicSubjectId = txmaEvent.user?.public_subject_id ?? currentTrackerRecord?.publicSubjectId ?? "";
+  const now = new Date().toISOString();
+  const isNewLatestDate = new Date(txmaEvent.timestamp * 1000) > (currentTrackerRecord ? new Date(currentTrackerRecord.userLastActive) : new Date(0));
+
+  const newItem: InactiveAccountTrackerRecord = {
+    commonSubjectId: userId,
+    publicSubjectId,
+    userLastActive: latestDate.toISOString(),
+    userLastActiveSource: txmaEvent.event_name,
+    ...(txmaEvent.event_id && { userLastActiveSourceId: txmaEvent.event_id }),
+    userLastActiveUpdated: isNewLatestDate ? now : (currentTrackerRecord?.userLastActiveUpdated ?? now),
+    dateForDeletion: getDateForDeletion(latestDate),
+    emailAddress: email,
+    emailAddressSource: txmaEvent.event_name,
+    ...(txmaEvent.event_id && { emailAddressSourceId: txmaEvent.event_id }),
+    emailAddressLastUpdated: txmaEvent.user?.email ? now : (currentTrackerRecord?.emailAddressLastUpdated ?? now),
+    status: 'pending',
+    statusLastUpdated: now,
+    hasSetupMfa: currentTrackerRecord?.hasSetupMfa ?? false,
+  };
+
+  const transactionItems = buildTransactionItems(tableName, userNotificationsTableName, olhClientId, userId, newItem, currentTrackerRecord, txmaEvent);
+
+  try {
+    await dynamoDocClient.send(new TransactWriteCommand({ TransactItems: transactionItems }));
+  } catch (error) {
+    throw new Error(`Failed to update inactive account tracker for user ${userId} ${error}`, {
+      cause: error
+    });
+  }
+};
+
 export const handler = async (
   event: DynamoDBStreamEvent,
   context: Context
@@ -59,72 +148,7 @@ export const handler = async (
     const txmaEvent = unmarshall(
       record.dynamodb?.NewImage?.event.M as Record<string, AttributeValue>
     ) as TxmaEvent;
-    
-    const userId = txmaEvent.user?.user_id;
-    assert(userId !== undefined, "user_id is undefined in the event");
-    if (txmaEvent.user?.email === undefined) {
-      logger.warn(`AUTH_EVENT_NO_EMAIL for userId ${userId}`)
-    }
-    
-    const currentTrackerRecord = await getCurrentRecordForUser(userId, tableName);
-    const email = txmaEvent.user?.email ?? currentTrackerRecord?.emailAddress ?? "";
-    const latestDate = getLatestDate(txmaEvent, currentTrackerRecord);
 
-    if (currentTrackerRecord?.status === 'deleting') {
-      logger.warn(`AUTH_EVENT_ON_DELETING_ACCOUNT ${userId}`)
-      return;
-    }
-
-    const publicSubjectId = txmaEvent.user?.public_subject_id ?? currentTrackerRecord?.publicSubjectId ?? "";
-    const now = new Date().toISOString();
-    const isNewLatestDate = new Date(txmaEvent.timestamp * 1000) > (currentTrackerRecord ? new Date(currentTrackerRecord.userLastActive) : new Date(0));
-
-    const newItem: InactiveAccountTrackerRecord = {
-      commonSubjectId: userId,
-      publicSubjectId,
-      userLastActive: latestDate.toISOString(),
-      userLastActiveSource: txmaEvent.event_name,
-      ...(txmaEvent.event_id && { userLastActiveSourceId: txmaEvent.event_id }),
-      userLastActiveUpdated: isNewLatestDate ? now : (currentTrackerRecord?.userLastActiveUpdated ?? now),
-      dateForDeletion: getDateForDeletion(latestDate),
-      emailAddress: email,
-      emailAddressSource: txmaEvent.event_name,
-      ...(txmaEvent.event_id && { emailAddressSourceId: txmaEvent.event_id }),
-      emailAddressLastUpdated: txmaEvent.user?.email ? now : (currentTrackerRecord?.emailAddressLastUpdated ?? now),
-      status: 'pending',
-      statusLastUpdated: now,
-      hasSetupMfa: currentTrackerRecord?.hasSetupMfa ?? false,
-    }
-
-    const transactionItems: TransactionItems = [
-      { Put: { TableName: tableName, Item: newItem as unknown as Record<string, unknown> } },
-    ];
-
-    if (currentTrackerRecord && currentTrackerRecord.dateForDeletion !== newItem.dateForDeletion) {
-      // if the dates are the same, then we don't need to delete the old record as
-      // it would have been updated in place by the Put command
-      transactionItems.push({
-        Delete: { TableName: tableName, Key: { dateForDeletion: currentTrackerRecord.dateForDeletion, commonSubjectId: userId } }
-      });
-    }
-
-    if (txmaEvent.client_id !== olhClientId) {
-      // if the user logs in to a different RP, then we won't show them the account kept notificaton
-      // when they log in to Home
-      transactionItems.push({
-        Delete: {
-          TableName: userNotificationsTableName,
-          Key: { internalCommonSubjectId: userId },
-        },
-      });
-    }
-
-    try {
-      await dynamoDocClient.send(new TransactWriteCommand({ TransactItems: transactionItems }));
-    } catch (error) {
-      throw new Error(`Failed to update inactive account tracker for user ${userId} ${error}`, {
-        cause: error
-      });
-    }
+    await processRecord(txmaEvent, tableName, userNotificationsTableName, olhClientId);
   }
 };

--- a/src/update-inactive-account-tracker.ts
+++ b/src/update-inactive-account-tracker.ts
@@ -75,18 +75,25 @@ export const handler = async (
       return;
     }
 
-    const publicSubjectId = txmaEvent.user?.public_subject_id ?? currentTrackerRecord?.publicSubjectId;
+    const publicSubjectId = txmaEvent.user?.public_subject_id ?? currentTrackerRecord?.publicSubjectId ?? "";
+    const now = new Date().toISOString();
+    const isNewLatestDate = new Date(txmaEvent.timestamp * 1000) > (currentTrackerRecord ? new Date(currentTrackerRecord.userLastActive) : new Date(0));
 
     const newItem: InactiveAccountTrackerRecord = {
       commonSubjectId: userId,
-      ...(publicSubjectId && { publicSubjectId }),
+      publicSubjectId,
       userLastActive: latestDate.toISOString(),
+      userLastActiveSource: txmaEvent.event_name,
+      ...(txmaEvent.event_id && { userLastActiveSourceId: txmaEvent.event_id }),
+      userLastActiveUpdated: isNewLatestDate ? now : (currentTrackerRecord?.userLastActiveUpdated ?? now),
       dateForDeletion: getDateForDeletion(latestDate),
       emailAddress: email,
+      emailAddressSource: txmaEvent.event_name,
+      ...(txmaEvent.event_id && { emailAddressSourceId: txmaEvent.event_id }),
+      emailAddressLastUpdated: txmaEvent.user?.email ? now : (currentTrackerRecord?.emailAddressLastUpdated ?? now),
       status: 'pending',
-      statusLastUpdated: new Date().toISOString(),
-      source: "txma_audit_event",
-      sourceId: txmaEvent.event_id,
+      statusLastUpdated: now,
+      hasSetupMfa: currentTrackerRecord?.hasSetupMfa ?? false,
     }
 
     const transactionItems: TransactionItems = [


### PR DESCRIPTION
## Proposed changes

<!-- Provide a summary of your changes in the title above -->
[OLH-4504]: Updated lambdas to follow the new schema

### What changed

Updated the InactiveAccountTrackerRecord schema to separately track where userLastActive and emailAddress data came from, replacing the single source/sourceId pair with independent source fields for each. We also made publicSubjectId required and added hasSetupMfa to support downstream notification decisions. The changes were applied to the model, the update-inactive-account-tracker lambda (the only one that constructs the record), and the relevant tests — all 326 tests pass before and after the rebase.


### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists

<!-- Merging this PR deploys to production. Please answer accurately. -->

### Environment variables or secrets

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Added parameters to Cloudformation template
- [ ] Added new secret or systems manager parameter
- [ ] Added new environment variable

### Permissions

- [ ] This PR adds or changes permissions

### Monitoring

- [ ] This PR includes changes that need to be monitored in production as the scope of the change could cause issues

## Testing

1. Inserted a test TxMA event into the raw events DynamoDB table with event type AUTH_TOKEN_SENT_TO_ORCHESTRATION
2. Confirmed the DynamoDB stream triggered the update-inactive-account-tracker lambda by observing the record count in inactive_account_tracker go from 18 to 19
3. Located the new record by commonSubjectId and verified all new schema fields were correctly populated:
    - userLastActiveSource and emailAddressSource = AUTH_TOKEN_SENT_TO_ORCHESTRATION
    - userLastActiveSourceId and emailAddressSourceId = the event ID from the test record
    - userLastActiveUpdated and emailAddressLastUpdated = timestamp of when the lambda ran
    - publicSubjectId = value from the test event
    - hasSetupMfa = false
    - dateForDeletion = 2030-01-01 (5 years from the event timestamp)

## How to review

<!-- Describe any non-standard steps to review this work, or highlight any areas that you'd like the reviewer's opinion on -->


[OLH-4504]: https://govukverify.atlassian.net/browse/OLH-4504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ