### PR TITLE
BAU: Integration test batch resilience

### DIFF
--- a/pre-merge-integration-tests/api_call.py
+++ b/pre-merge-integration-tests/api_call.py
@@ -1,9 +1,11 @@
 import time
 import json
 import uuid
+import threading
 import boto3
 import os
 import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from botocore.exceptions import ClientError
 from boto3.dynamodb.conditions import Key
 
@@ -14,8 +16,13 @@ dynamodb = boto3.resource('dynamodb')
 QUEUE_URL = os.getenv('SQS_QUEUE_ARN')
 ACTIVITY_LOG_TABLE = 'activity_log'
 USER_SERVICES_TABLE = 'user_services'
-RAW_EVENTS_TABLE = 'raw_events'
 INACTIVE_ACCOUNT_TRACKER_TABLE = 'inactive_account_tracker_store'
+
+
+# --- Logging ---
+
+def log(test_id, message):
+    print(f"  [{test_id}] {message}")
 
 
 # --- Helpers ---
@@ -29,54 +36,28 @@ def generate_event_id():
     return str(uuid.uuid4())
 
 
-def send_message(queue_url, body):
+def send_message(queue_url, body, test_id=""):
     message_body = json.dumps(body) if isinstance(body, dict) else body
-    print(f"  Sending message to queue: {queue_url}")
+    log(test_id, "Sending message to queue")
     try:
         response = sqs.send_message(
             QueueUrl=queue_url,
             MessageBody=message_body,
         )
-        print(f"  Message sent with Message ID: {response['MessageId']}")
+        log(test_id, f"Message sent with ID: {response['MessageId']}")
         return response
     except Exception as e:
-        print(f"  Error sending message: {str(e)}")
+        log(test_id, f"Error sending message: {str(e)}")
         raise
 
 
-# SQS send_message_batch supports a maximum of 10 messages per call
-def send_batch(queue_url, bodies):
-    entries = []
-    for i, body in enumerate(bodies):
-        message_body = json.dumps(body) if isinstance(body, dict) else body
-        entries.append({
-            'Id': str(i),
-            'MessageBody': message_body,
-        })
-    print(f"  Sending batch of {len(entries)} messages to queue")
-    try:
-        response = sqs.send_message_batch(
-            QueueUrl=queue_url,
-            Entries=entries,
-        )
-        successful = response.get('Successful', [])
-        failed = response.get('Failed', [])
-        print(f"  Batch sent: {len(successful)} successful, {len(failed)} failed")
-        if failed:
-            raise Exception(f"Failed to send {len(failed)} messages: {failed}")
-        return response
-    except Exception as e:
-        print(f"  Error sending batch: {str(e)}")
-        raise
-
-
-def poll_for_item(table_name, key_condition, index_name=None, timeout=30):
+def poll_for_item(table_name, key_condition, index_name=None, timeout=30, test_id=""):
     delay = 1
     max_attempts = int(timeout / delay)
     table = dynamodb.Table(table_name)
 
     for attempt in range(1, max_attempts + 1):
