### PR TITLE
BAU: require event_id in save-raw-events and query-user-services

### DIFF
--- a/src/query-user-services.ts
+++ b/src/query-user-services.ts
@@ -48,6 +48,7 @@ export const validateTxmaEventBody = (txmaEvent: TxmaEvent): void => {
   if (
     txmaEvent.timestamp !== undefined &&
     txmaEvent.event_name !== undefined &&
+    txmaEvent.event_id !== undefined &&
     txmaEvent.client_id !== undefined &&
     txmaEvent.user !== undefined
   ) {

--- a/src/save-raw-events.ts
+++ b/src/save-raw-events.ts
@@ -62,6 +62,7 @@ export const validateTxmaEventBody = (txmaEvent: TxmaEvent): void => {
   if (
     txmaEvent.timestamp &&
     txmaEvent.event_name &&
+    txmaEvent.event_id &&
     txmaEvent.client_id &&
     txmaEvent.user
   ) {
@@ -70,11 +71,13 @@ export const validateTxmaEventBody = (txmaEvent: TxmaEvent): void => {
     const missingFields: string[] = [];
     if (!txmaEvent.timestamp) missingFields.push(`txmaEvent.timestamp is ${txmaEvent.timestamp}`);
     if (!txmaEvent.event_name) missingFields.push(`txmaEvent.event_name is ${txmaEvent.event_name}`);
+    if (!txmaEvent.event_id) missingFields.push(`txmaEvent.event_id is ${txmaEvent.event_id}`);
     if (!txmaEvent.client_id) missingFields.push(`txmaEvent.client_id is ${txmaEvent.client_id}`);
     if (!txmaEvent.user) missingFields.push(`txmaEvent.user is ${txmaEvent.user}`);
     logger.info("Could not validate TxmaEvent context", {
       timestamp: txmaEvent.timestamp,
       eventName: txmaEvent.event_name,
+      eventId: txmaEvent.event_id,
       typeofClientId: typeof txmaEvent.client_id,
       typeofUser: typeof txmaEvent.user,
     });

--- a/src/tests/query-user-services.test.ts
+++ b/src/tests/query-user-services.test.ts
@@ -245,6 +245,17 @@ describe("validateTxmaEventBody", () => {
       validateTxmaEventBody(txmaEvent);
     }).toThrow();
   });
+  test("throws error when event_id is missing", () => {
+    const txmaEvent = JSON.parse(
+      JSON.stringify({
+        ...TEST_TXMA_EVENT,
+        event_id: undefined,
+      })
+    );
+    expect(() => {
+      validateTxmaEventBody(txmaEvent);
+    }).toThrow();
+  });
 });
 
 describe("validateUser", () => {

--- a/src/tests/save-raw-events.test.ts
+++ b/src/tests/save-raw-events.test.ts
@@ -239,6 +239,28 @@ describe("validateTxmaEventBody", () => {
     }).toThrow(new Error(`Could not validate TxmaEvent with id ${txmaEvent.event_id} and name ${txmaEvent.event_name}: txmaEvent.event_name is null`));
   });
 
+  test("throws error when event_id key is missing", () => {
+    const invalidTxmaEvent = {
+      ...makeTxmaEvent(),
+      event_id: undefined,
+    };
+    const txmaEvent = JSON.parse(JSON.stringify(invalidTxmaEvent));
+    expect(() => {
+      validateTxmaEventBody(txmaEvent);
+    }).toThrow(new Error(`Could not validate TxmaEvent with id ${txmaEvent.event_id} and name ${txmaEvent.event_name}: txmaEvent.event_id is undefined`));
+  });
+
+  test("throws error when event_id value is null", () => {
+    const invalidTxmaEvent = {
+      ...makeTxmaEvent(),
+      event_id: null,
+    };
+    const txmaEvent = JSON.parse(JSON.stringify(invalidTxmaEvent));
+    expect(() => {
+      validateTxmaEventBody(txmaEvent);
+    }).toThrow(new Error(`Could not validate TxmaEvent with id ${txmaEvent.event_id} and name ${txmaEvent.event_name}: txmaEvent.event_id is null`));
+  });
+
   test("throws error when user key is missing", () => {
     const invalidTxmaEvent = {
       ...makeTxmaEvent(),


### PR DESCRIPTION
## Proposed changes

### What changed

Adding the same event_id check across event validation means we also stop these event without the ID being written to raw_events in the first place, so they can never reach the stream.

The events we subscribe to already and allow through our allowlist have event_id added to them. https://github.com/govuk-one-login/txma-event-self-serve/blob/main/config/consumer/sqs/accounts.json

AUTH_UPDATE_EMAIL & AUTH_DELETE_ACCOUNT will need event_id added to them via the TxMA subscription, but that can come later (as the raw event lambda ignores them anyway right now)

We should move to use the central event validation library as soon as we can to avoid these kind of issues https://www.npmjs.com/package/@govuk-one-login/event-catalogue-utils

### Why did it change

format-activity-log already rejects events missing event_id, but save-raw-events and query-user-services did not check for it. This let malformed events without event_id pass the upstream gate and get written to raw_events. The DynamoDB stream then delivered them to format-activity-log, which threw on every retry. Since the stream's event source mapping has unlimited retries and record age, this permanently blocked the shard and stopped all subsequent events being processed.

### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists

<!-- Merging this PR deploys to production. Please answer accurately. -->

### Environment variables or secrets

- [X] No environment variables or secrets were added or changed


### Permissions

- [ ] This PR adds or changes permissions

### Monitoring

- [X] This PR includes changes that need to be monitored in production as the scope of the change could cause issues

## Testing

<!-- Provide a summary of any manual testing you've done, for example deploying the branch to dev -->

## How to review

<!-- Describe any non-standard steps to review this work, or highlight any areas that you'd like the reviewer's opinion on -->
