### PR TITLE
OLH-4487: Improve email address provenance tracking in the inactive account tracker

### DIFF
--- a/src/tests/update-inactive-account-tracker.test.ts
+++ b/src/tests/update-inactive-account-tracker.test.ts
@@ -2,18 +2,9 @@ import { vi, describe, test, expect, afterEach, beforeEach } from "vitest";
 import { DynamoDBRecord, Context, DynamoDBStreamEvent } from "aws-lambda";
 import { Logger } from "@aws-lambda-powertools/logger";
 import { mockClient } from "aws-sdk-client-mock";
-import {
-  DynamoDBDocumentClient,
-  GetCommand,
-  QueryCommand,
-  TransactWriteCommand,
-} from "@aws-sdk/lib-dynamodb";
+import { DynamoDBDocumentClient, GetCommand, QueryCommand, TransactWriteCommand } from "@aws-sdk/lib-dynamodb";
 import { handler } from "../update-inactive-account-tracker.js";
-import {
-  generateDynamoStreamRecord,
-  timestamp,
-  txmaEventId,
-} from "./testFixtures.js";
+import { generateDynamoStreamRecord, timestamp, txmaEventId } from "./testFixtures.js";
 
 const dynamoMock = mockClient(DynamoDBDocumentClient);
 
@@ -41,11 +32,10 @@ describe("UpdateInactiveAccountTracker handler", () => {
   });
 
   test("queries CommonSubjectIdIndex with user_id", async () => {
+
     dynamoMock.on(QueryCommand).resolves({ Items: [] });
     dynamoMock.on(TransactWriteCommand).resolves({});
-    const event: DynamoDBStreamEvent = {
-      Records: [generateDynamoStreamRecord("test-client")],
-    };
+    const event: DynamoDBStreamEvent = { Records: [generateDynamoStreamRecord("test-client")] };
     await handler(event, {} as Context);
     expect(dynamoMock).toHaveReceivedCommandWith(QueryCommand, {
       TableName: "test-table",
@@ -58,23 +48,14 @@ describe("UpdateInactiveAccountTracker handler", () => {
   test("writes new tracker record via transaction when no existing record", async () => {
     dynamoMock.on(QueryCommand).resolves({ Items: [] });
     dynamoMock.on(TransactWriteCommand).resolves({});
-    const event: DynamoDBStreamEvent = {
-      Records: [generateDynamoStreamRecord("test-client")],
-    };
+    const event: DynamoDBStreamEvent = { Records: [generateDynamoStreamRecord("test-client")] };
     await handler(event, {} as Context);
     expect(dynamoMock).toHaveReceivedCommandWith(TransactWriteCommand, {
       TransactItems: expect.arrayContaining([
         expect.objectContaining({
           Put: expect.objectContaining({
             TableName: "test-table",
-            Item: expect.objectContaining({
-              commonSubjectId: "qwerty",
-              status: "pending",
-              userLastActiveSource: "AUTH_AUTH_CODE_ISSUED",
-              userLastActiveSourceId: "event_id",
-              emailAddressSource: "AUTH_AUTH_CODE_ISSUED",
-              emailAddressSourceId: "event_id",
-            }),
+            Item: expect.objectContaining({ commonSubjectId: "qwerty", status: "pending", userLastActiveSource: "AUTH_AUTH_CODE_ISSUED", userLastActiveSourceId: "event_id", emailAddressSource: "AUTH_AUTH_CODE_ISSUED", emailAddressSourceId: "event_id" }),
           }),
         }),
       ]),
@@ -91,17 +72,13 @@ describe("UpdateInactiveAccountTracker handler", () => {
   test("uses event timestamp as latestDate when no existing record", async () => {
     dynamoMock.on(QueryCommand).resolves({ Items: [] });
     dynamoMock.on(TransactWriteCommand).resolves({});
-    const event: DynamoDBStreamEvent = {
-      Records: [generateDynamoStreamRecord("test-client")],
-    };
+    const event: DynamoDBStreamEvent = { Records: [generateDynamoStreamRecord("test-client")] };
     await handler(event, {} as Context);
     expect(dynamoMock).toHaveReceivedCommandWith(TransactWriteCommand, {
       TransactItems: expect.arrayContaining([
         expect.objectContaining({
           Put: expect.objectContaining({
-            Item: expect.objectContaining({
-              userLastActive: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T/),
-            }),
+            Item: expect.objectContaining({ userLastActive: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T/) }),
           }),
         }),
       ]),
@@ -111,21 +88,10 @@ describe("UpdateInactiveAccountTracker handler", () => {
   test("uses existing userLastActive when it is later than event timestamp", async () => {
     const futureDate = new Date(Date.now() + 86400000).toISOString();
     dynamoMock.on(QueryCommand).resolves({
-      Items: [
-        {
-          commonSubjectId: "qwerty",
-          dateForDeletion: "2099-01-01",
-          userLastActive: futureDate,
-          status: "active",
-          emailAddress: "x",
-          statusLastUpdated: "",
-        },
-      ],
+      Items: [{ commonSubjectId: "qwerty", dateForDeletion: "2099-01-01", userLastActive: futureDate, status: "active", emailAddress: "x", statusLastUpdated: "" }],
     });
     dynamoMock.on(TransactWriteCommand).resolves({});
-    const event: DynamoDBStreamEvent = {
-      Records: [generateDynamoStreamRecord("test-client")],
-    };
+    const event: DynamoDBStreamEvent = { Records: [generateDynamoStreamRecord("test-client")] };
     await handler(event, {} as Context);
     expect(dynamoMock).toHaveReceivedCommandWith(TransactWriteCommand, {
       TransactItems: expect.arrayContaining([
@@ -146,81 +112,37 @@ describe("UpdateInactiveAccountTracker handler", () => {
 
   test("returns early and logs warning when currentItem status is deleting", async () => {
     dynamoMock.on(QueryCommand).resolves({
-      Items: [
-        {
-          commonSubjectId: "qwerty",
-          dateForDeletion: "2026-01-01",
-          userLastActive: "2026-01-01T00:00:00.000Z",
-          status: "deleting",
-          emailAddress: "x",
-          statusLastUpdated: "",
-        },
-      ],
+      Items: [{ commonSubjectId: "qwerty", dateForDeletion: "2026-01-01", userLastActive: "2026-01-01T00:00:00.000Z", status: "deleting", emailAddress: "x", statusLastUpdated: "" }],
     });
-    const event: DynamoDBStreamEvent = {
-      Records: [generateDynamoStreamRecord("test-client")],
-    };
+    const event: DynamoDBStreamEvent = { Records: [generateDynamoStreamRecord("test-client")] };
     await handler(event, {} as Context);
-    expect(loggerWarnMock).toHaveBeenCalledWith(
-      "AUTH_EVENT_ON_DELETING_ACCOUNT qwerty"
-    );
+    expect(loggerWarnMock).toHaveBeenCalledWith("AUTH_EVENT_ON_DELETING_ACCOUNT qwerty");
     expect(dynamoMock).not.toHaveReceivedCommand(TransactWriteCommand);
   });
 
   test("throws assertion error when more than one tracker record exists", async () => {
     dynamoMock.on(QueryCommand).resolves({
       Items: [
-        {
-          commonSubjectId: "qwerty",
-          dateForDeletion: "2026-01-01",
-          userLastActive: "2026-01-01T00:00:00.000Z",
-          status: "pending",
-          emailAddress: "x",
-          statusLastUpdated: "",
-        },
-        {
-          commonSubjectId: "qwerty",
-          dateForDeletion: "2026-01-02",
-          userLastActive: "2026-01-02T00:00:00.000Z",
-          status: "pending",
-          emailAddress: "x",
-          statusLastUpdated: "",
-        },
+        { commonSubjectId: "qwerty", dateForDeletion: "2026-01-01", userLastActive: "2026-01-01T00:00:00.000Z", status: "pending", emailAddress: "x", statusLastUpdated: "" },
+        { commonSubjectId: "qwerty", dateForDeletion: "2026-01-02", userLastActive: "2026-01-02T00:00:00.000Z", status: "pending", emailAddress: "x", statusLastUpdated: "" },
       ],
     });
-    const event: DynamoDBStreamEvent = {
-      Records: [generateDynamoStreamRecord("test-client")],
-    };
-    await expect(handler(event, {} as Context)).rejects.toThrow(
-      "found more than one inactivity tracker record for qwerty"
-    );
+    const event: DynamoDBStreamEvent = { Records: [generateDynamoStreamRecord("test-client")] };
+    await expect(handler(event, {} as Context)).rejects.toThrow("found more than one inactivity tracker record for qwerty");
   });
 
   test("does not delete notification when no existing notification found", async () => {
     dynamoMock.on(QueryCommand).resolves({
-      Items: [
-        {
-          commonSubjectId: "qwerty",
-          dateForDeletion: "2026-01-01",
-          userLastActive: "2020-01-01T00:00:00.000Z",
-          status: "pending",
-          emailAddress: "x",
-          statusLastUpdated: "",
-        },
-      ],
+      Items: [{ commonSubjectId: "qwerty", dateForDeletion: "2026-01-01", userLastActive: "2020-01-01T00:00:00.000Z", status: "pending", emailAddress: "x", statusLastUpdated: "" }],
     });
     dynamoMock.on(GetCommand).resolves({ Item: undefined });
     dynamoMock.on(TransactWriteCommand).resolves({});
-    const event: DynamoDBStreamEvent = {
-      Records: [generateDynamoStreamRecord("test-client")],
-    };
+    const event: DynamoDBStreamEvent = { Records: [generateDynamoStreamRecord("test-client")] };
     await handler(event, {} as Context);
     expect(dynamoMock).toHaveReceivedCommandWith(TransactWriteCommand, {
       TransactItems: expect.not.arrayContaining([
         expect.objectContaining({
-          Delete: expect.objectContaining({
-            TableName: "user-notifications-table",
-          }),
+          Delete: expect.objectContaining({ TableName: "user-notifications-table" }),
         }),
       ]),
     });
@@ -228,42 +150,20 @@ describe("UpdateInactiveAccountTracker handler", () => {
 
   test("does not check notification store when currentItem status is not pending", async () => {
     dynamoMock.on(QueryCommand).resolves({
-      Items: [
-        {
-          commonSubjectId: "qwerty",
-          dateForDeletion: "2026-01-01",
-          userLastActive: "2020-01-01T00:00:00.000Z",
-          status: "active",
-          emailAddress: "x",
-          statusLastUpdated: "",
-        },
-      ],
+      Items: [{ commonSubjectId: "qwerty", dateForDeletion: "2026-01-01", userLastActive: "2020-01-01T00:00:00.000Z", status: "active", emailAddress: "x", statusLastUpdated: "" }],
     });
     dynamoMock.on(TransactWriteCommand).resolves({});
-    const event: DynamoDBStreamEvent = {
-      Records: [generateDynamoStreamRecord("test-client")],
-    };
+    const event: DynamoDBStreamEvent = { Records: [generateDynamoStreamRecord("test-client")] };
     await handler(event, {} as Context);
     expect(dynamoMock).not.toHaveReceivedCommand(GetCommand);
   });
 
   test("does not delete tracker record when dateForDeletion is unchanged", async () => {
     dynamoMock.on(QueryCommand).resolves({
-      Items: [
-        {
-          commonSubjectId: "qwerty",
-          dateForDeletion: "1978-11-29",
-          userLastActive: "1970-01-01T00:00:00.000Z",
-          status: "pending",
-          emailAddress: "x",
-          statusLastUpdated: "",
-        },
-      ],
+      Items: [{ commonSubjectId: "qwerty", dateForDeletion: "1978-11-29", userLastActive: "1970-01-01T00:00:00.000Z", status: "pending", emailAddress: "x", statusLastUpdated: "" }],
     });
     dynamoMock.on(TransactWriteCommand).resolves({});
-    const event: DynamoDBStreamEvent = {
-      Records: [generateDynamoStreamRecord("test-client")],
-    };
+    const event: DynamoDBStreamEvent = { Records: [generateDynamoStreamRecord("test-client")] };
     await handler(event, {} as Context);
     expect(dynamoMock).toHaveReceivedCommandWith(TransactWriteCommand, {
       TransactItems: expect.not.arrayContaining([
@@ -276,12 +176,8 @@ describe("UpdateInactiveAccountTracker handler", () => {
 
   test("throws error when transaction fails", async () => {
     dynamoMock.on(QueryCommand).resolves({ Items: [] });
-    dynamoMock
-      .on(TransactWriteCommand)
-      .rejects(new Error("TransactionCanceledException"));
-    const event: DynamoDBStreamEvent = {
-      Records: [generateDynamoStreamRecord("test-client")],
-    };
+    dynamoMock.on(TransactWriteCommand).rejects(new Error("TransactionCanceledException"));
+    const event: DynamoDBStreamEvent = { Records: [generateDynamoStreamRecord("test-client")] };
     await expect(handler(event, {} as Context)).rejects.toThrow(
       "Failed to update inactive account tracker for user qwerty"
     );
@@ -289,15 +185,7 @@ describe("UpdateInactiveAccountTracker handler", () => {
 
   test("includes email and does not log warning when email exists on the event", async () => {
     dynamoMock.on(QueryCommand).resolves({
-      Items: [
-        {
-          commonSubjectId: "qwerty",
-          dateForDeletion: "1978-11-29",
-          userLastActive: "1970-01-01T00:00:00.000Z",
-          status: "pending",
-          statusLastUpdated: "",
-        },
-      ],
+      Items: [{ commonSubjectId: "qwerty", dateForDeletion: "1978-11-29", userLastActive: "1970-01-01T00:00:00.000Z", status: "pending", statusLastUpdated: "" }],
     });
     const recordWithEmail = {
       dynamodb: {
@@ -309,18 +197,16 @@ describe("UpdateInactiveAccountTracker handler", () => {
               user: {
                 M: {
                   user_id: { S: "qwerty" },
-                  email: { S: "email@exists.uk" },
-                },
-              },
-            },
-          },
-        },
-      },
+                  email: { S: "email@exists.uk" }
+                }
+              }
+            }
+          }
+        }
+      }
     };
 
-    const event: DynamoDBStreamEvent = {
-      Records: [recordWithEmail as DynamoDBRecord],
-    };
+    const event: DynamoDBStreamEvent = { Records: [recordWithEmail as DynamoDBRecord] };
     await handler(event, {} as Context);
     expect(dynamoMock).toHaveReceivedCommandWith(TransactWriteCommand, {
       TransactItems: expect.arrayContaining([
@@ -337,15 +223,7 @@ describe("UpdateInactiveAccountTracker handler", () => {
 
   test("logs warning when email is missing from the event and from pre-existing record", async () => {
     dynamoMock.on(QueryCommand).resolves({
-      Items: [
-        {
-          commonSubjectId: "qwerty",
-          dateForDeletion: "1978-11-29",
-          userLastActive: "1970-01-01T00:00:00.000Z",
-          status: "pending",
-          statusLastUpdated: "",
-        },
-      ],
+      Items: [{ commonSubjectId: "qwerty", dateForDeletion: "1978-11-29", userLastActive: "1970-01-01T00:00:00.000Z", status: "pending", statusLastUpdated: "" }],
     });
     const invalidRecord = {
       dynamodb: {
@@ -356,34 +234,27 @@ describe("UpdateInactiveAccountTracker handler", () => {
               timestamp: { N: "1711929600" },
               user: {
                 M: {
-                  user_id: { S: "qwerty" },
-                },
-              },
-            },
-          },
-        },
-      },
+                  user_id: { S: "qwerty" }
+                }
+              }
+            }
+          }
+        }
+      }
     };
-    const event: DynamoDBStreamEvent = {
-      Records: [invalidRecord as DynamoDBRecord],
-    };
+    const event: DynamoDBStreamEvent = { Records: [invalidRecord as DynamoDBRecord] };
     await handler(event, {} as Context);
     expect(dynamoMock).toHaveReceivedCommandWith(TransactWriteCommand, {
       TransactItems: expect.arrayContaining([
         expect.objectContaining({
           Put: expect.objectContaining({
             TableName: "test-table",
-            Item: expect.objectContaining({
-              commonSubjectId: "qwerty",
-              emailAddress: "",
-            }),
+            Item: expect.objectContaining({ commonSubjectId: "qwerty", emailAddress: "" }),
           }),
         }),
       ]),
     });
-    expect(loggerWarnMock).toHaveBeenCalledWith(
-      "AUTH_EVENT_NO_EMAIL for userId qwerty"
-    );
+    expect(loggerWarnMock).toHaveBeenCalledWith("AUTH_EVENT_NO_EMAIL for userId qwerty");
   });
 
   test("stores publicSubjectId from event when present", async () => {
@@ -408,17 +279,13 @@ describe("UpdateInactiveAccountTracker handler", () => {
         },
       },
     };
-    const event: DynamoDBStreamEvent = {
-      Records: [recordWithPublicSubjectId as DynamoDBRecord],
-    };
+    const event: DynamoDBStreamEvent = { Records: [recordWithPublicSubjectId as DynamoDBRecord] };
     await handler(event, {} as Context);
     expect(dynamoMock).toHaveReceivedCommandWith(TransactWriteCommand, {
       TransactItems: expect.arrayContaining([
         expect.objectContaining({
           Put: expect.objectContaining({
-            Item: expect.objectContaining({
-              publicSubjectId: "public-subject-123",
-            }),
+            Item: expect.objectContaining({ publicSubjectId: "public-subject-123" }),
           }),
         }),
       ]),
@@ -427,17 +294,7 @@ describe("UpdateInactiveAccountTracker handler", () => {
 
   test("falls back to publicSubjectId from existing tracker record when not on event", async () => {
     dynamoMock.on(QueryCommand).resolves({
-      Items: [
-        {
-          commonSubjectId: "qwerty",
-          dateForDeletion: "1978-11-29",
-          userLastActive: "1970-01-01T00:00:00.000Z",
-          emailAddress: "x",
-          publicSubjectId: "public-subject-from-record",
-          status: "pending",
-          statusLastUpdated: "",
-        },
-      ],
+      Items: [{ commonSubjectId: "qwerty", dateForDeletion: "1978-11-29", userLastActive: "1970-01-01T00:00:00.000Z", emailAddress: "x", publicSubjectId: "public-subject-from-record", status: "pending", statusLastUpdated: "" }],
     });
     dynamoMock.on(TransactWriteCommand).resolves({});
     const recordWithoutPublicSubjectId = {
@@ -454,17 +311,13 @@ describe("UpdateInactiveAccountTracker handler", () => {
         },
       },
     };
-    const event: DynamoDBStreamEvent = {
-      Records: [recordWithoutPublicSubjectId as DynamoDBRecord],
-    };
+    const event: DynamoDBStreamEvent = { Records: [recordWithoutPublicSubjectId as DynamoDBRecord] };
     await handler(event, {} as Context);
     expect(dynamoMock).toHaveReceivedCommandWith(TransactWriteCommand, {
       TransactItems: expect.arrayContaining([
         expect.objectContaining({
           Put: expect.objectContaining({
-            Item: expect.objectContaining({
-              publicSubjectId: "public-subject-from-record",
-            }),
+            Item: expect.objectContaining({ publicSubjectId: "public-subject-from-record" }),
           }),
         }),
       ]),
@@ -488,9 +341,7 @@ describe("UpdateInactiveAccountTracker handler", () => {
         },
       },
     };
-    const event: DynamoDBStreamEvent = {
-      Records: [recordWithoutPublicSubjectId as DynamoDBRecord],
-    };
+    const event: DynamoDBStreamEvent = { Records: [recordWithoutPublicSubjectId as DynamoDBRecord] };
     await handler(event, {} as Context);
     expect(dynamoMock).toHaveReceivedCommandWith(TransactWriteCommand, {
       TransactItems: expect.arrayContaining([
@@ -505,25 +356,11 @@ describe("UpdateInactiveAccountTracker handler", () => {
 
   test("preserves emailAddressSource and emailAddressSourceId from existing record when email is unchanged", async () => {
     dynamoMock.on(QueryCommand).resolves({
-      Items: [
-        {
-          commonSubjectId: "qwerty",
-          dateForDeletion: "1978-11-29",
-          userLastActive: "1970-01-01T00:00:00.000Z",
-          emailAddress: "foo@bar.com",
-          emailAddressSource: "AUTH_PREVIOUS_EVENT",
-          emailAddressSourceId: "old-event-id",
-          emailAddressLastUpdated: "2020-01-01T00:00:00.000Z",
-          status: "pending",
-          statusLastUpdated: "",
-        },
-      ],
+      Items: [{ commonSubjectId: "qwerty", dateForDeletion: "1978-11-29", userLastActive: "1970-01-01T00:00:00.000Z", emailAddress: "foo@bar.com", emailAddressSource: "AUTH_PREVIOUS_EVENT", emailAddressSourceId: "old-event-id", emailAddressLastUpdated: "2020-01-01T00:00:00.000Z", status: "pending", statusLastUpdated: "" }],
     });
     dynamoMock.on(TransactWriteCommand).resolves({});
     // generateDynamoStreamRecord includes email: "foo@bar.com" which matches the existing record
-    const event: DynamoDBStreamEvent = {
-      Records: [generateDynamoStreamRecord("test-client")],
-    };
+    const event: DynamoDBStreamEvent = { Records: [generateDynamoStreamRecord("test-client")] };
     await handler(event, {} as Context);
     expect(dynamoMock).toHaveReceivedCommandWith(TransactWriteCommand, {
       TransactItems: expect.arrayContaining([
@@ -543,26 +380,12 @@ describe("UpdateInactiveAccountTracker handler", () => {
 
   test("updates emailAddressSource, emailAddressSourceId and emailAddressLastUpdated when email changes", async () => {
     dynamoMock.on(QueryCommand).resolves({
-      Items: [
-        {
-          commonSubjectId: "qwerty",
-          dateForDeletion: "1978-11-29",
-          userLastActive: "1970-01-01T00:00:00.000Z",
-          emailAddress: "old@email.com",
-          emailAddressSource: "AUTH_PREVIOUS_EVENT",
-          emailAddressSourceId: "old-event-id",
-          emailAddressLastUpdated: "2020-01-01T00:00:00.000Z",
-          status: "pending",
-          statusLastUpdated: "",
-        },
-      ],
+      Items: [{ commonSubjectId: "qwerty", dateForDeletion: "1978-11-29", userLastActive: "1970-01-01T00:00:00.000Z", emailAddress: "old@email.com", emailAddressSource: "AUTH_PREVIOUS_EVENT", emailAddressSourceId: "old-event-id", emailAddressLastUpdated: "2020-01-01T00:00:00.000Z", status: "pending", statusLastUpdated: "" }],
     });
     dynamoMock.on(TransactWriteCommand).resolves({});
     // generateDynamoStreamRecord uses timestamp = 123456789 seconds => 1973-11-29T21:33:09.000Z
     const expectedEventDateTime = new Date(timestamp * 1000).toISOString();
-    const event: DynamoDBStreamEvent = {
-      Records: [generateDynamoStreamRecord("test-client")],
-    };
+    const event: DynamoDBStreamEvent = { Records: [generateDynamoStreamRecord("test-client")] };
     await handler(event, {} as Context);
     expect(dynamoMock).toHaveReceivedCommandWith(TransactWriteCommand, {
       TransactItems: expect.arrayContaining([
@@ -582,16 +405,7 @@ describe("UpdateInactiveAccountTracker handler", () => {
 
   test("logs warning when email is missing from the event but is present in pre-existing record", async () => {
     dynamoMock.on(QueryCommand).resolves({
-      Items: [
-        {
-          commonSubjectId: "qwerty",
-          dateForDeletion: "1978-11-29",
-          userLastActive: "1970-01-01T00:00:00.000Z",
-          emailAddress: "testing-warning@test.co",
-          status: "pending",
-          statusLastUpdated: "",
-        },
-      ],
+      Items: [{ commonSubjectId: "qwerty", dateForDeletion: "1978-11-29", userLastActive: "1970-01-01T00:00:00.000Z", emailAddress: "testing-warning@test.co", status: "pending", statusLastUpdated: "" }],
     });
     const invalidRecord = {
       dynamodb: {
@@ -602,51 +416,40 @@ describe("UpdateInactiveAccountTracker handler", () => {
               timestamp: { N: "1711929600" },
               user: {
                 M: {
-                  user_id: { S: "qwerty" },
-                },
-              },
-            },
-          },
-        },
-      },
+                  user_id: { S: "qwerty" }
+                }
+              }
+            }
+          }
+        }
+      }
     };
-    const event: DynamoDBStreamEvent = {
-      Records: [invalidRecord as DynamoDBRecord],
-    };
+    const event: DynamoDBStreamEvent = { Records: [invalidRecord as DynamoDBRecord] };
     await handler(event, {} as Context);
     expect(dynamoMock).toHaveReceivedCommandWith(TransactWriteCommand, {
       TransactItems: expect.arrayContaining([
         expect.objectContaining({
           Put: expect.objectContaining({
             TableName: "test-table",
-            Item: expect.objectContaining({
-              commonSubjectId: "qwerty",
-              emailAddress: "testing-warning@test.co",
-            }),
+            Item: expect.objectContaining({ commonSubjectId: "qwerty", emailAddress: "testing-warning@test.co" }),
           }),
         }),
       ]),
     });
-    expect(loggerWarnMock).toHaveBeenCalledWith(
-      "AUTH_EVENT_NO_EMAIL for userId qwerty"
-    );
+    expect(loggerWarnMock).toHaveBeenCalledWith("AUTH_EVENT_NO_EMAIL for userId qwerty");
   });
 
   test("sets statusLastUpdated to the event timestamp", async () => {
     dynamoMock.on(QueryCommand).resolves({ Items: [] });
     dynamoMock.on(TransactWriteCommand).resolves({});
     const expectedEventDateTime = new Date(timestamp * 1000).toISOString();
-    const event: DynamoDBStreamEvent = {
-      Records: [generateDynamoStreamRecord("test-client")],
-    };
+    const event: DynamoDBStreamEvent = { Records: [generateDynamoStreamRecord("test-client")] };
     await handler(event, {} as Context);
     expect(dynamoMock).toHaveReceivedCommandWith(TransactWriteCommand, {
       TransactItems: expect.arrayContaining([
         expect.objectContaining({
           Put: expect.objectContaining({
-            Item: expect.objectContaining({
-              statusLastUpdated: expectedEventDateTime,
-            }),
+            Item: expect.objectContaining({ statusLastUpdated: expectedEventDateTime }),
           }),
         }),
       ]),
@@ -657,17 +460,13 @@ describe("UpdateInactiveAccountTracker handler", () => {
     dynamoMock.on(QueryCommand).resolves({ Items: [] });
     dynamoMock.on(TransactWriteCommand).resolves({});
     const expectedEventDateTime = new Date(timestamp * 1000).toISOString();
-    const event: DynamoDBStreamEvent = {
-      Records: [generateDynamoStreamRecord("test-client")],
-    };
+    const event: DynamoDBStreamEvent = { Records: [generateDynamoStreamRecord("test-client")] };
     await handler(event, {} as Context);
     expect(dynamoMock).toHaveReceivedCommandWith(TransactWriteCommand, {
       TransactItems: expect.arrayContaining([
         expect.objectContaining({
           Put: expect.objectContaining({
-            Item: expect.objectContaining({
-              userLastActiveUpdated: expectedEventDateTime,
-            }),
+            Item: expect.objectContaining({ userLastActiveUpdated: expectedEventDateTime }),
           }),
         }),
       ]),
@@ -678,30 +477,16 @@ describe("UpdateInactiveAccountTracker handler", () => {
     const existingLastActiveUpdated = "2099-01-01T00:00:00.000Z";
     const futureDate = new Date(Date.now() + 86400000).toISOString();
     dynamoMock.on(QueryCommand).resolves({
-      Items: [
-        {
-          commonSubjectId: "qwerty",
-          dateForDeletion: "2099-01-01",
-          userLastActive: futureDate,
-          userLastActiveUpdated: existingLastActiveUpdated,
-          status: "pending",
-          emailAddress: "x",
-          statusLastUpdated: "",
-        },
-      ],
+      Items: [{ commonSubjectId: "qwerty", dateForDeletion: "2099-01-01", userLastActive: futureDate, userLastActiveUpdated: existingLastActiveUpdated, status: "pending", emailAddress: "x", statusLastUpdated: "" }],
     });
     dynamoMock.on(TransactWriteCommand).resolves({});
-    const event: DynamoDBStreamEvent = {
-      Records: [generateDynamoStreamRecord("test-client")],
-    };
+    const event: DynamoDBStreamEvent = { Records: [generateDynamoStreamRecord("test-client")] };
     await handler(event, {} as Context);
     expect(dynamoMock).toHaveReceivedCommandWith(TransactWriteCommand, {
       TransactItems: expect.arrayContaining([
         expect.objectContaining({
           Put: expect.objectContaining({
-            Item: expect.objectContaining({
-              userLastActiveUpdated: existingLastActiveUpdated,
-            }),
+            Item: expect.objectContaining({ userLastActiveUpdated: existingLastActiveUpdated }),
           }),
         }),
       ]),
@@ -709,15 +494,13 @@ describe("UpdateInactiveAccountTracker handler", () => {
   });
 
   test("converts historic millisecond timestamps to seconds", async () => {
-    const msTimestamp = 1711929600000;
+    const msTimestamp = 1711929600000; 
     const expectedLastActive = "2024-04-01T00:00:00.000Z";
     const expectedDeletionDate = "2029-04-01";
 
     const streamRecord = generateDynamoStreamRecord("test-client");
     if (streamRecord.dynamodb?.NewImage?.event?.M) {
-      streamRecord.dynamodb.NewImage.event.M.timestamp = {
-        N: msTimestamp.toString(),
-      };
+      streamRecord.dynamodb.NewImage.event.M.timestamp = { N: msTimestamp.toString() };
     }
 
     dynamoMock.on(QueryCommand).resolves({ Items: [] });
@@ -731,9 +514,9 @@ describe("UpdateInactiveAccountTracker handler", () => {
         expect.objectContaining({
           Put: expect.objectContaining({
             TableName: "test-table",
-            Item: expect.objectContaining({
+            Item: expect.objectContaining({ 
               userLastActive: expectedLastActive,
-              dateForDeletion: expectedDeletionDate,
+              dateForDeletion: expectedDeletionDate
             }),
           }),
         }),
@@ -742,14 +525,12 @@ describe("UpdateInactiveAccountTracker handler", () => {
   });
 
   test("leaves valid second-based timestamps untouched", async () => {
-    const secondsTimestamp = 1711929600;
+    const secondsTimestamp = 1711929600; 
     const expectedLastActive = "2024-04-01T00:00:00.000Z";
 
     const streamRecord = generateDynamoStreamRecord("test-client");
     if (streamRecord.dynamodb?.NewImage?.event?.M) {
-      streamRecord.dynamodb.NewImage.event.M.timestamp = {
-        N: secondsTimestamp.toString(),
-      };
+      streamRecord.dynamodb.NewImage.event.M.timestamp = { N: secondsTimestamp.toString() };
     }
 
     dynamoMock.on(QueryCommand).resolves({ Items: [] });
@@ -762,8 +543,8 @@ describe("UpdateInactiveAccountTracker handler", () => {
       TransactItems: expect.arrayContaining([
         expect.objectContaining({
           Put: expect.objectContaining({
-            Item: expect.objectContaining({
-              userLastActive: expectedLastActive,
+            Item: expect.objectContaining({ 
+              userLastActive: expectedLastActive 
             }),
           }),
         }),

--- a/src/tests/update-inactive-account-tracker.test.ts
+++ b/src/tests/update-inactive-account-tracker.test.ts
@@ -2,9 +2,18 @@ import { vi, describe, test, expect, afterEach, beforeEach } from "vitest";
 import { DynamoDBRecord, Context, DynamoDBStreamEvent } from "aws-lambda";
 import { Logger } from "@aws-lambda-powertools/logger";
 import { mockClient } from "aws-sdk-client-mock";
-import { DynamoDBDocumentClient, GetCommand, QueryCommand, TransactWriteCommand } from "@aws-sdk/lib-dynamodb";
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  QueryCommand,
+  TransactWriteCommand,
+} from "@aws-sdk/lib-dynamodb";
 import { handler } from "../update-inactive-account-tracker.js";
-import { generateDynamoStreamRecord, timestamp } from "./testFixtures.js";
+import {
+  generateDynamoStreamRecord,
+  timestamp,
+  txmaEventId,
+} from "./testFixtures.js";
 
 const dynamoMock = mockClient(DynamoDBDocumentClient);
 
@@ -32,10 +41,11 @@ describe("UpdateInactiveAccountTracker handler", () => {
   });
 
   test("queries CommonSubjectIdIndex with user_id", async () => {
-
     dynamoMock.on(QueryCommand).resolves({ Items: [] });
     dynamoMock.on(TransactWriteCommand).resolves({});
-    const event: DynamoDBStreamEvent = { Records: [generateDynamoStreamRecord("test-client")] };
+    const event: DynamoDBStreamEvent = {
+      Records: [generateDynamoStreamRecord("test-client")],
+    };
     await handler(event, {} as Context);
     expect(dynamoMock).toHaveReceivedCommandWith(QueryCommand, {
       TableName: "test-table",
@@ -48,14 +58,23 @@ describe("UpdateInactiveAccountTracker handler", () => {
   test("writes new tracker record via transaction when no existing record", async () => {
     dynamoMock.on(QueryCommand).resolves({ Items: [] });
     dynamoMock.on(TransactWriteCommand).resolves({});
-    const event: DynamoDBStreamEvent = { Records: [generateDynamoStreamRecord("test-client")] };
+    const event: DynamoDBStreamEvent = {
+      Records: [generateDynamoStreamRecord("test-client")],
+    };
     await handler(event, {} as Context);
     expect(dynamoMock).toHaveReceivedCommandWith(TransactWriteCommand, {
       TransactItems: expect.arrayContaining([
         expect.objectContaining({
           Put: expect.objectContaining({
             TableName: "test-table",
-            Item: expect.objectContaining({ commonSubjectId: "qwerty", status: "pending", userLastActiveSource: "AUTH_AUTH_CODE_ISSUED", userLastActiveSourceId: "event_id", emailAddressSource: "AUTH_AUTH_CODE_ISSUED", emailAddressSourceId: "event_id" }),
+            Item: expect.objectContaining({
+              commonSubjectId: "qwerty",
+              status: "pending",
+              userLastActiveSource: "AUTH_AUTH_CODE_ISSUED",
+              userLastActiveSourceId: "event_id",
+              emailAddressSource: "AUTH_AUTH_CODE_ISSUED",
+              emailAddressSourceId: "event_id",
+            }),
           }),
         }),
       ]),
@@ -72,13 +91,17 @@ describe("UpdateInactiveAccountTracker handler", () => {
   test("uses event timestamp as latestDate when no existing record", async () => {
     dynamoMock.on(QueryCommand).resolves({ Items: [] });
     dynamoMock.on(TransactWriteCommand).resolves({});
-    const event: DynamoDBStreamEvent = { Records: [generateDynamoStreamRecord("test-client")] };
+    const event: DynamoDBStreamEvent = {
+      Records: [generateDynamoStreamRecord("test-client")],
+    };
     await handler(event, {} as Context);
     expect(dynamoMock).toHaveReceivedCommandWith(TransactWriteCommand, {
       TransactItems: expect.arrayContaining([
         expect.objectContaining({
           Put: expect.objectContaining({
-            Item: expect.objectContaining({ userLastActive: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T/) }),
+            Item: expect.objectContaining({
+              userLastActive: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T/),
+            }),
           }),
         }),
       ]),
@@ -88,10 +111,21 @@ describe("UpdateInactiveAccountTracker handler", () => {
   test("uses existing userLastActive when it is later than event timestamp", async () => {
     const futureDate = new Date(Date.now() + 86400000).toISOString();
     dynamoMock.on(QueryCommand).resolves({
-      Items: [{ commonSubjectId: "qwerty", dateForDeletion: "2099-01-01", userLastActive: futureDate, status: "active", emailAddress: "x", statusLastUpdated: "" }],
+      Items: [
+        {
+          commonSubjectId: "qwerty",
+          dateForDeletion: "2099-01-01",
+          userLastActive: futureDate,
+          status: "active",
+          emailAddress: "x",
+          statusLastUpdated: "",
+        },
+      ],
     });
     dynamoMock.on(TransactWriteCommand).resolves({});
-    const event: DynamoDBStreamEvent = { Records: [generateDynamoStreamRecord("test-client")] };
+    const event: DynamoDBStreamEvent = {
+      Records: [generateDynamoStreamRecord("test-client")],
+    };
     await handler(event, {} as Context);
     expect(dynamoMock).toHaveReceivedCommandWith(TransactWriteCommand, {
       TransactItems: expect.arrayContaining([
@@ -112,37 +146,81 @@ describe("UpdateInactiveAccountTracker handler", () => {
 
   test("returns early and logs warning when currentItem status is deleting", async () => {
     dynamoMock.on(QueryCommand).resolves({
-      Items: [{ commonSubjectId: "qwerty", dateForDeletion: "2026-01-01", userLastActive: "2026-01-01T00:00:00.000Z", status: "deleting", emailAddress: "x", statusLastUpdated: "" }],
+      Items: [
+        {
+          commonSubjectId: "qwerty",
+          dateForDeletion: "2026-01-01",
+          userLastActive: "2026-01-01T00:00:00.000Z",
+          status: "deleting",
+          emailAddress: "x",
+          statusLastUpdated: "",
+        },
+      ],
     });
-    const event: DynamoDBStreamEvent = { Records: [generateDynamoStreamRecord("test-client")] };
+    const event: DynamoDBStreamEvent = {
+      Records: [generateDynamoStreamRecord("test-client")],
+    };
     await handler(event, {} as Context);
-    expect(loggerWarnMock).toHaveBeenCalledWith("AUTH_EVENT_ON_DELETING_ACCOUNT qwerty");
+    expect(loggerWarnMock).toHaveBeenCalledWith(
+      "AUTH_EVENT_ON_DELETING_ACCOUNT qwerty"
+    );
     expect(dynamoMock).not.toHaveReceivedCommand(TransactWriteCommand);
   });
 
   test("throws assertion error when more than one tracker record exists", async () => {
     dynamoMock.on(QueryCommand).resolves({
       Items: [
-        { commonSubjectId: "qwerty", dateForDeletion: "2026-01-01", userLastActive: "2026-01-01T00:00:00.000Z", status: "pending", emailAddress: "x", statusLastUpdated: "" },
-        { commonSubjectId: "qwerty", dateForDeletion: "2026-01-02", userLastActive: "2026-01-02T00:00:00.000Z", status: "pending", emailAddress: "x", statusLastUpdated: "" },
+        {
+          commonSubjectId: "qwerty",
+          dateForDeletion: "2026-01-01",
+          userLastActive: "2026-01-01T00:00:00.000Z",
+          status: "pending",
+          emailAddress: "x",
+          statusLastUpdated: "",
+        },
+        {
+          commonSubjectId: "qwerty",
+          dateForDeletion: "2026-01-02",
+          userLastActive: "2026-01-02T00:00:00.000Z",
+          status: "pending",
+          emailAddress: "x",
+          statusLastUpdated: "",
+        },
       ],
     });
-    const event: DynamoDBStreamEvent = { Records: [generateDynamoStreamRecord("test-client")] };
-    await expect(handler(event, {} as Context)).rejects.toThrow("found more than one inactivity tracker record for qwerty");
+    const event: DynamoDBStreamEvent = {
+      Records: [generateDynamoStreamRecord("test-client")],
+    };
+    await expect(handler(event, {} as Context)).rejects.toThrow(
+      "found more than one inactivity tracker record for qwerty"
+    );
   });
 
   test("does not delete notification when no existing notification found", async () => {
     dynamoMock.on(QueryCommand).resolves({
-      Items: [{ commonSubjectId: "qwerty", dateForDeletion: "2026-01-01", userLastActive: "2020-01-01T00:00:00.000Z", status: "pending", emailAddress: "x", statusLastUpdated: "" }],
+      Items: [
+        {
+          commonSubjectId: "qwerty",
+          dateForDeletion: "2026-01-01",
+          userLastActive: "2020-01-01T00:00:00.000Z",
+          status: "pending",
+          emailAddress: "x",
+          statusLastUpdated: "",
+        },
+      ],
     });
     dynamoMock.on(GetCommand).resolves({ Item: undefined });
     dynamoMock.on(TransactWriteCommand).resolves({});
-    const event: DynamoDBStreamEvent = { Records: [generateDynamoStreamRecord("test-client")] };
+    const event: DynamoDBStreamEvent = {
+      Records: [generateDynamoStreamRecord("test-client")],
+    };
     await handler(event, {} as Context);
     expect(dynamoMock).toHaveReceivedCommandWith(TransactWriteCommand, {
       TransactItems: expect.not.arrayContaining([
         expect.objectContaining({
-          Delete: expect.objectContaining({ TableName: "user-notifications-table" }),
+          Delete: expect.objectContaining({
+            TableName: "user-notifications-table",
+          }),
         }),
       ]),
     });
@@ -150,20 +228,42 @@ describe("UpdateInactiveAccountTracker handler", () => {
 
   test("does not check notification store when currentItem status is not pending", async () => {
     dynamoMock.on(QueryCommand).resolves({
-      Items: [{ commonSubjectId: "qwerty", dateForDeletion: "2026-01-01", userLastActive: "2020-01-01T00:00:00.000Z", status: "active", emailAddress: "x", statusLastUpdated: "" }],
+      Items: [
+        {
+          commonSubjectId: "qwerty",
+          dateForDeletion: "2026-01-01",
+          userLastActive: "2020-01-01T00:00:00.000Z",
+          status: "active",
+          emailAddress: "x",
+          statusLastUpdated: "",
+        },
+      ],
     });
     dynamoMock.on(TransactWriteCommand).resolves({});
-    const event: DynamoDBStreamEvent = { Records: [generateDynamoStreamRecord("test-client")] };
+    const event: DynamoDBStreamEvent = {
+      Records: [generateDynamoStreamRecord("test-client")],
+    };
     await handler(event, {} as Context);
     expect(dynamoMock).not.toHaveReceivedCommand(GetCommand);
   });
 
   test("does not delete tracker record when dateForDeletion is unchanged", async () => {
     dynamoMock.on(QueryCommand).resolves({
-      Items: [{ commonSubjectId: "qwerty", dateForDeletion: "1978-11-29", userLastActive: "1970-01-01T00:00:00.000Z", status: "pending", emailAddress: "x", statusLastUpdated: "" }],
+      Items: [
+        {
+          commonSubjectId: "qwerty",
+          dateForDeletion: "1978-11-29",
+          userLastActive: "1970-01-01T00:00:00.000Z",
+          status: "pending",
+          emailAddress: "x",
+          statusLastUpdated: "",
+        },
+      ],
     });
     dynamoMock.on(TransactWriteCommand).resolves({});
-    const event: DynamoDBStreamEvent = { Records: [generateDynamoStreamRecord("test-client")] };
+    const event: DynamoDBStreamEvent = {
+      Records: [generateDynamoStreamRecord("test-client")],
+    };
     await handler(event, {} as Context);
     expect(dynamoMock).toHaveReceivedCommandWith(TransactWriteCommand, {
       TransactItems: expect.not.arrayContaining([
@@ -176,8 +276,12 @@ describe("UpdateInactiveAccountTracker handler", () => {
 
   test("throws error when transaction fails", async () => {
     dynamoMock.on(QueryCommand).resolves({ Items: [] });
-    dynamoMock.on(TransactWriteCommand).rejects(new Error("TransactionCanceledException"));
-    const event: DynamoDBStreamEvent = { Records: [generateDynamoStreamRecord("test-client")] };
+    dynamoMock
+      .on(TransactWriteCommand)
+      .rejects(new Error("TransactionCanceledException"));
+    const event: DynamoDBStreamEvent = {
+      Records: [generateDynamoStreamRecord("test-client")],
+    };
     await expect(handler(event, {} as Context)).rejects.toThrow(
       "Failed to update inactive account tracker for user qwerty"
     );
@@ -185,7 +289,15 @@ describe("UpdateInactiveAccountTracker handler", () => {
 
   test("includes email and does not log warning when email exists on the event", async () => {
     dynamoMock.on(QueryCommand).resolves({
-      Items: [{ commonSubjectId: "qwerty", dateForDeletion: "1978-11-29", userLastActive: "1970-01-01T00:00:00.000Z", status: "pending", statusLastUpdated: "" }],
+      Items: [
+        {
+          commonSubjectId: "qwerty",
+          dateForDeletion: "1978-11-29",
+          userLastActive: "1970-01-01T00:00:00.000Z",
+          status: "pending",
+          statusLastUpdated: "",
+        },
+      ],
     });
     const recordWithEmail = {
       dynamodb: {
@@ -197,16 +309,18 @@ describe("UpdateInactiveAccountTracker handler", () => {
               user: {
                 M: {
                   user_id: { S: "qwerty" },
-                  email: { S: "email@exists.uk" }
-                }
-              }
-            }
-          }
-        }
-      }
+                  email: { S: "email@exists.uk" },
+                },
+              },
+            },
+          },
+        },
+      },
     };
 
-    const event: DynamoDBStreamEvent = { Records: [recordWithEmail as DynamoDBRecord] };
+    const event: DynamoDBStreamEvent = {
+      Records: [recordWithEmail as DynamoDBRecord],
+    };
     await handler(event, {} as Context);
     expect(dynamoMock).toHaveReceivedCommandWith(TransactWriteCommand, {
       TransactItems: expect.arrayContaining([
@@ -223,7 +337,15 @@ describe("UpdateInactiveAccountTracker handler", () => {
 
   test("logs warning when email is missing from the event and from pre-existing record", async () => {
     dynamoMock.on(QueryCommand).resolves({
-      Items: [{ commonSubjectId: "qwerty", dateForDeletion: "1978-11-29", userLastActive: "1970-01-01T00:00:00.000Z", status: "pending", statusLastUpdated: "" }],
+      Items: [
+        {
+          commonSubjectId: "qwerty",
+          dateForDeletion: "1978-11-29",
+          userLastActive: "1970-01-01T00:00:00.000Z",
+          status: "pending",
+          statusLastUpdated: "",
+        },
+      ],
     });
     const invalidRecord = {
       dynamodb: {
@@ -234,27 +356,34 @@ describe("UpdateInactiveAccountTracker handler", () => {
               timestamp: { N: "1711929600" },
               user: {
                 M: {
-                  user_id: { S: "qwerty" }
-                }
-              }
-            }
-          }
-        }
-      }
+                  user_id: { S: "qwerty" },
+                },
+              },
+            },
+          },
+        },
+      },
     };
-    const event: DynamoDBStreamEvent = { Records: [invalidRecord as DynamoDBRecord] };
+    const event: DynamoDBStreamEvent = {
+      Records: [invalidRecord as DynamoDBRecord],
+    };
     await handler(event, {} as Context);
     expect(dynamoMock).toHaveReceivedCommandWith(TransactWriteCommand, {
       TransactItems: expect.arrayContaining([
         expect.objectContaining({
           Put: expect.objectContaining({
             TableName: "test-table",
-            Item: expect.objectContaining({ commonSubjectId: "qwerty", emailAddress: "" }),
+            Item: expect.objectContaining({
+              commonSubjectId: "qwerty",
+              emailAddress: "",
+            }),
           }),
         }),
       ]),
     });
-    expect(loggerWarnMock).toHaveBeenCalledWith("AUTH_EVENT_NO_EMAIL for userId qwerty");
+    expect(loggerWarnMock).toHaveBeenCalledWith(
+      "AUTH_EVENT_NO_EMAIL for userId qwerty"
+    );
   });
 
   test("stores publicSubjectId from event when present", async () => {
@@ -279,13 +408,17 @@ describe("UpdateInactiveAccountTracker handler", () => {
         },
       },
     };
-    const event: DynamoDBStreamEvent = { Records: [recordWithPublicSubjectId as DynamoDBRecord] };
+    const event: DynamoDBStreamEvent = {
+      Records: [recordWithPublicSubjectId as DynamoDBRecord],
+    };
     await handler(event, {} as Context);
     expect(dynamoMock).toHaveReceivedCommandWith(TransactWriteCommand, {
       TransactItems: expect.arrayContaining([
         expect.objectContaining({
           Put: expect.objectContaining({
-            Item: expect.objectContaining({ publicSubjectId: "public-subject-123" }),
+            Item: expect.objectContaining({
+              publicSubjectId: "public-subject-123",
+            }),
           }),
         }),
       ]),
@@ -294,7 +427,17 @@ describe("UpdateInactiveAccountTracker handler", () => {
 
   test("falls back to publicSubjectId from existing tracker record when not on event", async () => {
     dynamoMock.on(QueryCommand).resolves({
-      Items: [{ commonSubjectId: "qwerty", dateForDeletion: "1978-11-29", userLastActive: "1970-01-01T00:00:00.000Z", emailAddress: "x", publicSubjectId: "public-subject-from-record", status: "pending", statusLastUpdated: "" }],
+      Items: [
+        {
+          commonSubjectId: "qwerty",
+          dateForDeletion: "1978-11-29",
+          userLastActive: "1970-01-01T00:00:00.000Z",
+          emailAddress: "x",
+          publicSubjectId: "public-subject-from-record",
+          status: "pending",
+          statusLastUpdated: "",
+        },
+      ],
     });
     dynamoMock.on(TransactWriteCommand).resolves({});
     const recordWithoutPublicSubjectId = {
@@ -311,13 +454,17 @@ describe("UpdateInactiveAccountTracker handler", () => {
         },
       },
     };
-    const event: DynamoDBStreamEvent = { Records: [recordWithoutPublicSubjectId as DynamoDBRecord] };
+    const event: DynamoDBStreamEvent = {
+      Records: [recordWithoutPublicSubjectId as DynamoDBRecord],
+    };
     await handler(event, {} as Context);
     expect(dynamoMock).toHaveReceivedCommandWith(TransactWriteCommand, {
       TransactItems: expect.arrayContaining([
         expect.objectContaining({
           Put: expect.objectContaining({
-            Item: expect.objectContaining({ publicSubjectId: "public-subject-from-record" }),
+            Item: expect.objectContaining({
+              publicSubjectId: "public-subject-from-record",
+            }),
           }),
         }),
       ]),
@@ -341,7 +488,9 @@ describe("UpdateInactiveAccountTracker handler", () => {
         },
       },
     };
-    const event: DynamoDBStreamEvent = { Records: [recordWithoutPublicSubjectId as DynamoDBRecord] };
+    const event: DynamoDBStreamEvent = {
+      Records: [recordWithoutPublicSubjectId as DynamoDBRecord],
+    };
     await handler(event, {} as Context);
     expect(dynamoMock).toHaveReceivedCommandWith(TransactWriteCommand, {
       TransactItems: expect.arrayContaining([
@@ -354,9 +503,95 @@ describe("UpdateInactiveAccountTracker handler", () => {
     });
   });
 
+  test("preserves emailAddressSource and emailAddressSourceId from existing record when email is unchanged", async () => {
+    dynamoMock.on(QueryCommand).resolves({
+      Items: [
+        {
+          commonSubjectId: "qwerty",
+          dateForDeletion: "1978-11-29",
+          userLastActive: "1970-01-01T00:00:00.000Z",
+          emailAddress: "foo@bar.com",
+          emailAddressSource: "AUTH_PREVIOUS_EVENT",
+          emailAddressSourceId: "old-event-id",
+          emailAddressLastUpdated: "2020-01-01T00:00:00.000Z",
+          status: "pending",
+          statusLastUpdated: "",
+        },
+      ],
+    });
+    dynamoMock.on(TransactWriteCommand).resolves({});
+    // generateDynamoStreamRecord includes email: "foo@bar.com" which matches the existing record
+    const event: DynamoDBStreamEvent = {
+      Records: [generateDynamoStreamRecord("test-client")],
+    };
+    await handler(event, {} as Context);
+    expect(dynamoMock).toHaveReceivedCommandWith(TransactWriteCommand, {
+      TransactItems: expect.arrayContaining([
+        expect.objectContaining({
+          Put: expect.objectContaining({
+            Item: expect.objectContaining({
+              emailAddress: "foo@bar.com",
+              emailAddressSource: "AUTH_PREVIOUS_EVENT",
+              emailAddressSourceId: "old-event-id",
+              emailAddressLastUpdated: "2020-01-01T00:00:00.000Z",
+            }),
+          }),
+        }),
+      ]),
+    });
+  });
+
+  test("updates emailAddressSource, emailAddressSourceId and emailAddressLastUpdated when email changes", async () => {
+    dynamoMock.on(QueryCommand).resolves({
+      Items: [
+        {
+          commonSubjectId: "qwerty",
+          dateForDeletion: "1978-11-29",
+          userLastActive: "1970-01-01T00:00:00.000Z",
+          emailAddress: "old@email.com",
+          emailAddressSource: "AUTH_PREVIOUS_EVENT",
+          emailAddressSourceId: "old-event-id",
+          emailAddressLastUpdated: "2020-01-01T00:00:00.000Z",
+          status: "pending",
+          statusLastUpdated: "",
+        },
+      ],
+    });
+    dynamoMock.on(TransactWriteCommand).resolves({});
+    // generateDynamoStreamRecord uses timestamp = 123456789 seconds => 1973-11-29T21:33:09.000Z
+    const expectedEventDateTime = new Date(timestamp * 1000).toISOString();
+    const event: DynamoDBStreamEvent = {
+      Records: [generateDynamoStreamRecord("test-client")],
+    };
+    await handler(event, {} as Context);
+    expect(dynamoMock).toHaveReceivedCommandWith(TransactWriteCommand, {
+      TransactItems: expect.arrayContaining([
+        expect.objectContaining({
+          Put: expect.objectContaining({
+            Item: expect.objectContaining({
+              emailAddress: "foo@bar.com",
+              emailAddressSource: "AUTH_AUTH_CODE_ISSUED",
+              emailAddressSourceId: txmaEventId,
+              emailAddressLastUpdated: expectedEventDateTime,
+            }),
+          }),
+        }),
+      ]),
+    });
+  });
+
   test("logs warning when email is missing from the event but is present in pre-existing record", async () => {
     dynamoMock.on(QueryCommand).resolves({
-      Items: [{ commonSubjectId: "qwerty", dateForDeletion: "1978-11-29", userLastActive: "1970-01-01T00:00:00.000Z", emailAddress: "testing-warning@test.co", status: "pending", statusLastUpdated: "" }],
+      Items: [
+        {
+          commonSubjectId: "qwerty",
+          dateForDeletion: "1978-11-29",
+          userLastActive: "1970-01-01T00:00:00.000Z",
+          emailAddress: "testing-warning@test.co",
+          status: "pending",
+          statusLastUpdated: "",
+        },
+      ],
     });
     const invalidRecord = {
       dynamodb: {
@@ -367,37 +602,122 @@ describe("UpdateInactiveAccountTracker handler", () => {
               timestamp: { N: "1711929600" },
               user: {
                 M: {
-                  user_id: { S: "qwerty" }
-                }
-              }
-            }
-          }
-        }
-      }
+                  user_id: { S: "qwerty" },
+                },
+              },
+            },
+          },
+        },
+      },
     };
-    const event: DynamoDBStreamEvent = { Records: [invalidRecord as DynamoDBRecord] };
+    const event: DynamoDBStreamEvent = {
+      Records: [invalidRecord as DynamoDBRecord],
+    };
     await handler(event, {} as Context);
     expect(dynamoMock).toHaveReceivedCommandWith(TransactWriteCommand, {
       TransactItems: expect.arrayContaining([
         expect.objectContaining({
           Put: expect.objectContaining({
             TableName: "test-table",
-            Item: expect.objectContaining({ commonSubjectId: "qwerty", emailAddress: "testing-warning@test.co" }),
+            Item: expect.objectContaining({
+              commonSubjectId: "qwerty",
+              emailAddress: "testing-warning@test.co",
+            }),
           }),
         }),
       ]),
     });
-    expect(loggerWarnMock).toHaveBeenCalledWith("AUTH_EVENT_NO_EMAIL for userId qwerty");
+    expect(loggerWarnMock).toHaveBeenCalledWith(
+      "AUTH_EVENT_NO_EMAIL for userId qwerty"
+    );
+  });
+
+  test("sets statusLastUpdated to the event timestamp", async () => {
+    dynamoMock.on(QueryCommand).resolves({ Items: [] });
+    dynamoMock.on(TransactWriteCommand).resolves({});
+    const expectedEventDateTime = new Date(timestamp * 1000).toISOString();
+    const event: DynamoDBStreamEvent = {
+      Records: [generateDynamoStreamRecord("test-client")],
+    };
+    await handler(event, {} as Context);
+    expect(dynamoMock).toHaveReceivedCommandWith(TransactWriteCommand, {
+      TransactItems: expect.arrayContaining([
+        expect.objectContaining({
+          Put: expect.objectContaining({
+            Item: expect.objectContaining({
+              statusLastUpdated: expectedEventDateTime,
+            }),
+          }),
+        }),
+      ]),
+    });
+  });
+
+  test("sets userLastActiveUpdated to the event timestamp when event is newer", async () => {
+    dynamoMock.on(QueryCommand).resolves({ Items: [] });
+    dynamoMock.on(TransactWriteCommand).resolves({});
+    const expectedEventDateTime = new Date(timestamp * 1000).toISOString();
+    const event: DynamoDBStreamEvent = {
+      Records: [generateDynamoStreamRecord("test-client")],
+    };
+    await handler(event, {} as Context);
+    expect(dynamoMock).toHaveReceivedCommandWith(TransactWriteCommand, {
+      TransactItems: expect.arrayContaining([
+        expect.objectContaining({
+          Put: expect.objectContaining({
+            Item: expect.objectContaining({
+              userLastActiveUpdated: expectedEventDateTime,
+            }),
+          }),
+        }),
+      ]),
+    });
+  });
+
+  test("preserves userLastActiveUpdated from existing record when event is older", async () => {
+    const existingLastActiveUpdated = "2099-01-01T00:00:00.000Z";
+    const futureDate = new Date(Date.now() + 86400000).toISOString();
+    dynamoMock.on(QueryCommand).resolves({
+      Items: [
+        {
+          commonSubjectId: "qwerty",
+          dateForDeletion: "2099-01-01",
+          userLastActive: futureDate,
+          userLastActiveUpdated: existingLastActiveUpdated,
+          status: "pending",
+          emailAddress: "x",
+          statusLastUpdated: "",
+        },
+      ],
+    });
+    dynamoMock.on(TransactWriteCommand).resolves({});
+    const event: DynamoDBStreamEvent = {
+      Records: [generateDynamoStreamRecord("test-client")],
+    };
+    await handler(event, {} as Context);
+    expect(dynamoMock).toHaveReceivedCommandWith(TransactWriteCommand, {
+      TransactItems: expect.arrayContaining([
+        expect.objectContaining({
+          Put: expect.objectContaining({
+            Item: expect.objectContaining({
+              userLastActiveUpdated: existingLastActiveUpdated,
+            }),
+          }),
+        }),
+      ]),
+    });
   });
 
   test("converts historic millisecond timestamps to seconds", async () => {
-    const msTimestamp = 1711929600000; 
+    const msTimestamp = 1711929600000;
     const expectedLastActive = "2024-04-01T00:00:00.000Z";
     const expectedDeletionDate = "2029-04-01";
 
     const streamRecord = generateDynamoStreamRecord("test-client");
     if (streamRecord.dynamodb?.NewImage?.event?.M) {
-      streamRecord.dynamodb.NewImage.event.M.timestamp = { N: msTimestamp.toString() };
+      streamRecord.dynamodb.NewImage.event.M.timestamp = {
+        N: msTimestamp.toString(),
+      };
     }
 
     dynamoMock.on(QueryCommand).resolves({ Items: [] });
@@ -411,9 +731,9 @@ describe("UpdateInactiveAccountTracker handler", () => {
         expect.objectContaining({
           Put: expect.objectContaining({
             TableName: "test-table",
-            Item: expect.objectContaining({ 
+            Item: expect.objectContaining({
               userLastActive: expectedLastActive,
-              dateForDeletion: expectedDeletionDate
+              dateForDeletion: expectedDeletionDate,
             }),
           }),
         }),
@@ -422,12 +742,14 @@ describe("UpdateInactiveAccountTracker handler", () => {
   });
 
   test("leaves valid second-based timestamps untouched", async () => {
-    const secondsTimestamp = 1711929600; 
+    const secondsTimestamp = 1711929600;
     const expectedLastActive = "2024-04-01T00:00:00.000Z";
 
     const streamRecord = generateDynamoStreamRecord("test-client");
     if (streamRecord.dynamodb?.NewImage?.event?.M) {
-      streamRecord.dynamodb.NewImage.event.M.timestamp = { N: secondsTimestamp.toString() };
+      streamRecord.dynamodb.NewImage.event.M.timestamp = {
+        N: secondsTimestamp.toString(),
+      };
     }
 
     dynamoMock.on(QueryCommand).resolves({ Items: [] });
@@ -440,8 +762,8 @@ describe("UpdateInactiveAccountTracker handler", () => {
       TransactItems: expect.arrayContaining([
         expect.objectContaining({
           Put: expect.objectContaining({
-            Item: expect.objectContaining({ 
-              userLastActive: expectedLastActive 
+            Item: expect.objectContaining({
+              userLastActive: expectedLastActive,
             }),
           }),
         }),

--- a/src/tests/update-inactive-account-tracker.test.ts
+++ b/src/tests/update-inactive-account-tracker.test.ts
@@ -439,6 +439,27 @@ describe("UpdateInactiveAccountTracker handler", () => {
     expect(loggerWarnMock).toHaveBeenCalledWith("AUTH_EVENT_NO_EMAIL for userId qwerty");
   });
 
+  test("uses event_timestamp_ms for eventDateTime when present", async () => {
+    dynamoMock.on(QueryCommand).resolves({ Items: [] });
+    dynamoMock.on(TransactWriteCommand).resolves({});
+    const msTimestamp = 1711929600123;
+    const streamRecord = generateDynamoStreamRecord("test-client");
+    if (streamRecord.dynamodb?.NewImage?.event?.M) {
+      streamRecord.dynamodb.NewImage.event.M.event_timestamp_ms = { N: msTimestamp.toString() };
+    }
+    const event: DynamoDBStreamEvent = { Records: [streamRecord] };
+    await handler(event, {} as Context);
+    expect(dynamoMock).toHaveReceivedCommandWith(TransactWriteCommand, {
+      TransactItems: expect.arrayContaining([
+        expect.objectContaining({
+          Put: expect.objectContaining({
+            Item: expect.objectContaining({ statusLastUpdated: new Date(msTimestamp).toISOString() }),
+          }),
+        }),
+      ]),
+    });
+  });
+
   test("sets statusLastUpdated to the event timestamp", async () => {
     dynamoMock.on(QueryCommand).resolves({ Items: [] });
     dynamoMock.on(TransactWriteCommand).resolves({});

--- a/src/tests/update-user-email.test.ts
+++ b/src/tests/update-user-email.test.ts
@@ -2,11 +2,7 @@ import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
 import { Context, DynamoDBStreamEvent } from "aws-lambda";
 import { Logger } from "@aws-lambda-powertools/logger";
 import { mockClient } from "aws-sdk-client-mock";
-import {
-  DynamoDBDocumentClient,
-  QueryCommand,
-  UpdateCommand,
-} from "@aws-sdk/lib-dynamodb";
+import { DynamoDBDocumentClient, QueryCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
 import { handler } from "../update-user-email.js";
 
 const dynamoMock = mockClient(DynamoDBDocumentClient);
@@ -18,8 +14,7 @@ describe("update-user-email", () => {
     .mockImplementation(() => undefined);
 
   beforeEach(() => {
-    process.env.INACTIVE_ACCOUNT_TRACKER_TABLE_NAME =
-      "test-inactive-tracker-table";
+    process.env.INACTIVE_ACCOUNT_TRACKER_TABLE_NAME = "test-inactive-tracker-table";
     dynamoMock.reset();
   });
 
@@ -28,7 +23,10 @@ describe("update-user-email", () => {
     delete process.env.INACTIVE_ACCOUNT_TRACKER_TABLE_NAME;
   });
 
-  const createEvent = (userId?: string, email?: string): DynamoDBStreamEvent =>
+  const createEvent = (
+    userId?: string,
+    email?: string
+  ): DynamoDBStreamEvent =>
     ({
       Records: [
         {
@@ -65,17 +63,10 @@ describe("update-user-email", () => {
   });
 
   it("queries the CommonSubjectIdIndex with the user_id", async () => {
-    dynamoMock.on(QueryCommand).resolves({
-      Items: [
-        { dateForDeletion: "2031-06-30", commonSubjectId: "test-user-id" },
-      ],
-    });
+    dynamoMock.on(QueryCommand).resolves({ Items: [{ dateForDeletion: "2031-06-30", commonSubjectId: "test-user-id" }] });
     dynamoMock.on(UpdateCommand).resolves({});
 
-    await handler(
-      createEvent("test-user-id", "new-email@example.com"),
-      {} as Context
-    );
+    await handler(createEvent("test-user-id", "new-email@example.com"), {} as Context);
 
     expect(dynamoMock).toHaveReceivedCommandWith(QueryCommand, {
       TableName: "test-inactive-tracker-table",
@@ -87,20 +78,11 @@ describe("update-user-email", () => {
 
   it("updates email address fields when a record is found", async () => {
     dynamoMock.on(QueryCommand).resolves({
-      Items: [
-        {
-          dateForDeletion: "2031-06-30",
-          commonSubjectId: "test-user-id",
-          emailAddress: "old@example.com",
-        },
-      ],
+      Items: [{ dateForDeletion: "2031-06-30", commonSubjectId: "test-user-id", emailAddress: "old@example.com" }],
     });
     dynamoMock.on(UpdateCommand).resolves({});
 
-    await handler(
-      createEvent("test-user-id", "new-email@example.com"),
-      {} as Context
-    );
+    await handler(createEvent("test-user-id", "new-email@example.com"), {} as Context);
 
     expect(dynamoMock).toHaveReceivedCommandWith(UpdateCommand, {
       TableName: "test-inactive-tracker-table",
@@ -108,8 +90,7 @@ describe("update-user-email", () => {
         dateForDeletion: "2031-06-30",
         commonSubjectId: "test-user-id",
       },
-      UpdateExpression:
-        "SET emailAddress = :email, emailAddressSource = :source, emailAddressLastUpdated = :lastUpdated",
+      UpdateExpression: "SET emailAddress = :email, emailAddressSource = :source, emailAddressLastUpdated = :lastUpdated",
       ExpressionAttributeValues: {
         ":email": "new-email@example.com",
         ":source": "AUTH_UPDATE_EMAIL",
@@ -120,41 +101,31 @@ describe("update-user-email", () => {
 
   it("includes emailAddressSourceId in update when event_id is present", async () => {
     dynamoMock.on(QueryCommand).resolves({
-      Items: [
-        { dateForDeletion: "2031-06-30", commonSubjectId: "test-user-id" },
-      ],
+      Items: [{ dateForDeletion: "2031-06-30", commonSubjectId: "test-user-id" }],
     });
     dynamoMock.on(UpdateCommand).resolves({});
 
     const eventWithId = {
-      Records: [
-        {
-          dynamodb: {
-            NewImage: {
-              event: {
-                M: {
-                  event_id: { S: "test-event-id" },
-                  event_name: { S: "AUTH_UPDATE_EMAIL" },
-                  timestamp: { N: "1666169856" },
-                  user: {
-                    M: {
-                      user_id: { S: "test-user-id" },
-                      email: { S: "new-email@example.com" },
-                    },
-                  },
-                },
+      Records: [{
+        dynamodb: {
+          NewImage: {
+            event: {
+              M: {
+                event_id: { S: "test-event-id" },
+                event_name: { S: "AUTH_UPDATE_EMAIL" },
+                timestamp: { N: "1666169856" },
+                user: { M: { user_id: { S: "test-user-id" }, email: { S: "new-email@example.com" } } },
               },
             },
           },
         },
-      ],
+      }],
     } as unknown as DynamoDBStreamEvent;
 
     await handler(eventWithId, {} as Context);
 
     expect(dynamoMock).toHaveReceivedCommandWith(UpdateCommand, {
-      UpdateExpression:
-        "SET emailAddress = :email, emailAddressSource = :source, emailAddressLastUpdated = :lastUpdated, emailAddressSourceId = :sourceId",
+      UpdateExpression: "SET emailAddress = :email, emailAddressSource = :source, emailAddressLastUpdated = :lastUpdated, emailAddressSourceId = :sourceId",
       ExpressionAttributeValues: {
         ":email": "new-email@example.com",
         ":source": "AUTH_UPDATE_EMAIL",
@@ -167,10 +138,7 @@ describe("update-user-email", () => {
   it("does not update when no record is found for the user", async () => {
     dynamoMock.on(QueryCommand).resolves({ Items: [] });
 
-    await handler(
-      createEvent("test-user-id", "new-email@example.com"),
-      {} as Context
-    );
+    await handler(createEvent("test-user-id", "new-email@example.com"), {} as Context);
 
     expect(dynamoMock).not.toHaveReceivedCommand(UpdateCommand);
     expect(loggerWarnMock).toHaveBeenCalledWith(
@@ -180,14 +148,9 @@ describe("update-user-email", () => {
   });
 
   it("processes multiple records in a single event", async () => {
-    dynamoMock
-      .on(QueryCommand)
-      .resolvesOnce({
-        Items: [{ dateForDeletion: "2031-06-30", commonSubjectId: "user-1" }],
-      })
-      .resolvesOnce({
-        Items: [{ dateForDeletion: "2031-07-15", commonSubjectId: "user-2" }],
-      });
+    dynamoMock.on(QueryCommand)
+      .resolvesOnce({ Items: [{ dateForDeletion: "2031-06-30", commonSubjectId: "user-1" }] })
+      .resolvesOnce({ Items: [{ dateForDeletion: "2031-07-15", commonSubjectId: "user-2" }] });
     dynamoMock.on(UpdateCommand).resolves({});
 
     const multiRecordEvent = {
@@ -241,12 +204,7 @@ describe("update-user-email", () => {
     delete process.env.INACTIVE_ACCOUNT_TRACKER_TABLE_NAME;
 
     await expect(
-      handler(
-        createEvent("test-user-id", "new-email@example.com"),
-        {} as Context
-      )
-    ).rejects.toThrow(
-      'Environment variable "INACTIVE_ACCOUNT_TRACKER_TABLE_NAME" is not set.'
-    );
+      handler(createEvent("test-user-id", "new-email@example.com"), {} as Context)
+    ).rejects.toThrow('Environment variable "INACTIVE_ACCOUNT_TRACKER_TABLE_NAME" is not set.');
   });
 });

--- a/src/tests/update-user-email.test.ts
+++ b/src/tests/update-user-email.test.ts
@@ -2,7 +2,11 @@ import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
 import { Context, DynamoDBStreamEvent } from "aws-lambda";
 import { Logger } from "@aws-lambda-powertools/logger";
 import { mockClient } from "aws-sdk-client-mock";
-import { DynamoDBDocumentClient, QueryCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
+import {
+  DynamoDBDocumentClient,
+  QueryCommand,
+  UpdateCommand,
+} from "@aws-sdk/lib-dynamodb";
 import { handler } from "../update-user-email.js";
 
 const dynamoMock = mockClient(DynamoDBDocumentClient);
@@ -14,7 +18,8 @@ describe("update-user-email", () => {
     .mockImplementation(() => undefined);
 
   beforeEach(() => {
-    process.env.INACTIVE_ACCOUNT_TRACKER_TABLE_NAME = "test-inactive-tracker-table";
+    process.env.INACTIVE_ACCOUNT_TRACKER_TABLE_NAME =
+      "test-inactive-tracker-table";
     dynamoMock.reset();
   });
 
@@ -23,10 +28,7 @@ describe("update-user-email", () => {
     delete process.env.INACTIVE_ACCOUNT_TRACKER_TABLE_NAME;
   });
 
-  const createEvent = (
-    userId?: string,
-    email?: string
-  ): DynamoDBStreamEvent =>
+  const createEvent = (userId?: string, email?: string): DynamoDBStreamEvent =>
     ({
       Records: [
         {
@@ -63,10 +65,17 @@ describe("update-user-email", () => {
   });
 
   it("queries the CommonSubjectIdIndex with the user_id", async () => {
-    dynamoMock.on(QueryCommand).resolves({ Items: [{ dateForDeletion: "2031-06-30", commonSubjectId: "test-user-id" }] });
+    dynamoMock.on(QueryCommand).resolves({
+      Items: [
+        { dateForDeletion: "2031-06-30", commonSubjectId: "test-user-id" },
+      ],
+    });
     dynamoMock.on(UpdateCommand).resolves({});
 
-    await handler(createEvent("test-user-id", "new-email@example.com"), {} as Context);
+    await handler(
+      createEvent("test-user-id", "new-email@example.com"),
+      {} as Context
+    );
 
     expect(dynamoMock).toHaveReceivedCommandWith(QueryCommand, {
       TableName: "test-inactive-tracker-table",
@@ -76,13 +85,22 @@ describe("update-user-email", () => {
     });
   });
 
-  it("updates the emailAddress field when a record is found", async () => {
+  it("updates email address fields when a record is found", async () => {
     dynamoMock.on(QueryCommand).resolves({
-      Items: [{ dateForDeletion: "2031-06-30", commonSubjectId: "test-user-id", emailAddress: "old@example.com" }],
+      Items: [
+        {
+          dateForDeletion: "2031-06-30",
+          commonSubjectId: "test-user-id",
+          emailAddress: "old@example.com",
+        },
+      ],
     });
     dynamoMock.on(UpdateCommand).resolves({});
 
-    await handler(createEvent("test-user-id", "new-email@example.com"), {} as Context);
+    await handler(
+      createEvent("test-user-id", "new-email@example.com"),
+      {} as Context
+    );
 
     expect(dynamoMock).toHaveReceivedCommandWith(UpdateCommand, {
       TableName: "test-inactive-tracker-table",
@@ -90,15 +108,69 @@ describe("update-user-email", () => {
         dateForDeletion: "2031-06-30",
         commonSubjectId: "test-user-id",
       },
-      UpdateExpression: "SET emailAddress = :email",
-      ExpressionAttributeValues: { ":email": "new-email@example.com" },
+      UpdateExpression:
+        "SET emailAddress = :email, emailAddressSource = :source, emailAddressLastUpdated = :lastUpdated",
+      ExpressionAttributeValues: {
+        ":email": "new-email@example.com",
+        ":source": "AUTH_UPDATE_EMAIL",
+        ":lastUpdated": new Date(1666169856 * 1000).toISOString(),
+      },
+    });
+  });
+
+  it("includes emailAddressSourceId in update when event_id is present", async () => {
+    dynamoMock.on(QueryCommand).resolves({
+      Items: [
+        { dateForDeletion: "2031-06-30", commonSubjectId: "test-user-id" },
+      ],
+    });
+    dynamoMock.on(UpdateCommand).resolves({});
+
+    const eventWithId = {
+      Records: [
+        {
+          dynamodb: {
+            NewImage: {
+              event: {
+                M: {
+                  event_id: { S: "test-event-id" },
+                  event_name: { S: "AUTH_UPDATE_EMAIL" },
+                  timestamp: { N: "1666169856" },
+                  user: {
+                    M: {
+                      user_id: { S: "test-user-id" },
+                      email: { S: "new-email@example.com" },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      ],
+    } as unknown as DynamoDBStreamEvent;
+
+    await handler(eventWithId, {} as Context);
+
+    expect(dynamoMock).toHaveReceivedCommandWith(UpdateCommand, {
+      UpdateExpression:
+        "SET emailAddress = :email, emailAddressSource = :source, emailAddressLastUpdated = :lastUpdated, emailAddressSourceId = :sourceId",
+      ExpressionAttributeValues: {
+        ":email": "new-email@example.com",
+        ":source": "AUTH_UPDATE_EMAIL",
+        ":lastUpdated": new Date(1666169856 * 1000).toISOString(),
+        ":sourceId": "test-event-id",
+      },
     });
   });
 
   it("does not update when no record is found for the user", async () => {
     dynamoMock.on(QueryCommand).resolves({ Items: [] });
 
-    await handler(createEvent("test-user-id", "new-email@example.com"), {} as Context);
+    await handler(
+      createEvent("test-user-id", "new-email@example.com"),
+      {} as Context
+    );
 
     expect(dynamoMock).not.toHaveReceivedCommand(UpdateCommand);
     expect(loggerWarnMock).toHaveBeenCalledWith(
@@ -108,9 +180,14 @@ describe("update-user-email", () => {
   });
 
   it("processes multiple records in a single event", async () => {
-    dynamoMock.on(QueryCommand)
-      .resolvesOnce({ Items: [{ dateForDeletion: "2031-06-30", commonSubjectId: "user-1" }] })
-      .resolvesOnce({ Items: [{ dateForDeletion: "2031-07-15", commonSubjectId: "user-2" }] });
+    dynamoMock
+      .on(QueryCommand)
+      .resolvesOnce({
+        Items: [{ dateForDeletion: "2031-06-30", commonSubjectId: "user-1" }],
+      })
+      .resolvesOnce({
+        Items: [{ dateForDeletion: "2031-07-15", commonSubjectId: "user-2" }],
+      });
     dynamoMock.on(UpdateCommand).resolves({});
 
     const multiRecordEvent = {
@@ -164,7 +241,12 @@ describe("update-user-email", () => {
     delete process.env.INACTIVE_ACCOUNT_TRACKER_TABLE_NAME;
 
     await expect(
-      handler(createEvent("test-user-id", "new-email@example.com"), {} as Context)
-    ).rejects.toThrow('Environment variable "INACTIVE_ACCOUNT_TRACKER_TABLE_NAME" is not set.');
+      handler(
+        createEvent("test-user-id", "new-email@example.com"),
+        {} as Context
+      )
+    ).rejects.toThrow(
+      'Environment variable "INACTIVE_ACCOUNT_TRACKER_TABLE_NAME" is not set.'
+    );
   });
 });

--- a/src/tests/update-user-email.test.ts
+++ b/src/tests/update-user-email.test.ts
@@ -76,6 +76,39 @@ describe("update-user-email", () => {
     });
   });
 
+  it("uses event_timestamp_ms for emailAddressLastUpdated when present", async () => {
+    dynamoMock.on(QueryCommand).resolves({
+      Items: [{ dateForDeletion: "2031-06-30", commonSubjectId: "test-user-id" }],
+    });
+    dynamoMock.on(UpdateCommand).resolves({});
+
+    const msTimestamp = 1666169856123;
+    const eventWithMs = {
+      Records: [{
+        dynamodb: {
+          NewImage: {
+            event: {
+              M: {
+                event_name: { S: "AUTH_UPDATE_EMAIL" },
+                timestamp: { N: "1666169856" },
+                event_timestamp_ms: { N: msTimestamp.toString() },
+                user: { M: { user_id: { S: "test-user-id" }, email: { S: "new-email@example.com" } } },
+              },
+            },
+          },
+        },
+      }],
+    } as unknown as DynamoDBStreamEvent;
+
+    await handler(eventWithMs, {} as Context);
+
+    expect(dynamoMock).toHaveReceivedCommandWith(UpdateCommand, {
+      ExpressionAttributeValues: expect.objectContaining({
+        ":lastUpdated": new Date(msTimestamp).toISOString(),
+      }),
+    });
+  });
+
   it("updates email address fields when a record is found", async () => {
     dynamoMock.on(QueryCommand).resolves({
       Items: [{ dateForDeletion: "2031-06-30", commonSubjectId: "test-user-id", emailAddress: "old@example.com" }],

--- a/src/update-inactive-account-tracker.ts
+++ b/src/update-inactive-account-tracker.ts
@@ -1,29 +1,20 @@
 import { Context, DynamoDBStreamEvent } from "aws-lambda";
 import { AttributeValue, DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { unmarshall } from "@aws-sdk/util-dynamodb";
-import {
-  DynamoDBDocumentClient,
-  QueryCommand,
-  TransactWriteCommand,
-} from "@aws-sdk/lib-dynamodb";
+import { DynamoDBDocumentClient, QueryCommand, TransactWriteCommand } from "@aws-sdk/lib-dynamodb";
 import { TxmaEvent } from "./common/model.js";
 import { getEnvironmentVariable } from "./common/utils.js";
 import { Logger } from "@aws-lambda-powertools/logger";
 import type { InactiveAccountTrackerRecord } from "./common/model.ts";
-import assert from "node:assert/strict";
+import assert from 'node:assert/strict';
 
 const logger = new Logger();
 const dynamoClient = new DynamoDBClient({});
 const dynamoDocClient = DynamoDBDocumentClient.from(dynamoClient);
 
-type TransactionItems = ConstructorParameters<
-  typeof TransactWriteCommand
->[0]["TransactItems"];
+type TransactionItems = ConstructorParameters<typeof TransactWriteCommand>[0]['TransactItems']
 
-const getCurrentRecordForUser = async (
-  userId: string,
-  tableName: string
-): Promise<InactiveAccountTrackerRecord | null> => {
+const getCurrentRecordForUser = async (userId: string, tableName: string): Promise<InactiveAccountTrackerRecord | null> => {
   const response = await dynamoDocClient.send(
     new QueryCommand({
       IndexName: "CommonSubjectIdIndex",
@@ -34,24 +25,16 @@ const getCurrentRecordForUser = async (
   );
 
   assert(response.Items !== undefined, "Query response is missing Items");
-  assert(
-    response.Items.length < 2,
-    `found more than one inactivity tracker record for ${userId}`
-  );
+  assert(response.Items.length < 2, `found more than one inactivity tracker record for ${userId}`)
 
-  return response.Items.length > 0
-    ? (response.Items[0] as InactiveAccountTrackerRecord)
-    : null;
-};
+  return response.Items.length > 0 ? response.Items[0] as InactiveAccountTrackerRecord : null;
+}
 
-const getLatestDate = (
-  txmaEvent: TxmaEvent,
-  trackerRecord: InactiveAccountTrackerRecord | null
-) => {
+const getLatestDate = (txmaEvent: TxmaEvent, trackerRecord: InactiveAccountTrackerRecord | null) => {
   let timestamp = txmaEvent.timestamp;
 
   // some txma events timestamps are in milliseconds when they should be in seconds.
-  // if the timestamp is over 13 digits it is essentially guaranteed to be in milliseconds.
+  // if the timestamp is over 13 digits it is essentially guaranteed to be in milliseconds. 
   // 13 digit millisecond timestamps started 9 September 2001.
   if (timestamp.toString().length >= 13) {
     timestamp = Math.floor(timestamp / 1000);
@@ -60,18 +43,16 @@ const getLatestDate = (
   // if the timestamp on the audit event is older than the last active timestamp we have for the user
   // we should keep the existing date as it means the events have been receieved out of order
   const eventDate = new Date(timestamp * 1000);
-  const trackerDate = trackerRecord
-    ? new Date(trackerRecord.userLastActive)
-    : new Date(0);
+  const trackerDate = trackerRecord ? new Date(trackerRecord.userLastActive) : new Date(0);
 
   return eventDate > trackerDate ? eventDate : trackerDate;
-};
+}
 
 const getDateForDeletion = (latestDate: Date): string => {
   const deletionDate = new Date(latestDate);
   deletionDate.setFullYear(deletionDate.getFullYear() + 5);
   return deletionDate.toISOString().split("T")[0];
-};
+}
 
 const buildTransactionItems = (
   tableName: string,
@@ -83,28 +64,14 @@ const buildTransactionItems = (
   txmaEvent: TxmaEvent
 ): TransactionItems => {
   const items: TransactionItems = [
-    {
-      Put: {
-        TableName: tableName,
-        Item: newItem as unknown as Record<string, unknown>,
-      },
-    },
+    { Put: { TableName: tableName, Item: newItem as unknown as Record<string, unknown> } },
   ];
 
-  if (
-    currentTrackerRecord &&
-    currentTrackerRecord.dateForDeletion !== newItem.dateForDeletion
-  ) {
+  if (currentTrackerRecord && currentTrackerRecord.dateForDeletion !== newItem.dateForDeletion) {
     // if the dates are the same, then we don't need to delete the old record as
     // it would have been updated in place by the Put command
     items.push({
-      Delete: {
-        TableName: tableName,
-        Key: {
-          dateForDeletion: currentTrackerRecord.dateForDeletion,
-          commonSubjectId: userId,
-        },
-      },
+      Delete: { TableName: tableName, Key: { dateForDeletion: currentTrackerRecord.dateForDeletion, commonSubjectId: userId } }
     });
   }
 
@@ -137,45 +104,26 @@ const processRecord = async (
 
   const currentTrackerRecord = await getCurrentRecordForUser(userId, tableName);
 
-  if (currentTrackerRecord?.status === "deleting") {
+  if (currentTrackerRecord?.status === 'deleting') {
     logger.warn(`AUTH_EVENT_ON_DELETING_ACCOUNT ${userId}`);
     return;
   }
 
-  const eventDateTime = new Date(
-    txmaEvent.event_timestamp_ms ?? txmaEvent.timestamp * 1000
-  ).toISOString();
+  const eventDateTime = new Date(txmaEvent.event_timestamp_ms ?? (txmaEvent.timestamp * 1000)).toISOString();
 
   const newEmailAddress = (() => {
-    if (
-      txmaEvent.user?.email &&
-      txmaEvent.user.email !== currentTrackerRecord?.emailAddress
-    ) {
+    if (txmaEvent.user?.email && txmaEvent.user.email !== currentTrackerRecord?.emailAddress) {
       return txmaEvent.user.email;
     }
   })();
-  const emailAddress =
-    newEmailAddress ?? currentTrackerRecord?.emailAddress ?? "";
-  const emailAddressSource = newEmailAddress
-    ? txmaEvent.event_name
-    : (currentTrackerRecord?.emailAddressSource ?? "");
-  const emailAddressSourceId = newEmailAddress
-    ? txmaEvent.event_id
-    : currentTrackerRecord?.emailAddressSourceId;
-  const emailAddressLastUpdated = newEmailAddress
-    ? eventDateTime
-    : (currentTrackerRecord?.emailAddressLastUpdated ?? "");
+  const emailAddress = newEmailAddress ?? currentTrackerRecord?.emailAddress ?? "";
+  const emailAddressSource = newEmailAddress ? txmaEvent.event_name : (currentTrackerRecord?.emailAddressSource ?? "");
+  const emailAddressSourceId = newEmailAddress ? txmaEvent.event_id : currentTrackerRecord?.emailAddressSourceId;
+  const emailAddressLastUpdated = newEmailAddress ? eventDateTime : (currentTrackerRecord?.emailAddressLastUpdated ?? "");
 
   const latestDate = getLatestDate(txmaEvent, currentTrackerRecord);
-  const publicSubjectId =
-    txmaEvent.user?.public_subject_id ??
-    currentTrackerRecord?.publicSubjectId ??
-    "";
-  const isNewLatestDate =
-    new Date(txmaEvent.timestamp * 1000) >
-    (currentTrackerRecord
-      ? new Date(currentTrackerRecord.userLastActive)
-      : new Date(0));
+  const publicSubjectId = txmaEvent.user?.public_subject_id ?? currentTrackerRecord?.publicSubjectId ?? "";
+  const isNewLatestDate = new Date(txmaEvent.timestamp * 1000) > (currentTrackerRecord ? new Date(currentTrackerRecord.userLastActive) : new Date(0));
 
   const newItem: InactiveAccountTrackerRecord = {
     commonSubjectId: userId,
@@ -183,40 +131,25 @@ const processRecord = async (
     userLastActive: latestDate.toISOString(),
     userLastActiveSource: txmaEvent.event_name,
     ...(txmaEvent.event_id && { userLastActiveSourceId: txmaEvent.event_id }),
-    userLastActiveUpdated: isNewLatestDate
-      ? eventDateTime
-      : (currentTrackerRecord?.userLastActiveUpdated ?? eventDateTime),
+    userLastActiveUpdated: isNewLatestDate ? eventDateTime : (currentTrackerRecord?.userLastActiveUpdated ?? eventDateTime),
     dateForDeletion: getDateForDeletion(latestDate),
     emailAddress,
     emailAddressSource,
     emailAddressSourceId,
     emailAddressLastUpdated,
-    status: "pending",
+    status: 'pending',
     statusLastUpdated: eventDateTime,
     hasSetupMfa: currentTrackerRecord?.hasSetupMfa ?? false,
   };
 
-  const transactionItems = buildTransactionItems(
-    tableName,
-    userNotificationsTableName,
-    olhClientId,
-    userId,
-    newItem,
-    currentTrackerRecord,
-    txmaEvent
-  );
+  const transactionItems = buildTransactionItems(tableName, userNotificationsTableName, olhClientId, userId, newItem, currentTrackerRecord, txmaEvent);
 
   try {
-    await dynamoDocClient.send(
-      new TransactWriteCommand({ TransactItems: transactionItems })
-    );
+    await dynamoDocClient.send(new TransactWriteCommand({ TransactItems: transactionItems }));
   } catch (error) {
-    throw new Error(
-      `Failed to update inactive account tracker for user ${userId} ${error}`,
-      {
-        cause: error,
-      }
-    );
+    throw new Error(`Failed to update inactive account tracker for user ${userId} ${error}`, {
+      cause: error
+    });
   }
 };
 
@@ -226,12 +159,8 @@ export const handler = async (
 ): Promise<void> => {
   logger.addContext(context);
 
-  const tableName = getEnvironmentVariable(
-    "INACTIVE_ACCOUNT_TRACKER_TABLE_NAME"
-  );
-  const userNotificationsTableName = getEnvironmentVariable(
-    "USER_NOTIFICATIONS_TABLE_NAME"
-  );
+  const tableName = getEnvironmentVariable("INACTIVE_ACCOUNT_TRACKER_TABLE_NAME");
+  const userNotificationsTableName = getEnvironmentVariable("USER_NOTIFICATIONS_TABLE_NAME");
   const olhClientId = getEnvironmentVariable("OLH_CLIENT_ID");
 
   for (const record of event.Records) {
@@ -239,11 +168,6 @@ export const handler = async (
       record.dynamodb?.NewImage?.event.M as Record<string, AttributeValue>
     ) as TxmaEvent;
 
-    await processRecord(
-      txmaEvent,
-      tableName,
-      userNotificationsTableName,
-      olhClientId
-    );
+    await processRecord(txmaEvent, tableName, userNotificationsTableName, olhClientId);
   }
 };

--- a/src/update-inactive-account-tracker.ts
+++ b/src/update-inactive-account-tracker.ts
@@ -1,20 +1,29 @@
 import { Context, DynamoDBStreamEvent } from "aws-lambda";
 import { AttributeValue, DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { unmarshall } from "@aws-sdk/util-dynamodb";
-import { DynamoDBDocumentClient, QueryCommand, TransactWriteCommand } from "@aws-sdk/lib-dynamodb";
+import {
+  DynamoDBDocumentClient,
+  QueryCommand,
+  TransactWriteCommand,
+} from "@aws-sdk/lib-dynamodb";
 import { TxmaEvent } from "./common/model.js";
 import { getEnvironmentVariable } from "./common/utils.js";
 import { Logger } from "@aws-lambda-powertools/logger";
 import type { InactiveAccountTrackerRecord } from "./common/model.ts";
-import assert from 'node:assert/strict';
+import assert from "node:assert/strict";
 
 const logger = new Logger();
 const dynamoClient = new DynamoDBClient({});
 const dynamoDocClient = DynamoDBDocumentClient.from(dynamoClient);
 
-type TransactionItems = ConstructorParameters<typeof TransactWriteCommand>[0]['TransactItems']
+type TransactionItems = ConstructorParameters<
+  typeof TransactWriteCommand
+>[0]["TransactItems"];
 
-const getCurrentRecordForUser = async (userId: string, tableName: string): Promise<InactiveAccountTrackerRecord | null> => {
+const getCurrentRecordForUser = async (
+  userId: string,
+  tableName: string
+): Promise<InactiveAccountTrackerRecord | null> => {
   const response = await dynamoDocClient.send(
     new QueryCommand({
       IndexName: "CommonSubjectIdIndex",
@@ -25,16 +34,24 @@ const getCurrentRecordForUser = async (userId: string, tableName: string): Promi
   );
 
   assert(response.Items !== undefined, "Query response is missing Items");
-  assert(response.Items.length < 2, `found more than one inactivity tracker record for ${userId}`)
+  assert(
+    response.Items.length < 2,
+    `found more than one inactivity tracker record for ${userId}`
+  );
 
-  return response.Items.length > 0 ? response.Items[0] as InactiveAccountTrackerRecord : null;
-}
+  return response.Items.length > 0
+    ? (response.Items[0] as InactiveAccountTrackerRecord)
+    : null;
+};
 
-const getLatestDate = (txmaEvent: TxmaEvent, trackerRecord: InactiveAccountTrackerRecord | null) => {
+const getLatestDate = (
+  txmaEvent: TxmaEvent,
+  trackerRecord: InactiveAccountTrackerRecord | null
+) => {
   let timestamp = txmaEvent.timestamp;
 
   // some txma events timestamps are in milliseconds when they should be in seconds.
-  // if the timestamp is over 13 digits it is essentially guaranteed to be in milliseconds. 
+  // if the timestamp is over 13 digits it is essentially guaranteed to be in milliseconds.
   // 13 digit millisecond timestamps started 9 September 2001.
   if (timestamp.toString().length >= 13) {
     timestamp = Math.floor(timestamp / 1000);
@@ -43,16 +60,18 @@ const getLatestDate = (txmaEvent: TxmaEvent, trackerRecord: InactiveAccountTrack
   // if the timestamp on the audit event is older than the last active timestamp we have for the user
   // we should keep the existing date as it means the events have been receieved out of order
   const eventDate = new Date(timestamp * 1000);
-  const trackerDate = trackerRecord ? new Date(trackerRecord.userLastActive) : new Date(0);
+  const trackerDate = trackerRecord
+    ? new Date(trackerRecord.userLastActive)
+    : new Date(0);
 
   return eventDate > trackerDate ? eventDate : trackerDate;
-}
+};
 
 const getDateForDeletion = (latestDate: Date): string => {
   const deletionDate = new Date(latestDate);
   deletionDate.setFullYear(deletionDate.getFullYear() + 5);
   return deletionDate.toISOString().split("T")[0];
-}
+};
 
 const buildTransactionItems = (
   tableName: string,
@@ -64,14 +83,28 @@ const buildTransactionItems = (
   txmaEvent: TxmaEvent
 ): TransactionItems => {
   const items: TransactionItems = [
-    { Put: { TableName: tableName, Item: newItem as unknown as Record<string, unknown> } },
+    {
+      Put: {
+        TableName: tableName,
+        Item: newItem as unknown as Record<string, unknown>,
+      },
+    },
   ];
 
-  if (currentTrackerRecord && currentTrackerRecord.dateForDeletion !== newItem.dateForDeletion) {
+  if (
+    currentTrackerRecord &&
+    currentTrackerRecord.dateForDeletion !== newItem.dateForDeletion
+  ) {
     // if the dates are the same, then we don't need to delete the old record as
     // it would have been updated in place by the Put command
     items.push({
-      Delete: { TableName: tableName, Key: { dateForDeletion: currentTrackerRecord.dateForDeletion, commonSubjectId: userId } }
+      Delete: {
+        TableName: tableName,
+        Key: {
+          dateForDeletion: currentTrackerRecord.dateForDeletion,
+          commonSubjectId: userId,
+        },
+      },
     });
   }
 
@@ -104,26 +137,45 @@ const processRecord = async (
 
   const currentTrackerRecord = await getCurrentRecordForUser(userId, tableName);
 
-  if (currentTrackerRecord?.status === 'deleting') {
+  if (currentTrackerRecord?.status === "deleting") {
     logger.warn(`AUTH_EVENT_ON_DELETING_ACCOUNT ${userId}`);
     return;
   }
 
-  const eventDateTime = new Date(txmaEvent.timestamp * 1000).toISOString();
+  const eventDateTime = new Date(
+    txmaEvent.event_timestamp_ms ?? txmaEvent.timestamp * 1000
+  ).toISOString();
 
   const newEmailAddress = (() => {
-    if (txmaEvent.user?.email && txmaEvent.user.email !== currentTrackerRecord?.emailAddress) {
+    if (
+      txmaEvent.user?.email &&
+      txmaEvent.user.email !== currentTrackerRecord?.emailAddress
+    ) {
       return txmaEvent.user.email;
     }
   })();
-  const emailAddress = newEmailAddress ?? currentTrackerRecord?.emailAddress ?? "";
-  const emailAddressSource = newEmailAddress ? txmaEvent.event_name : (currentTrackerRecord?.emailAddressSource ?? "");
-  const emailAddressSourceId = newEmailAddress ? txmaEvent.event_id : currentTrackerRecord?.emailAddressSourceId;
-  const emailAddressLastUpdated = newEmailAddress ? eventDateTime : (currentTrackerRecord?.emailAddressLastUpdated ?? "");
+  const emailAddress =
+    newEmailAddress ?? currentTrackerRecord?.emailAddress ?? "";
+  const emailAddressSource = newEmailAddress
+    ? txmaEvent.event_name
+    : (currentTrackerRecord?.emailAddressSource ?? "");
+  const emailAddressSourceId = newEmailAddress
+    ? txmaEvent.event_id
+    : currentTrackerRecord?.emailAddressSourceId;
+  const emailAddressLastUpdated = newEmailAddress
+    ? eventDateTime
+    : (currentTrackerRecord?.emailAddressLastUpdated ?? "");
 
   const latestDate = getLatestDate(txmaEvent, currentTrackerRecord);
-  const publicSubjectId = txmaEvent.user?.public_subject_id ?? currentTrackerRecord?.publicSubjectId ?? "";
-  const isNewLatestDate = new Date(txmaEvent.timestamp * 1000) > (currentTrackerRecord ? new Date(currentTrackerRecord.userLastActive) : new Date(0));
+  const publicSubjectId =
+    txmaEvent.user?.public_subject_id ??
+    currentTrackerRecord?.publicSubjectId ??
+    "";
+  const isNewLatestDate =
+    new Date(txmaEvent.timestamp * 1000) >
+    (currentTrackerRecord
+      ? new Date(currentTrackerRecord.userLastActive)
+      : new Date(0));
 
   const newItem: InactiveAccountTrackerRecord = {
     commonSubjectId: userId,
@@ -131,25 +183,40 @@ const processRecord = async (
     userLastActive: latestDate.toISOString(),
     userLastActiveSource: txmaEvent.event_name,
     ...(txmaEvent.event_id && { userLastActiveSourceId: txmaEvent.event_id }),
-    userLastActiveUpdated: isNewLatestDate ? eventDateTime : (currentTrackerRecord?.userLastActiveUpdated ?? eventDateTime),
+    userLastActiveUpdated: isNewLatestDate
+      ? eventDateTime
+      : (currentTrackerRecord?.userLastActiveUpdated ?? eventDateTime),
     dateForDeletion: getDateForDeletion(latestDate),
     emailAddress,
     emailAddressSource,
     emailAddressSourceId,
     emailAddressLastUpdated,
-    status: 'pending',
+    status: "pending",
     statusLastUpdated: eventDateTime,
     hasSetupMfa: currentTrackerRecord?.hasSetupMfa ?? false,
   };
 
-  const transactionItems = buildTransactionItems(tableName, userNotificationsTableName, olhClientId, userId, newItem, currentTrackerRecord, txmaEvent);
+  const transactionItems = buildTransactionItems(
+    tableName,
+    userNotificationsTableName,
+    olhClientId,
+    userId,
+    newItem,
+    currentTrackerRecord,
+    txmaEvent
+  );
 
   try {
-    await dynamoDocClient.send(new TransactWriteCommand({ TransactItems: transactionItems }));
+    await dynamoDocClient.send(
+      new TransactWriteCommand({ TransactItems: transactionItems })
+    );
   } catch (error) {
-    throw new Error(`Failed to update inactive account tracker for user ${userId} ${error}`, {
-      cause: error
-    });
+    throw new Error(
+      `Failed to update inactive account tracker for user ${userId} ${error}`,
+      {
+        cause: error,
+      }
+    );
   }
 };
 
@@ -159,8 +226,12 @@ export const handler = async (
 ): Promise<void> => {
   logger.addContext(context);
 
-  const tableName = getEnvironmentVariable("INACTIVE_ACCOUNT_TRACKER_TABLE_NAME");
-  const userNotificationsTableName = getEnvironmentVariable("USER_NOTIFICATIONS_TABLE_NAME");
+  const tableName = getEnvironmentVariable(
+    "INACTIVE_ACCOUNT_TRACKER_TABLE_NAME"
+  );
+  const userNotificationsTableName = getEnvironmentVariable(
+    "USER_NOTIFICATIONS_TABLE_NAME"
+  );
   const olhClientId = getEnvironmentVariable("OLH_CLIENT_ID");
 
   for (const record of event.Records) {
@@ -168,6 +239,11 @@ export const handler = async (
       record.dynamodb?.NewImage?.event.M as Record<string, AttributeValue>
     ) as TxmaEvent;
 
-    await processRecord(txmaEvent, tableName, userNotificationsTableName, olhClientId);
+    await processRecord(
+      txmaEvent,
+      tableName,
+      userNotificationsTableName,
+      olhClientId
+    );
   }
 };

--- a/src/update-inactive-account-tracker.ts
+++ b/src/update-inactive-account-tracker.ts
@@ -1,29 +1,20 @@
 import { Context, DynamoDBStreamEvent } from "aws-lambda";
 import { AttributeValue, DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { unmarshall } from "@aws-sdk/util-dynamodb";
-import {
-  DynamoDBDocumentClient,
-  QueryCommand,
-  TransactWriteCommand,
-} from "@aws-sdk/lib-dynamodb";
+import { DynamoDBDocumentClient, QueryCommand, TransactWriteCommand } from "@aws-sdk/lib-dynamodb";
 import { TxmaEvent } from "./common/model.js";
 import { getEnvironmentVariable } from "./common/utils.js";
 import { Logger } from "@aws-lambda-powertools/logger";
 import type { InactiveAccountTrackerRecord } from "./common/model.ts";
-import assert from "node:assert/strict";
+import assert from 'node:assert/strict';
 
 const logger = new Logger();
 const dynamoClient = new DynamoDBClient({});
 const dynamoDocClient = DynamoDBDocumentClient.from(dynamoClient);
 
-type TransactionItems = ConstructorParameters<
-  typeof TransactWriteCommand
->[0]["TransactItems"];
+type TransactionItems = ConstructorParameters<typeof TransactWriteCommand>[0]['TransactItems']
 
-const getCurrentRecordForUser = async (
-  userId: string,
-  tableName: string
-): Promise<InactiveAccountTrackerRecord | null> => {
+const getCurrentRecordForUser = async (userId: string, tableName: string): Promise<InactiveAccountTrackerRecord | null> => {
   const response = await dynamoDocClient.send(
     new QueryCommand({
       IndexName: "CommonSubjectIdIndex",
@@ -34,24 +25,16 @@ const getCurrentRecordForUser = async (
   );
 
   assert(response.Items !== undefined, "Query response is missing Items");
-  assert(
-    response.Items.length < 2,
-    `found more than one inactivity tracker record for ${userId}`
-  );
+  assert(response.Items.length < 2, `found more than one inactivity tracker record for ${userId}`)
 
-  return response.Items.length > 0
-    ? (response.Items[0] as InactiveAccountTrackerRecord)
-    : null;
-};
+  return response.Items.length > 0 ? response.Items[0] as InactiveAccountTrackerRecord : null;
+}
 
-const getLatestDate = (
-  txmaEvent: TxmaEvent,
-  trackerRecord: InactiveAccountTrackerRecord | null
-) => {
+const getLatestDate = (txmaEvent: TxmaEvent, trackerRecord: InactiveAccountTrackerRecord | null) => {
   let timestamp = txmaEvent.timestamp;
 
   // some txma events timestamps are in milliseconds when they should be in seconds.
-  // if the timestamp is over 13 digits it is essentially guaranteed to be in milliseconds.
+  // if the timestamp is over 13 digits it is essentially guaranteed to be in milliseconds. 
   // 13 digit millisecond timestamps started 9 September 2001.
   if (timestamp.toString().length >= 13) {
     timestamp = Math.floor(timestamp / 1000);
@@ -60,18 +43,16 @@ const getLatestDate = (
   // if the timestamp on the audit event is older than the last active timestamp we have for the user
   // we should keep the existing date as it means the events have been receieved out of order
   const eventDate = new Date(timestamp * 1000);
-  const trackerDate = trackerRecord
-    ? new Date(trackerRecord.userLastActive)
-    : new Date(0);
+  const trackerDate = trackerRecord ? new Date(trackerRecord.userLastActive) : new Date(0);
 
   return eventDate > trackerDate ? eventDate : trackerDate;
-};
+}
 
 const getDateForDeletion = (latestDate: Date): string => {
   const deletionDate = new Date(latestDate);
   deletionDate.setFullYear(deletionDate.getFullYear() + 5);
   return deletionDate.toISOString().split("T")[0];
-};
+}
 
 const buildTransactionItems = (
   tableName: string,
@@ -83,28 +64,14 @@ const buildTransactionItems = (
   txmaEvent: TxmaEvent
 ): TransactionItems => {
   const items: TransactionItems = [
-    {
-      Put: {
-        TableName: tableName,
-        Item: newItem as unknown as Record<string, unknown>,
-      },
-    },
+    { Put: { TableName: tableName, Item: newItem as unknown as Record<string, unknown> } },
   ];
 
-  if (
-    currentTrackerRecord &&
-    currentTrackerRecord.dateForDeletion !== newItem.dateForDeletion
-  ) {
+  if (currentTrackerRecord && currentTrackerRecord.dateForDeletion !== newItem.dateForDeletion) {
     // if the dates are the same, then we don't need to delete the old record as
     // it would have been updated in place by the Put command
     items.push({
-      Delete: {
-        TableName: tableName,
-        Key: {
-          dateForDeletion: currentTrackerRecord.dateForDeletion,
-          commonSubjectId: userId,
-        },
-      },
+      Delete: { TableName: tableName, Key: { dateForDeletion: currentTrackerRecord.dateForDeletion, commonSubjectId: userId } }
     });
   }
 
@@ -137,7 +104,7 @@ const processRecord = async (
 
   const currentTrackerRecord = await getCurrentRecordForUser(userId, tableName);
 
-  if (currentTrackerRecord?.status === "deleting") {
+  if (currentTrackerRecord?.status === 'deleting') {
     logger.warn(`AUTH_EVENT_ON_DELETING_ACCOUNT ${userId}`);
     return;
   }
@@ -145,35 +112,18 @@ const processRecord = async (
   const eventDateTime = new Date(txmaEvent.timestamp * 1000).toISOString();
 
   const newEmailAddress = (() => {
-    if (
-      txmaEvent.user?.email &&
-      txmaEvent.user.email !== currentTrackerRecord?.emailAddress
-    ) {
+    if (txmaEvent.user?.email && txmaEvent.user.email !== currentTrackerRecord?.emailAddress) {
       return txmaEvent.user.email;
     }
   })();
-  const emailAddress =
-    newEmailAddress ?? currentTrackerRecord?.emailAddress ?? "";
-  const emailAddressSource = newEmailAddress
-    ? txmaEvent.event_name
-    : (currentTrackerRecord?.emailAddressSource ?? "");
-  const emailAddressSourceId = newEmailAddress
-    ? txmaEvent.event_id
-    : currentTrackerRecord?.emailAddressSourceId;
-  const emailAddressLastUpdated = newEmailAddress
-    ? eventDateTime
-    : (currentTrackerRecord?.emailAddressLastUpdated ?? "");
+  const emailAddress = newEmailAddress ?? currentTrackerRecord?.emailAddress ?? "";
+  const emailAddressSource = newEmailAddress ? txmaEvent.event_name : (currentTrackerRecord?.emailAddressSource ?? "");
+  const emailAddressSourceId = newEmailAddress ? txmaEvent.event_id : currentTrackerRecord?.emailAddressSourceId;
+  const emailAddressLastUpdated = newEmailAddress ? eventDateTime : (currentTrackerRecord?.emailAddressLastUpdated ?? "");
 
   const latestDate = getLatestDate(txmaEvent, currentTrackerRecord);
-  const publicSubjectId =
-    txmaEvent.user?.public_subject_id ??
-    currentTrackerRecord?.publicSubjectId ??
-    "";
-  const isNewLatestDate =
-    new Date(txmaEvent.timestamp * 1000) >
-    (currentTrackerRecord
-      ? new Date(currentTrackerRecord.userLastActive)
-      : new Date(0));
+  const publicSubjectId = txmaEvent.user?.public_subject_id ?? currentTrackerRecord?.publicSubjectId ?? "";
+  const isNewLatestDate = new Date(txmaEvent.timestamp * 1000) > (currentTrackerRecord ? new Date(currentTrackerRecord.userLastActive) : new Date(0));
 
   const newItem: InactiveAccountTrackerRecord = {
     commonSubjectId: userId,
@@ -181,40 +131,25 @@ const processRecord = async (
     userLastActive: latestDate.toISOString(),
     userLastActiveSource: txmaEvent.event_name,
     ...(txmaEvent.event_id && { userLastActiveSourceId: txmaEvent.event_id }),
-    userLastActiveUpdated: isNewLatestDate
-      ? eventDateTime
-      : (currentTrackerRecord?.userLastActiveUpdated ?? eventDateTime),
+    userLastActiveUpdated: isNewLatestDate ? eventDateTime : (currentTrackerRecord?.userLastActiveUpdated ?? eventDateTime),
     dateForDeletion: getDateForDeletion(latestDate),
     emailAddress,
     emailAddressSource,
     emailAddressSourceId,
     emailAddressLastUpdated,
-    status: "pending",
+    status: 'pending',
     statusLastUpdated: eventDateTime,
     hasSetupMfa: currentTrackerRecord?.hasSetupMfa ?? false,
   };
 
-  const transactionItems = buildTransactionItems(
-    tableName,
-    userNotificationsTableName,
-    olhClientId,
-    userId,
-    newItem,
-    currentTrackerRecord,
-    txmaEvent
-  );
+  const transactionItems = buildTransactionItems(tableName, userNotificationsTableName, olhClientId, userId, newItem, currentTrackerRecord, txmaEvent);
 
   try {
-    await dynamoDocClient.send(
-      new TransactWriteCommand({ TransactItems: transactionItems })
-    );
+    await dynamoDocClient.send(new TransactWriteCommand({ TransactItems: transactionItems }));
   } catch (error) {
-    throw new Error(
-      `Failed to update inactive account tracker for user ${userId} ${error}`,
-      {
-        cause: error,
-      }
-    );
+    throw new Error(`Failed to update inactive account tracker for user ${userId} ${error}`, {
+      cause: error
+    });
   }
 };
 
@@ -224,12 +159,8 @@ export const handler = async (
 ): Promise<void> => {
   logger.addContext(context);
 
-  const tableName = getEnvironmentVariable(
-    "INACTIVE_ACCOUNT_TRACKER_TABLE_NAME"
-  );
-  const userNotificationsTableName = getEnvironmentVariable(
-    "USER_NOTIFICATIONS_TABLE_NAME"
-  );
+  const tableName = getEnvironmentVariable("INACTIVE_ACCOUNT_TRACKER_TABLE_NAME");
+  const userNotificationsTableName = getEnvironmentVariable("USER_NOTIFICATIONS_TABLE_NAME");
   const olhClientId = getEnvironmentVariable("OLH_CLIENT_ID");
 
   for (const record of event.Records) {
@@ -237,11 +168,6 @@ export const handler = async (
       record.dynamodb?.NewImage?.event.M as Record<string, AttributeValue>
     ) as TxmaEvent;
 
-    await processRecord(
-      txmaEvent,
-      tableName,
-      userNotificationsTableName,
-      olhClientId
-    );
+    await processRecord(txmaEvent, tableName, userNotificationsTableName, olhClientId);
   }
 };

--- a/src/update-inactive-account-tracker.ts
+++ b/src/update-inactive-account-tracker.ts
@@ -1,20 +1,29 @@
 import { Context, DynamoDBStreamEvent } from "aws-lambda";
 import { AttributeValue, DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { unmarshall } from "@aws-sdk/util-dynamodb";
-import { DynamoDBDocumentClient, QueryCommand, TransactWriteCommand } from "@aws-sdk/lib-dynamodb";
+import {
+  DynamoDBDocumentClient,
+  QueryCommand,
+  TransactWriteCommand,
+} from "@aws-sdk/lib-dynamodb";
 import { TxmaEvent } from "./common/model.js";
 import { getEnvironmentVariable } from "./common/utils.js";
 import { Logger } from "@aws-lambda-powertools/logger";
 import type { InactiveAccountTrackerRecord } from "./common/model.ts";
-import assert from 'node:assert/strict';
+import assert from "node:assert/strict";
 
 const logger = new Logger();
 const dynamoClient = new DynamoDBClient({});
 const dynamoDocClient = DynamoDBDocumentClient.from(dynamoClient);
 
-type TransactionItems = ConstructorParameters<typeof TransactWriteCommand>[0]['TransactItems']
+type TransactionItems = ConstructorParameters<
+  typeof TransactWriteCommand
+>[0]["TransactItems"];
 
-const getCurrentRecordForUser = async (userId: string, tableName: string): Promise<InactiveAccountTrackerRecord | null> => {
+const getCurrentRecordForUser = async (
+  userId: string,
+  tableName: string
+): Promise<InactiveAccountTrackerRecord | null> => {
   const response = await dynamoDocClient.send(
     new QueryCommand({
       IndexName: "CommonSubjectIdIndex",
@@ -25,16 +34,24 @@ const getCurrentRecordForUser = async (userId: string, tableName: string): Promi
   );
 
   assert(response.Items !== undefined, "Query response is missing Items");
-  assert(response.Items.length < 2, `found more than one inactivity tracker record for ${userId}`)
+  assert(
+    response.Items.length < 2,
+    `found more than one inactivity tracker record for ${userId}`
+  );
 
-  return response.Items.length > 0 ? response.Items[0] as InactiveAccountTrackerRecord : null;
-}
+  return response.Items.length > 0
+    ? (response.Items[0] as InactiveAccountTrackerRecord)
+    : null;
+};
 
-const getLatestDate = (txmaEvent: TxmaEvent, trackerRecord: InactiveAccountTrackerRecord | null) => {
+const getLatestDate = (
+  txmaEvent: TxmaEvent,
+  trackerRecord: InactiveAccountTrackerRecord | null
+) => {
   let timestamp = txmaEvent.timestamp;
 
   // some txma events timestamps are in milliseconds when they should be in seconds.
-  // if the timestamp is over 13 digits it is essentially guaranteed to be in milliseconds. 
+  // if the timestamp is over 13 digits it is essentially guaranteed to be in milliseconds.
   // 13 digit millisecond timestamps started 9 September 2001.
   if (timestamp.toString().length >= 13) {
     timestamp = Math.floor(timestamp / 1000);
@@ -43,16 +60,18 @@ const getLatestDate = (txmaEvent: TxmaEvent, trackerRecord: InactiveAccountTrack
   // if the timestamp on the audit event is older than the last active timestamp we have for the user
   // we should keep the existing date as it means the events have been receieved out of order
   const eventDate = new Date(timestamp * 1000);
-  const trackerDate = trackerRecord ? new Date(trackerRecord.userLastActive) : new Date(0);
+  const trackerDate = trackerRecord
+    ? new Date(trackerRecord.userLastActive)
+    : new Date(0);
 
   return eventDate > trackerDate ? eventDate : trackerDate;
-}
+};
 
 const getDateForDeletion = (latestDate: Date): string => {
   const deletionDate = new Date(latestDate);
   deletionDate.setFullYear(deletionDate.getFullYear() + 5);
   return deletionDate.toISOString().split("T")[0];
-}
+};
 
 const buildTransactionItems = (
   tableName: string,
@@ -64,14 +83,28 @@ const buildTransactionItems = (
   txmaEvent: TxmaEvent
 ): TransactionItems => {
   const items: TransactionItems = [
-    { Put: { TableName: tableName, Item: newItem as unknown as Record<string, unknown> } },
+    {
+      Put: {
+        TableName: tableName,
+        Item: newItem as unknown as Record<string, unknown>,
+      },
+    },
   ];
 
-  if (currentTrackerRecord && currentTrackerRecord.dateForDeletion !== newItem.dateForDeletion) {
+  if (
+    currentTrackerRecord &&
+    currentTrackerRecord.dateForDeletion !== newItem.dateForDeletion
+  ) {
     // if the dates are the same, then we don't need to delete the old record as
     // it would have been updated in place by the Put command
     items.push({
-      Delete: { TableName: tableName, Key: { dateForDeletion: currentTrackerRecord.dateForDeletion, commonSubjectId: userId } }
+      Delete: {
+        TableName: tableName,
+        Key: {
+          dateForDeletion: currentTrackerRecord.dateForDeletion,
+          commonSubjectId: userId,
+        },
+      },
     });
   }
 
@@ -104,16 +137,43 @@ const processRecord = async (
 
   const currentTrackerRecord = await getCurrentRecordForUser(userId, tableName);
 
-  if (currentTrackerRecord?.status === 'deleting') {
+  if (currentTrackerRecord?.status === "deleting") {
     logger.warn(`AUTH_EVENT_ON_DELETING_ACCOUNT ${userId}`);
     return;
   }
 
-  const email = txmaEvent.user?.email ?? currentTrackerRecord?.emailAddress ?? "";
+  const eventDateTime = new Date(txmaEvent.timestamp * 1000).toISOString();
+
+  const newEmailAddress = (() => {
+    if (
+      txmaEvent.user?.email &&
+      txmaEvent.user.email !== currentTrackerRecord?.emailAddress
+    ) {
+      return txmaEvent.user.email;
+    }
+  })();
+  const emailAddress =
+    newEmailAddress ?? currentTrackerRecord?.emailAddress ?? "";
+  const emailAddressSource = newEmailAddress
+    ? txmaEvent.event_name
+    : (currentTrackerRecord?.emailAddressSource ?? "");
+  const emailAddressSourceId = newEmailAddress
+    ? txmaEvent.event_id
+    : currentTrackerRecord?.emailAddressSourceId;
+  const emailAddressLastUpdated = newEmailAddress
+    ? eventDateTime
+    : (currentTrackerRecord?.emailAddressLastUpdated ?? "");
+
   const latestDate = getLatestDate(txmaEvent, currentTrackerRecord);
-  const publicSubjectId = txmaEvent.user?.public_subject_id ?? currentTrackerRecord?.publicSubjectId ?? "";
-  const now = new Date().toISOString();
-  const isNewLatestDate = new Date(txmaEvent.timestamp * 1000) > (currentTrackerRecord ? new Date(currentTrackerRecord.userLastActive) : new Date(0));
+  const publicSubjectId =
+    txmaEvent.user?.public_subject_id ??
+    currentTrackerRecord?.publicSubjectId ??
+    "";
+  const isNewLatestDate =
+    new Date(txmaEvent.timestamp * 1000) >
+    (currentTrackerRecord
+      ? new Date(currentTrackerRecord.userLastActive)
+      : new Date(0));
 
   const newItem: InactiveAccountTrackerRecord = {
     commonSubjectId: userId,
@@ -121,25 +181,40 @@ const processRecord = async (
     userLastActive: latestDate.toISOString(),
     userLastActiveSource: txmaEvent.event_name,
     ...(txmaEvent.event_id && { userLastActiveSourceId: txmaEvent.event_id }),
-    userLastActiveUpdated: isNewLatestDate ? now : (currentTrackerRecord?.userLastActiveUpdated ?? now),
+    userLastActiveUpdated: isNewLatestDate
+      ? eventDateTime
+      : (currentTrackerRecord?.userLastActiveUpdated ?? eventDateTime),
     dateForDeletion: getDateForDeletion(latestDate),
-    emailAddress: email,
-    emailAddressSource: txmaEvent.event_name,
-    ...(txmaEvent.event_id && { emailAddressSourceId: txmaEvent.event_id }),
-    emailAddressLastUpdated: txmaEvent.user?.email ? now : (currentTrackerRecord?.emailAddressLastUpdated ?? now),
-    status: 'pending',
-    statusLastUpdated: now,
+    emailAddress,
+    emailAddressSource,
+    emailAddressSourceId,
+    emailAddressLastUpdated,
+    status: "pending",
+    statusLastUpdated: eventDateTime,
     hasSetupMfa: currentTrackerRecord?.hasSetupMfa ?? false,
   };
 
-  const transactionItems = buildTransactionItems(tableName, userNotificationsTableName, olhClientId, userId, newItem, currentTrackerRecord, txmaEvent);
+  const transactionItems = buildTransactionItems(
+    tableName,
+    userNotificationsTableName,
+    olhClientId,
+    userId,
+    newItem,
+    currentTrackerRecord,
+    txmaEvent
+  );
 
   try {
-    await dynamoDocClient.send(new TransactWriteCommand({ TransactItems: transactionItems }));
+    await dynamoDocClient.send(
+      new TransactWriteCommand({ TransactItems: transactionItems })
+    );
   } catch (error) {
-    throw new Error(`Failed to update inactive account tracker for user ${userId} ${error}`, {
-      cause: error
-    });
+    throw new Error(
+      `Failed to update inactive account tracker for user ${userId} ${error}`,
+      {
+        cause: error,
+      }
+    );
   }
 };
 
@@ -149,8 +224,12 @@ export const handler = async (
 ): Promise<void> => {
   logger.addContext(context);
 
-  const tableName = getEnvironmentVariable("INACTIVE_ACCOUNT_TRACKER_TABLE_NAME");
-  const userNotificationsTableName = getEnvironmentVariable("USER_NOTIFICATIONS_TABLE_NAME");
+  const tableName = getEnvironmentVariable(
+    "INACTIVE_ACCOUNT_TRACKER_TABLE_NAME"
+  );
+  const userNotificationsTableName = getEnvironmentVariable(
+    "USER_NOTIFICATIONS_TABLE_NAME"
+  );
   const olhClientId = getEnvironmentVariable("OLH_CLIENT_ID");
 
   for (const record of event.Records) {
@@ -158,6 +237,11 @@ export const handler = async (
       record.dynamodb?.NewImage?.event.M as Record<string, AttributeValue>
     ) as TxmaEvent;
 
-    await processRecord(txmaEvent, tableName, userNotificationsTableName, olhClientId);
+    await processRecord(
+      txmaEvent,
+      tableName,
+      userNotificationsTableName,
+      olhClientId
+    );
   }
 };

--- a/src/update-user-email.ts
+++ b/src/update-user-email.ts
@@ -1,11 +1,7 @@
 import { Context, DynamoDBStreamEvent } from "aws-lambda";
 import { AttributeValue, DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { unmarshall } from "@aws-sdk/util-dynamodb";
-import {
-  DynamoDBDocumentClient,
-  QueryCommand,
-  UpdateCommand,
-} from "@aws-sdk/lib-dynamodb";
+import { DynamoDBDocumentClient, QueryCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
 import { TxmaEvent } from "./common/model.js";
 import { getEnvironmentVariable } from "./common/utils.js";
 import { Logger } from "@aws-lambda-powertools/logger";
@@ -20,9 +16,7 @@ export const handler = async (
 ): Promise<void> => {
   logger.addContext(context);
 
-  const tableName = getEnvironmentVariable(
-    "INACTIVE_ACCOUNT_TRACKER_TABLE_NAME"
-  );
+  const tableName = getEnvironmentVariable("INACTIVE_ACCOUNT_TRACKER_TABLE_NAME");
 
   for (const record of event.Records) {
     const txmaEvent = unmarshall(
@@ -54,9 +48,7 @@ export const handler = async (
     );
 
     if (!queryResponse.Items || queryResponse.Items.length === 0) {
-      logger.warn("No inactive account tracker record found for user", {
-        userId,
-      });
+      logger.warn("No inactive account tracker record found for user", { userId });
       return;
     }
 
@@ -83,9 +75,6 @@ export const handler = async (
       })
     );
 
-    logger.info(
-      "Successfully updated email address in inactive account tracker",
-      { userId }
-    );
+    logger.info("Successfully updated email address in inactive account tracker", { userId });
   }
 };

--- a/src/update-user-email.ts
+++ b/src/update-user-email.ts
@@ -1,11 +1,7 @@
 import { Context, DynamoDBStreamEvent } from "aws-lambda";
 import { AttributeValue, DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { unmarshall } from "@aws-sdk/util-dynamodb";
-import {
-  DynamoDBDocumentClient,
-  QueryCommand,
-  UpdateCommand,
-} from "@aws-sdk/lib-dynamodb";
+import { DynamoDBDocumentClient, QueryCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
 import { TxmaEvent } from "./common/model.js";
 import { getEnvironmentVariable } from "./common/utils.js";
 import { Logger } from "@aws-lambda-powertools/logger";
@@ -20,9 +16,7 @@ export const handler = async (
 ): Promise<void> => {
   logger.addContext(context);
 
-  const tableName = getEnvironmentVariable(
-    "INACTIVE_ACCOUNT_TRACKER_TABLE_NAME"
-  );
+  const tableName = getEnvironmentVariable("INACTIVE_ACCOUNT_TRACKER_TABLE_NAME");
 
   for (const record of event.Records) {
     const txmaEvent = unmarshall(
@@ -54,17 +48,13 @@ export const handler = async (
     );
 
     if (!queryResponse.Items || queryResponse.Items.length === 0) {
-      logger.warn("No inactive account tracker record found for user", {
-        userId,
-      });
+      logger.warn("No inactive account tracker record found for user", { userId });
       return;
     }
 
     const trackerRecord = queryResponse.Items[0];
 
-    const eventDateTime = new Date(
-      txmaEvent.event_timestamp_ms ?? txmaEvent.timestamp * 1000
-    ).toISOString();
+    const eventDateTime = new Date(txmaEvent.event_timestamp_ms ?? (txmaEvent.timestamp * 1000)).toISOString();
 
     await dynamoDocClient.send(
       new UpdateCommand({
@@ -85,9 +75,6 @@ export const handler = async (
       })
     );
 
-    logger.info(
-      "Successfully updated email address in inactive account tracker",
-      { userId }
-    );
+    logger.info("Successfully updated email address in inactive account tracker", { userId });
   }
 };

--- a/src/update-user-email.ts
+++ b/src/update-user-email.ts
@@ -1,7 +1,11 @@
 import { Context, DynamoDBStreamEvent } from "aws-lambda";
 import { AttributeValue, DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { unmarshall } from "@aws-sdk/util-dynamodb";
-import { DynamoDBDocumentClient, QueryCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
+import {
+  DynamoDBDocumentClient,
+  QueryCommand,
+  UpdateCommand,
+} from "@aws-sdk/lib-dynamodb";
 import { TxmaEvent } from "./common/model.js";
 import { getEnvironmentVariable } from "./common/utils.js";
 import { Logger } from "@aws-lambda-powertools/logger";
@@ -16,7 +20,9 @@ export const handler = async (
 ): Promise<void> => {
   logger.addContext(context);
 
-  const tableName = getEnvironmentVariable("INACTIVE_ACCOUNT_TRACKER_TABLE_NAME");
+  const tableName = getEnvironmentVariable(
+    "INACTIVE_ACCOUNT_TRACKER_TABLE_NAME"
+  );
 
   for (const record of event.Records) {
     const txmaEvent = unmarshall(
@@ -48,13 +54,17 @@ export const handler = async (
     );
 
     if (!queryResponse.Items || queryResponse.Items.length === 0) {
-      logger.warn("No inactive account tracker record found for user", { userId });
+      logger.warn("No inactive account tracker record found for user", {
+        userId,
+      });
       return;
     }
 
     const trackerRecord = queryResponse.Items[0];
 
-    const eventDateTime = new Date(txmaEvent.timestamp * 1000).toISOString();
+    const eventDateTime = new Date(
+      txmaEvent.event_timestamp_ms ?? txmaEvent.timestamp * 1000
+    ).toISOString();
 
     await dynamoDocClient.send(
       new UpdateCommand({
@@ -75,6 +85,9 @@ export const handler = async (
       })
     );
 
-    logger.info("Successfully updated email address in inactive account tracker", { userId });
+    logger.info(
+      "Successfully updated email address in inactive account tracker",
+      { userId }
+    );
   }
 };

--- a/src/update-user-email.ts
+++ b/src/update-user-email.ts
@@ -1,7 +1,11 @@
 import { Context, DynamoDBStreamEvent } from "aws-lambda";
 import { AttributeValue, DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { unmarshall } from "@aws-sdk/util-dynamodb";
-import { DynamoDBDocumentClient, QueryCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
+import {
+  DynamoDBDocumentClient,
+  QueryCommand,
+  UpdateCommand,
+} from "@aws-sdk/lib-dynamodb";
 import { TxmaEvent } from "./common/model.js";
 import { getEnvironmentVariable } from "./common/utils.js";
 import { Logger } from "@aws-lambda-powertools/logger";
@@ -16,7 +20,9 @@ export const handler = async (
 ): Promise<void> => {
   logger.addContext(context);
 
-  const tableName = getEnvironmentVariable("INACTIVE_ACCOUNT_TRACKER_TABLE_NAME");
+  const tableName = getEnvironmentVariable(
+    "INACTIVE_ACCOUNT_TRACKER_TABLE_NAME"
+  );
 
   for (const record of event.Records) {
     const txmaEvent = unmarshall(
@@ -48,11 +54,15 @@ export const handler = async (
     );
 
     if (!queryResponse.Items || queryResponse.Items.length === 0) {
-      logger.warn("No inactive account tracker record found for user", { userId });
+      logger.warn("No inactive account tracker record found for user", {
+        userId,
+      });
       return;
     }
 
     const trackerRecord = queryResponse.Items[0];
+
+    const eventDateTime = new Date(txmaEvent.timestamp * 1000).toISOString();
 
     await dynamoDocClient.send(
       new UpdateCommand({
@@ -61,11 +71,21 @@ export const handler = async (
           dateForDeletion: trackerRecord.dateForDeletion,
           commonSubjectId: userId,
         },
-        UpdateExpression: "SET emailAddress = :email",
-        ExpressionAttributeValues: { ":email": newEmail },
+        UpdateExpression:
+          "SET emailAddress = :email, emailAddressSource = :source, emailAddressLastUpdated = :lastUpdated" +
+          (txmaEvent.event_id ? ", emailAddressSourceId = :sourceId" : ""),
+        ExpressionAttributeValues: {
+          ":email": newEmail,
+          ":source": txmaEvent.event_name,
+          ":lastUpdated": eventDateTime,
+          ...(txmaEvent.event_id && { ":sourceId": txmaEvent.event_id }),
+        },
       })
     );
 
-    logger.info("Successfully updated email address in inactive account tracker", { userId });
+    logger.info(
+      "Successfully updated email address in inactive account tracker",
+      { userId }
+    );
   }
 };


### PR DESCRIPTION
## Improve email address provenance tracking in the inactive account tracker

### `update-inactive-account-tracker`

- `emailAddressSource`, `emailAddressSourceId`, and `emailAddressLastUpdated` are now only updated when the email address has actually changed. Previously these fields were overwritten on every event, losing the record of which event originally set the email.
- All "last updated" timestamps (`statusLastUpdated`, `userLastActiveUpdated`, `emailAddressLastUpdated`) now use the event's own timestamp rather than the Lambda's wall-clock time.

### `update-user-email`

- When a user changes their email address, the tracker record now also updates `emailAddressSource`, `emailAddressSourceId` (when present), and `emailAddressLastUpdated` — consistent with the fields tracked by `update-inactive-account-tracker`.