-        print(f"  Polling {table_name} (attempt {attempt}/{max_attempts})...")
+        log(test_id, f"Polling {table_name} (attempt {attempt}/{max_attempts})...")
         try:
             query_params = {
                 'KeyConditionExpression': key_condition,
@@ -87,25 +68,27 @@ def poll_for_item(table_name, key_condition, index_name=None, timeout=30):
             response = table.query(**query_params)
             items = response.get('Items', [])
             if items:
-                print(f"  Found {len(items)} item(s)")
+                log(test_id, f"Found {len(items)} item(s)")
                 return items[0]
         except ClientError as e:
-            print(f"  Query error: {e.response['Error']['Message']}")
+            log(test_id, f"Query error: {e.response['Error']['Message']}")
 
         time.sleep(delay)
 
     return None
 
 
-def assert_item_exists(table_name, key_condition, index_name=None, timeout=30, description="item"):
-    item = poll_for_item(table_name, key_condition, index_name=index_name, timeout=timeout)
+def assert_item_exists(table_name, key_condition, index_name=None, timeout=30, description="item", test_id=""):
+    item = poll_for_item(table_name, key_condition, index_name=index_name, timeout=timeout, test_id=test_id)
     if item is None:
         raise AssertionError(f"Expected {description} in {table_name} but not found after {timeout}s")
     return item
 
 
-def assert_no_item(table_name, key_condition, index_name=None, wait=5, description="item"):
-    print(f"  Waiting {wait}s before checking {table_name} for absence of {description}...")
+# The wait time assumes max Lambda processing time is under 10s.
+# If the architecture changes (e.g. Step Functions), this may need increasing.
+def assert_no_item(table_name, key_condition, index_name=None, wait=10, description="item", test_id=""):
+    log(test_id, f"Waiting {wait}s before checking absence of {description}...")
     time.sleep(wait)
     table = dynamodb.Table(table_name)
     try:
@@ -121,22 +104,22 @@ def assert_no_item(table_name, key_condition, index_name=None, wait=5, descripti
             raise AssertionError(
                 f"Expected no {description} in {table_name} but found {len(items)} item(s): {items[0]}"
             )
-        print(f"  Confirmed: no {description} found in {table_name}")
+        log(test_id, f"Confirmed: no {description} found")
     except ClientError as e:
-        print(f"  Query error during assert_no_item: {e.response['Error']['Message']}")
+        log(test_id, f"Query error during assert_no_item: {e.response['Error']['Message']}")
         raise
 
 
-def delete_item(table_name, key):
+def delete_item(table_name, key, test_id=""):
     table = dynamodb.Table(table_name)
     try:
         table.delete_item(Key=key)
-        print(f"  Deleted item from {table_name}: {key}")
+        log(test_id, f"Deleted from {table_name}: {key}")
     except ClientError as e:
-        print(f"  Warning: error deleting from {table_name}: {e.response['Error']['Message']}")
+        log(test_id, f"Warning: error deleting from {table_name}: {e.response['Error']['Message']}")
 
 
-def delete_items_by_index(table_name, key_condition, index_name, key_fields):
+def delete_items_by_index(table_name, key_condition, index_name, key_fields, test_id=""):
     table = dynamodb.Table(table_name)
     try:
         response = table.query(
@@ -146,9 +129,9 @@ def delete_items_by_index(table_name, key_condition, index_name, key_fields):
         for item in response.get('Items', []):
             key = {field: item[field] for field in key_fields if field in item}
             table.delete_item(Key=key)
-            print(f"  Deleted item from {table_name}: {key}")
+            log(test_id, f"Deleted from {table_name}: {key}")
     except ClientError as e:
-        print(f"  Warning: error during cleanup of {table_name}: {e.response['Error']['Message']}")
+        log(test_id, f"Warning: error during cleanup of {table_name}: {e.response['Error']['Message']}")
 
 
 # --- Test Runner ---
@@ -157,12 +140,15 @@ class TestResults:
     def __init__(self):
         self.passed = []
         self.failed = []
+        self._lock = threading.Lock()
 
     def record_pass(self, name, duration):
-        self.passed.append((name, duration))
+        with self._lock:
+            self.passed.append((name, duration))
 
     def record_fail(self, name, duration, error):
-        self.failed.append((name, duration, error))
+        with self._lock:
+            self.failed.append((name, duration, error))
 
     def summary(self):
         total = len(self.passed) + len(self.failed)
@@ -184,31 +170,38 @@ class TestResults:
 
 
 def run_test(name, fn, results):
-    separator = "-" * 60
-    print(f"\n{separator}")
-    print(f"TEST: {name}")
-    print(separator)
+    test_id = name
+    log(test_id, "STARTED")
     start = time.time()
     try:
-        fn()
+        fn(test_id)
         duration = time.time() - start
         results.record_pass(name, duration)
-        print(f"  PASS ({duration:.1f}s)")
+        log(test_id, f"PASS ({duration:.1f}s)")
     except Exception as e:
         duration = time.time() - start
         results.record_fail(name, duration, str(e))
-        print(f"  FAIL ({duration:.1f}s): {e}")
+        log(test_id, f"FAIL ({duration:.1f}s): {e}")
+
+
+def run_tests_parallel(test_cases, results, max_workers=5):
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        futures = {
+            executor.submit(run_test, name, fn, results): name
+            for name, fn in test_cases
+        }
+        for future in as_completed(futures):
+            future.result()
 
 
 # --- Tests ---
 
-def test_auth_code_issued_creates_activity_log():
+def test_auth_code_issued_creates_activity_log(test_id):
     user_id = generate_user_id("auth-code-issued")
     event_id = generate_event_id()
     client_id = "vehicleOperatorLicense"
     timestamp = 1730800548523
 
-    # Setup: create user services entry
     table = dynamodb.Table(USER_SERVICES_TABLE)
     table.put_item(Item={
         "user_id": user_id,
@@ -223,7 +216,6 @@ def test_auth_code_issued_creates_activity_log():
     })
 
     try:
-        # Send event
         send_message(QUEUE_URL, {
             "event_name": "AUTH_AUTH_CODE_ISSUED",
             "event_id": event_id,
@@ -233,22 +225,21 @@ def test_auth_code_issued_creates_activity_log():
             },
             "client_id": client_id,
             "timestamp": timestamp,
-        })
+        }, test_id=test_id)
 
-        # Assert activity log created
         assert_item_exists(
             ACTIVITY_LOG_TABLE,
             Key('user_id').eq(user_id) & Key('event_id').eq(event_id),
             timeout=30,
             description=f"activity log for user {user_id}",
+            test_id=test_id,
         )
     finally:
