### PR TITLE
OLH-4519: enable AUTH_TOKEN_SENT_TO_ORCHESTRATION processing

### DIFF
--- a/src/query-user-services.ts
+++ b/src/query-user-services.ts
@@ -48,6 +48,7 @@ export const validateTxmaEventBody = (txmaEvent: TxmaEvent): void => {
   if (
     txmaEvent.timestamp !== undefined &&
     txmaEvent.event_name !== undefined &&
+    txmaEvent.event_id !== undefined &&
     txmaEvent.client_id !== undefined &&
     txmaEvent.user !== undefined
   ) {

--- a/src/save-raw-events.ts
+++ b/src/save-raw-events.ts
@@ -25,7 +25,12 @@ const ALLOWED_EVENT_NAMES = new Set([
   "AUTH_AUTH_CODE_ISSUED",
   "AUTH_IPV_AUTHORISATION_REQUESTED",
   "AUTH_IPV_SUCCESSFUL_IDENTITY_RESPONSE_RECEIVED",
+  "AUTH_TOKEN_SENT_TO_ORCHESTRATION",
 ]);
+
+// AUTH_TOKEN_SENT_TO_ORCHESTRATION has no session_id in its schema, as the
+// authentication session is already over by the time the token is exchanged.
+const EVENTS_WITHOUT_SESSION_ID = new Set(["AUTH_TOKEN_SENT_TO_ORCHESTRATION"]);
 
 const getEventId = (): string => {
   return crypto.randomUUID();
@@ -40,7 +45,9 @@ const getTTLDate = (): number => {
 
 export const validateUser = (event: TxmaEvent): void => {
   const user:UserData = event.user;
-  if (!user.user_id || !user.session_id) {
+  const requiresSessionId = !EVENTS_WITHOUT_SESSION_ID.has(event.event_name);
+
+  if (!user.user_id || (requiresSessionId && !user.session_id)) {
     logger.info("Could not validate User context", {
       typeofUser: typeof user,
       typeofUserUserId: typeof user.user_id,
@@ -51,7 +58,7 @@ export const validateUser = (event: TxmaEvent): void => {
     if (!user.user_id) {
       missingFields.push(`user_id is ${user.user_id}`);
     }
-    if (!user.session_id) {
+    if (requiresSessionId && !user.session_id) {
       missingFields.push(`session_id is ${user.session_id}`);
     }
     throw new Error(`Could not validate User for event_name ${event.event_name} with event_id ${event.event_id}: ${missingFields.join(", ")}`);

--- a/src/save-raw-events.ts
+++ b/src/save-raw-events.ts
@@ -62,6 +62,7 @@ export const validateTxmaEventBody = (txmaEvent: TxmaEvent): void => {
   if (
     txmaEvent.timestamp &&
     txmaEvent.event_name &&
+    txmaEvent.event_id &&
     txmaEvent.client_id &&
     txmaEvent.user
   ) {
@@ -70,11 +71,13 @@ export const validateTxmaEventBody = (txmaEvent: TxmaEvent): void => {
     const missingFields: string[] = [];
     if (!txmaEvent.timestamp) missingFields.push(`txmaEvent.timestamp is ${txmaEvent.timestamp}`);
     if (!txmaEvent.event_name) missingFields.push(`txmaEvent.event_name is ${txmaEvent.event_name}`);
+    if (!txmaEvent.event_id) missingFields.push(`txmaEvent.event_id is ${txmaEvent.event_id}`);
     if (!txmaEvent.client_id) missingFields.push(`txmaEvent.client_id is ${txmaEvent.client_id}`);
     if (!txmaEvent.user) missingFields.push(`txmaEvent.user is ${txmaEvent.user}`);
     logger.info("Could not validate TxmaEvent context", {
       timestamp: txmaEvent.timestamp,
       eventName: txmaEvent.event_name,
+      eventId: txmaEvent.event_id,
       typeofClientId: typeof txmaEvent.client_id,
       typeofUser: typeof txmaEvent.user,
     });

--- a/src/tests/query-user-services.test.ts
+++ b/src/tests/query-user-services.test.ts
@@ -245,6 +245,17 @@ describe("validateTxmaEventBody", () => {
       validateTxmaEventBody(txmaEvent);
     }).toThrow();
   });
+  test("throws error when event_id is missing", () => {
+    const txmaEvent = JSON.parse(
+      JSON.stringify({
+        ...TEST_TXMA_EVENT,
+        event_id: undefined,
+      })
+    );
+    expect(() => {
+      validateTxmaEventBody(txmaEvent);
+    }).toThrow();
+  });
 });
 
 describe("validateUser", () => {

--- a/src/tests/save-raw-events.test.ts
+++ b/src/tests/save-raw-events.test.ts
@@ -166,6 +166,32 @@ describe("validateUser", () => {
       validateUser(txmaEvent);
     }).toThrow(new Error(`Could not validate User for event_name AUTH_AUTH_CODE_ISSUED with event_id ab12345a-a12b-3ced-ef12-12a3b4cd5678: session_id is null`));
   });
+
+  test("does not throw when session_id is missing for AUTH_TOKEN_SENT_TO_ORCHESTRATION", () => {
+    const tokenSentEvent = {
+      ...makeTxmaEvent(),
+      event_name: "AUTH_TOKEN_SENT_TO_ORCHESTRATION",
+      user: { user_id: user.user_id },
+    };
+    const txmaEvent = JSON.parse(JSON.stringify(tokenSentEvent));
+
+    expect(() => {
+      validateUser(txmaEvent);
+    }).not.toThrow();
+  });
+
+  test("still throws when user_id is missing for AUTH_TOKEN_SENT_TO_ORCHESTRATION", () => {
+    const tokenSentEvent = {
+      ...makeTxmaEvent(),
+      event_name: "AUTH_TOKEN_SENT_TO_ORCHESTRATION",
+      user: {},
+    };
+    const txmaEvent = JSON.parse(JSON.stringify(tokenSentEvent));
+
+    expect(() => {
+      validateUser(txmaEvent);
+    }).toThrow(new Error(`Could not validate User for event_name AUTH_TOKEN_SENT_TO_ORCHESTRATION with event_id ab12345a-a12b-3ced-ef12-12a3b4cd5678: user_id is undefined`));
+  });
 });
 
 describe("validateTxmaEventBody", () => {
@@ -342,6 +368,7 @@ describe("handler only saves allowlisted events", () => {
     "AUTH_AUTH_CODE_ISSUED",
     "AUTH_IPV_AUTHORISATION_REQUESTED",
     "AUTH_IPV_SUCCESSFUL_IDENTITY_RESPONSE_RECEIVED",
+    "AUTH_TOKEN_SENT_TO_ORCHESTRATION",
   ])("writes to DynamoDB when event_name is %s", async (allowedEventName) => {
     vi.spyOn(Date, "now").mockImplementation(() => TIMESTAMP);
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -363,6 +390,28 @@ describe("handler only saves allowlisted events", () => {
     expect(dynamoMock.commandCalls(PutCommand).length).toEqual(1);
   });
 
+  test("writes to DynamoDB when event_name is AUTH_TOKEN_SENT_TO_ORCHESTRATION and user has no session_id", async () => {
+    vi.spyOn(Date, "now").mockImplementation(() => TIMESTAMP);
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    vi.spyOn(crypto, "randomUUID").mockImplementation(() => UUID);
+
+    const tokenSentEvent: SQSEvent = {
+      Records: [
+        {
+          ...TEST_SQS_RECORD,
+          body: JSON.stringify({
+            ...makeTxmaEvent(),
+            event_name: "AUTH_TOKEN_SENT_TO_ORCHESTRATION",
+            user: { user_id: user.user_id },
+          }),
+        },
+      ],
+    };
+    await handler(tokenSentEvent, {} as Context);
+    expect(dynamoMock.commandCalls(PutCommand).length).toEqual(1);
+  });
+
   test("does not write to DynamoDB and logs info when event_name is not in the allowlist", async () => {
     const ignoredEvent: SQSEvent = {
       Records: [
@@ -370,7 +419,7 @@ describe("handler only saves allowlisted events", () => {
           ...TEST_SQS_RECORD,
           body: JSON.stringify({
             ...makeTxmaEvent(),
-            event_name: "AUTH_TOKEN_SENT_TO_ORCHESTRATION",
+            event_name: "AUTH_OTHER_RANDOM_EVENT",
           }),
         },
       ],
@@ -378,7 +427,7 @@ describe("handler only saves allowlisted events", () => {
     await handler(ignoredEvent, {} as Context);
     expect(dynamoMock.commandCalls(PutCommand).length).toEqual(0);
     expect(mockLogger.info).toHaveBeenCalledWith(
-      "Ignoring AUTH_TOKEN_SENT_TO_ORCHESTRATION event - not in allowlist"
+      "Ignoring AUTH_OTHER_RANDOM_EVENT event - not in allowlist"
     );
   });
 
@@ -413,7 +462,7 @@ describe("handler only saves allowlisted events", () => {
           ...TEST_SQS_RECORD,
           body: JSON.stringify({
             ...makeTxmaEvent(),
-            event_name: "AUTH_TOKEN_SENT_TO_ORCHESTRATION",
+            event_name: "AUTH_OTHER_RANDOM_EVENT",
           }),
         },
         {

--- a/src/tests/save-raw-events.test.ts
+++ b/src/tests/save-raw-events.test.ts
@@ -239,6 +239,28 @@ describe("validateTxmaEventBody", () => {
     }).toThrow(new Error(`Could not validate TxmaEvent with id ${txmaEvent.event_id} and name ${txmaEvent.event_name}: txmaEvent.event_name is null`));
   });
 
+  test("throws error when event_id key is missing", () => {
+    const invalidTxmaEvent = {
+      ...makeTxmaEvent(),
+      event_id: undefined,
+    };
+    const txmaEvent = JSON.parse(JSON.stringify(invalidTxmaEvent));
+    expect(() => {
+      validateTxmaEventBody(txmaEvent);
+    }).toThrow(new Error(`Could not validate TxmaEvent with id ${txmaEvent.event_id} and name ${txmaEvent.event_name}: txmaEvent.event_id is undefined`));
+  });
+
+  test("throws error when event_id value is null", () => {
+    const invalidTxmaEvent = {
+      ...makeTxmaEvent(),
+      event_id: null,
+    };
+    const txmaEvent = JSON.parse(JSON.stringify(invalidTxmaEvent));
+    expect(() => {
+      validateTxmaEventBody(txmaEvent);
+    }).toThrow(new Error(`Could not validate TxmaEvent with id ${txmaEvent.event_id} and name ${txmaEvent.event_name}: txmaEvent.event_id is null`));
+  });
+
   test("throws error when user key is missing", () => {
     const invalidTxmaEvent = {
       ...makeTxmaEvent(),


### PR DESCRIPTION
## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->

Adds AUTH_TOKEN_SENT_TO_ORCHESTRATION to the save-raw-events allowlist so events flow through to DynamoDB raw_events, where the existing stream filter triggers update-inactive-account-tracker.

Relaxes session_id validation for this event as it is not in the event schema. Uses an explicit EVENTS_WITHOUT_SESSION_ID set to scope the relaxation.

Future work should refactor this validation to use the shared event validation library, but that is a separate piece of work.

### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists

<!-- Merging this PR deploys to production. Please answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Added parameters to Cloudformation template
- [ ] Added new secret or systems manager parameter
- [ ] Added new environment variable

### Permissions

- [ ] This PR adds or changes permissions

### Monitoring

- [x] This PR includes changes that need to be monitored in production as the scope of the change could cause issues

## Testing

<!-- Provide a summary of any manual testing you've done, for example deploying the branch to dev -->

## How to review

<!-- Describe any non-standard steps to review this work, or highlight any areas that you'd like the reviewer's opinion on -->
