### PR TITLE
OLH-4527: Historic millisecond timestamp workaround

### DIFF
--- a/src/tests/update-inactive-account-tracker.test.ts
+++ b/src/tests/update-inactive-account-tracker.test.ts
@@ -193,6 +193,7 @@ describe("UpdateInactiveAccountTracker handler", () => {
           event: {
             M: {
               client_id: { S: "test-client" },
+              timestamp: { N: "1711929600" },
               user: {
                 M: {
                   user_id: { S: "qwerty" },
@@ -230,6 +231,7 @@ describe("UpdateInactiveAccountTracker handler", () => {
           event: {
             M: {
               client_id: { S: "test-client" },
+              timestamp: { N: "1711929600" },
               user: {
                 M: {
                   user_id: { S: "qwerty" }
@@ -362,6 +364,7 @@ describe("UpdateInactiveAccountTracker handler", () => {
           event: {
             M: {
               client_id: { S: "test-client" },
+              timestamp: { N: "1711929600" },
               user: {
                 M: {
                   user_id: { S: "qwerty" }
@@ -385,5 +388,64 @@ describe("UpdateInactiveAccountTracker handler", () => {
       ]),
     });
     expect(loggerWarnMock).toHaveBeenCalledWith("AUTH_EVENT_NO_EMAIL for userId qwerty");
+  });
+
+  test("converts historic millisecond timestamps to seconds", async () => {
+    const msTimestamp = 1711929600000; 
+    const expectedLastActive = "2024-04-01T00:00:00.000Z";
+    const expectedDeletionDate = "2029-04-01";
+
+    const streamRecord = generateDynamoStreamRecord("test-client");
+    if (streamRecord.dynamodb?.NewImage?.event?.M) {
+      streamRecord.dynamodb.NewImage.event.M.timestamp = { N: msTimestamp.toString() };
+    }
+
+    dynamoMock.on(QueryCommand).resolves({ Items: [] });
+    dynamoMock.on(TransactWriteCommand).resolves({});
+
+    const event: DynamoDBStreamEvent = { Records: [streamRecord] };
+    await handler(event, {} as Context);
+
+    expect(dynamoMock).toHaveReceivedCommandWith(TransactWriteCommand, {
+      TransactItems: expect.arrayContaining([
+        expect.objectContaining({
+          Put: expect.objectContaining({
+            TableName: "test-table",
+            Item: expect.objectContaining({ 
+              userLastActive: expectedLastActive,
+              dateForDeletion: expectedDeletionDate
+            }),
+          }),
+        }),
+      ]),
+    });
+  });
+
+  test("leaves valid second-based timestamps untouched", async () => {
+    const secondsTimestamp = 1711929600; 
+    const expectedLastActive = "2024-04-01T00:00:00.000Z";
+
+    const streamRecord = generateDynamoStreamRecord("test-client");
+    if (streamRecord.dynamodb?.NewImage?.event?.M) {
+      streamRecord.dynamodb.NewImage.event.M.timestamp = { N: secondsTimestamp.toString() };
+    }
+
+    dynamoMock.on(QueryCommand).resolves({ Items: [] });
+    dynamoMock.on(TransactWriteCommand).resolves({});
+
+    const event: DynamoDBStreamEvent = { Records: [streamRecord] };
+    await handler(event, {} as Context);
+
+    expect(dynamoMock).toHaveReceivedCommandWith(TransactWriteCommand, {
+      TransactItems: expect.arrayContaining([
+        expect.objectContaining({
+          Put: expect.objectContaining({
+            Item: expect.objectContaining({ 
+              userLastActive: expectedLastActive 
+            }),
+          }),
+        }),
+      ]),
+    });
   });
 });

--- a/src/update-inactive-account-tracker.ts
+++ b/src/update-inactive-account-tracker.ts
@@ -31,9 +31,18 @@ const getCurrentRecordForUser = async (userId: string, tableName: string): Promi
 }
 
 const getLatestDate = (txmaEvent: TxmaEvent, trackerRecord: InactiveAccountTrackerRecord | null) => {
+  let timestamp = txmaEvent.timestamp;
+
+  // some txma events timestamps are in milliseconds when they should be in seconds.
+  // if the timestamp is over 13 digits it is essentially guaranteed to be in milliseconds. 
+  // 13 digit millisecond timestamps started 9 September 2001.
+  if (timestamp.toString().length >= 13) {
+    timestamp = Math.floor(timestamp / 1000);
+  }
+
   // if the timestamp on the audit event is older than the last active timestamp we have for the user
   // we should keep the existing date as it means the events have been receieved out of order
-  const eventDate = new Date(txmaEvent.timestamp * 1000);
+  const eventDate = new Date(timestamp * 1000);
   const trackerDate = trackerRecord ? new Date(trackerRecord.userLastActive) : new Date(0);
 
   return eventDate > trackerDate ? eventDate : trackerDate;


### PR DESCRIPTION


## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->

### What changed

Some txma events may have had timestamps recorded in milliseconds when they should have been in seconds. Detect if the date is in milliseconds by checking the number of digits it is made up of. Starting from 2001, Unix timestamps in milliseconds will have been 13 digits long.