-        # Teardown
-        delete_item(ACTIVITY_LOG_TABLE, {'event_id': event_id, 'user_id': user_id})
-        delete_item(USER_SERVICES_TABLE, {'user_id': user_id})
+        delete_item(ACTIVITY_LOG_TABLE, {'event_id': event_id, 'user_id': user_id}, test_id=test_id)
+        delete_item(USER_SERVICES_TABLE, {'user_id': user_id}, test_id=test_id)
 
 
-def test_unknown_event_is_silently_dropped():
+def test_unknown_event_is_silently_dropped(test_id):
     """An event with an unrecognised event_name should not produce any
     downstream records."""
     user_id = generate_user_id("unknown-event")
@@ -263,13 +254,13 @@ def test_unknown_event_is_silently_dropped():
         },
         "client_id": "vehicleOperatorLicense",
         "timestamp": 1730800548523,
-    })
+    }, test_id=test_id)
 
     assert_no_item(
         ACTIVITY_LOG_TABLE,
         Key('user_id').eq(user_id) & Key('event_id').eq(event_id),
-        wait=10,
         description=f"activity log for unknown event user {user_id}",
+        test_id=test_id,
     )
 
 
@@ -281,21 +272,16 @@ if __name__ == "__main__":
         sys.exit(1)
 
     print(f"Queue URL: {QUEUE_URL}")
-    print("Starting pre-merge integration tests...")
+    print("Starting pre-merge integration tests (parallel)...")
 
     results = TestResults()
 
-    run_test(
-        "AUTH_AUTH_CODE_ISSUED creates activity log entry",
-        test_auth_code_issued_creates_activity_log,
-        results,
-    )
+    test_cases = [
+        ("auth-code-issued", test_auth_code_issued_creates_activity_log),
+        ("unknown-event-dropped", test_unknown_event_is_silently_dropped),
+    ]
 
-    run_test(
-        "Unknown event is silently dropped (no activity log)",
-        test_unknown_event_is_silently_dropped,
-        results,
-    )
+    run_tests_parallel(test_cases, results)
 
     all_passed = results.summary()
     sys.exit(0 if all_passed else 1)

--- a/pre-merge-integration-tests/api_call.py
+++ b/pre-merge-integration-tests/api_call.py
@@ -248,6 +248,31 @@ def test_auth_code_issued_creates_activity_log():
         delete_item(USER_SERVICES_TABLE, {'user_id': user_id})
 
 
+def test_unknown_event_is_silently_dropped():
+    """An event with an unrecognised event_name should not produce any
+    downstream records."""
+    user_id = generate_user_id("unknown-event")
+    event_id = generate_event_id()
+
+    send_message(QUEUE_URL, {
+        "event_name": "FABRICATED_EVENT_NAME",
+        "event_id": event_id,
+        "user": {
+            "user_id": user_id,
+            "session_id": "7340477f-74da-46d4-9400-d22ae518da3a"
+        },
+        "client_id": "vehicleOperatorLicense",
+        "timestamp": 1730800548523,
+    })
+
+    assert_no_item(
+        ACTIVITY_LOG_TABLE,
+        Key('user_id').eq(user_id) & Key('event_id').eq(event_id),
+        wait=10,
+        description=f"activity log for unknown event user {user_id}",
+    )
+
+
 # --- Main ---
 
 if __name__ == "__main__":
@@ -263,6 +288,12 @@ if __name__ == "__main__":
     run_test(
         "AUTH_AUTH_CODE_ISSUED creates activity log entry",
         test_auth_code_issued_creates_activity_log,
+        results,
+    )
+
+    run_test(
+        "Unknown event is silently dropped (no activity log)",
+        test_unknown_event_is_silently_dropped,
         results,
     )
 


### PR DESCRIPTION
## Proposed changes

### What changed
  
- Added integration test asserting unknown/non-allowlisted events are silently dropped (no downstream records created)
- Tests now run in parallel via ThreadPoolExecutor with test-id-prefixed log lines for traceability
- TestResults uses threading lock for thread safety in parallel execution

### Why did it change

We had no integration test coverage for event rejection behaviour. These tests confirm the system correctly rejects what it should and remains resilient to bad messages in a batch. 
  
### Related links
  
- Stacks on https://github.com/govuk-one-login/di-account-management-backend/pull/1119

## Checklists

### Environment variables or secrets
  
- [x] No environment variables or secrets were added or changed
    
### Monitoring
  
- [ ] This PR includes changes that need to be monitored in production as the scope of the change could cause issues
  
## How to review

- Review this commit by commit. 
- See the action passes when run, like https://github.com/govuk-one-login/di-account-management-backend/actions/runs/30636144534
