### PR TITLE
OLH-4524: Add new event types to save-raw-events

### DIFF
--- a/src/save-raw-events.ts
+++ b/src/save-raw-events.ts
@@ -27,11 +27,16 @@ const ALLOWED_EVENT_NAMES = new Set([
   "AUTH_IPV_SUCCESSFUL_IDENTITY_RESPONSE_RECEIVED",
   "AUTH_TOKEN_SENT_TO_ORCHESTRATION",
   "AUTH_UPDATE_EMAIL",
+  "AUTH_CODE_VERIFIED",
+  "AUTH_PASSKEY_VERIFICATION_SUCCESSFUL",
+  "STS_REFRESH_TOKEN_ISSUED",
 ]);
 
-// AUTH_TOKEN_SENT_TO_ORCHESTRATION has no session_id in its schema, as the
-// authentication session is already over by the time the token is exchanged.
-const EVENTS_WITHOUT_SESSION_ID = new Set(["AUTH_TOKEN_SENT_TO_ORCHESTRATION"]);
+const EVENTS_WITHOUT_SESSION_ID = new Set([
+  // AUTH_TOKEN_SENT_TO_ORCHESTRATION has no session_id in its schema, as the
+  // authentication session is already over by the time the token is exchanged.
+  "AUTH_TOKEN_SENT_TO_ORCHESTRATION",
+]);
 
 const getEventId = (): string => {
   return crypto.randomUUID();
@@ -45,7 +50,7 @@ const getTTLDate = (): number => {
 };
 
 export const validateUser = (event: TxmaEvent): void => {
-  const user:UserData = event.user;
+  const user: UserData = event.user;
   const requiresSessionId = !EVENTS_WITHOUT_SESSION_ID.has(event.event_name);
 
   if (!user.user_id || (requiresSessionId && !user.session_id)) {
@@ -62,7 +67,9 @@ export const validateUser = (event: TxmaEvent): void => {
     if (requiresSessionId && !user.session_id) {
       missingFields.push(`session_id is ${user.session_id}`);
     }
-    throw new Error(`Could not validate User for event_name ${event.event_name} with event_id ${event.event_id}: ${missingFields.join(", ")}`);
+    throw new Error(
+      `Could not validate User for event_name ${event.event_name} with event_id ${event.event_id}: ${missingFields.join(", ")}`
+    );
   }
 };
 
@@ -77,11 +84,16 @@ export const validateTxmaEventBody = (txmaEvent: TxmaEvent): void => {
     validateUser(txmaEvent);
   } else {
     const missingFields: string[] = [];
-    if (!txmaEvent.timestamp) missingFields.push(`txmaEvent.timestamp is ${txmaEvent.timestamp}`);
-    if (!txmaEvent.event_name) missingFields.push(`txmaEvent.event_name is ${txmaEvent.event_name}`);
-    if (!txmaEvent.event_id) missingFields.push(`txmaEvent.event_id is ${txmaEvent.event_id}`);
-    if (!txmaEvent.client_id) missingFields.push(`txmaEvent.client_id is ${txmaEvent.client_id}`);
-    if (!txmaEvent.user) missingFields.push(`txmaEvent.user is ${txmaEvent.user}`);
+    if (!txmaEvent.timestamp)
+      missingFields.push(`txmaEvent.timestamp is ${txmaEvent.timestamp}`);
+    if (!txmaEvent.event_name)
+      missingFields.push(`txmaEvent.event_name is ${txmaEvent.event_name}`);
+    if (!txmaEvent.event_id)
+      missingFields.push(`txmaEvent.event_id is ${txmaEvent.event_id}`);
+    if (!txmaEvent.client_id)
+      missingFields.push(`txmaEvent.client_id is ${txmaEvent.client_id}`);
+    if (!txmaEvent.user)
+      missingFields.push(`txmaEvent.user is ${txmaEvent.user}`);
     logger.info("Could not validate TxmaEvent context", {
       timestamp: txmaEvent.timestamp,
       eventName: txmaEvent.event_name,
@@ -89,7 +101,9 @@ export const validateTxmaEventBody = (txmaEvent: TxmaEvent): void => {
       typeofClientId: typeof txmaEvent.client_id,
       typeofUser: typeof txmaEvent.user,
     });
-    throw new Error(`Could not validate TxmaEvent with id ${txmaEvent.event_id} and name ${txmaEvent.event_name}: ${missingFields.join(", ")}`);
+    throw new Error(
+      `Could not validate TxmaEvent with id ${txmaEvent.event_id} and name ${txmaEvent.event_name}: ${missingFields.join(", ")}`
+    );
   }
 };
 

--- a/src/tests/save-raw-events.test.ts
+++ b/src/tests/save-raw-events.test.ts
@@ -394,28 +394,6 @@ describe("handler only saves allowlisted events", () => {
     expect(dynamoMock.commandCalls(PutCommand).length).toEqual(1);
   });
 
-  test("writes to DynamoDB when event_name is STS_REFRESH_TOKEN_ISSUED and user has no email or public_subject_id", async () => {
-    vi.spyOn(Date, "now").mockImplementation(() => TIMESTAMP);
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-expect-error
-    vi.spyOn(crypto, "randomUUID").mockImplementation(() => UUID);
-
-    const stsEvent: SQSEvent = {
-      Records: [
-        {
-          ...TEST_SQS_RECORD,
-          body: JSON.stringify({
-            ...makeTxmaEvent(),
-            event_name: "STS_REFRESH_TOKEN_ISSUED",
-            user: { user_id: user.user_id, session_id: user.session_id },
-          }),
-        },
-      ],
-    };
-    await handler(stsEvent, {} as Context);
-    expect(dynamoMock.commandCalls(PutCommand).length).toEqual(1);
-  });
-
   test("writes to DynamoDB when event_name is AUTH_TOKEN_SENT_TO_ORCHESTRATION and user has no session_id", async () => {
     vi.spyOn(Date, "now").mockImplementation(() => TIMESTAMP);
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/src/tests/save-raw-events.test.ts
+++ b/src/tests/save-raw-events.test.ts
@@ -370,6 +370,9 @@ describe("handler only saves allowlisted events", () => {
     "AUTH_IPV_SUCCESSFUL_IDENTITY_RESPONSE_RECEIVED",
     "AUTH_TOKEN_SENT_TO_ORCHESTRATION",
     "AUTH_UPDATE_EMAIL",
+    "AUTH_CODE_VERIFIED",
+    "AUTH_PASSKEY_VERIFICATION_SUCCESSFUL",
+    "STS_REFRESH_TOKEN_ISSUED",
   ])("writes to DynamoDB when event_name is %s", async (allowedEventName) => {
     vi.spyOn(Date, "now").mockImplementation(() => TIMESTAMP);
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -388,6 +391,28 @@ describe("handler only saves allowlisted events", () => {
       ],
     };
     await handler(allowedEvent, {} as Context);
+    expect(dynamoMock.commandCalls(PutCommand).length).toEqual(1);
+  });
+
+  test("writes to DynamoDB when event_name is STS_REFRESH_TOKEN_ISSUED and user has no email or public_subject_id", async () => {
+    vi.spyOn(Date, "now").mockImplementation(() => TIMESTAMP);
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    vi.spyOn(crypto, "randomUUID").mockImplementation(() => UUID);
+
+    const stsEvent: SQSEvent = {
+      Records: [
+        {
+          ...TEST_SQS_RECORD,
+          body: JSON.stringify({
+            ...makeTxmaEvent(),
+            event_name: "STS_REFRESH_TOKEN_ISSUED",
+            user: { user_id: user.user_id, session_id: user.session_id },
+          }),
+        },
+      ],
+    };
+    await handler(stsEvent, {} as Context);
     expect(dynamoMock.commandCalls(PutCommand).length).toEqual(1);
   });
 

--- a/template.yaml
+++ b/template.yaml
@@ -3170,7 +3170,7 @@ Resources:
             StartingPosition: LATEST
             FilterCriteria:
               Filters:
-                - Pattern: '{ "eventName": ["INSERT"], "dynamodb": { "NewImage": { "event": { "M": { "event_name": { "S": ["AUTH_TOKEN_SENT_TO_ORCHESTRATION"] } } } } } }'
+                - Pattern: '{ "eventName": ["INSERT"], "dynamodb": { "NewImage": { "event": { "M": { "event_name": { "S": ["AUTH_TOKEN_SENT_TO_ORCHESTRATION", "AUTH_CODE_VERIFIED", "AUTH_PASSKEY_VERIFICATION_SUCCESSFUL", "STS_REFRESH_TOKEN_ISSUED"] } } } } } }'
       DeadLetterQueue:
         Type: SQS
         TargetArn: !GetAtt UpdateInactiveAccountTrackerDeadLetterQueue.Arn


### PR DESCRIPTION
## OLH-4524: Add new event types to save-raw-events

### `src/save-raw-events.ts`
- Added three new event names to the `ALLOWED_EVENT_NAMES` allowlist:
  - `AUTH_CODE_VERIFIED`
  - `AUTH_PASSKEY_VERIFICATION_SUCCESSFUL`
  - `STS_REFRESH_TOKEN_ISSUED`
- Minor formatting/style fixes (whitespace, line wrapping on long strings)

### `template.yaml`
- Updated the DynamoDB stream filter on the `UpdateInactiveAccountTracker` Lambda event source mapping to include the three new event names alongside the existing `AUTH_TOKEN_SENT_TO_ORCHESTRATION`

### `src/tests/save-raw-events.test.ts`
- Added all missing event names to the `test.each` allowlist coverage (`AUTH_CODE_VERIFIED`, `AUTH_PASSKEY_VERIFICATION_SUCCESSFUL`, `STS_REFRESH_TOKEN_ISSUED`)