### PR TITLE
OLH-4536: Only update email address if it's the latest

### DIFF
--- a/src/tests/update-inactive-account-tracker.test.ts
+++ b/src/tests/update-inactive-account-tracker.test.ts
@@ -380,7 +380,7 @@ describe("UpdateInactiveAccountTracker handler", () => {
 
   test("updates emailAddressSource, emailAddressSourceId and emailAddressLastUpdated when email changes", async () => {
     dynamoMock.on(QueryCommand).resolves({
-      Items: [{ commonSubjectId: "qwerty", dateForDeletion: "1978-11-29", userLastActive: "1970-01-01T00:00:00.000Z", emailAddress: "old@email.com", emailAddressSource: "AUTH_PREVIOUS_EVENT", emailAddressSourceId: "old-event-id", emailAddressLastUpdated: "2020-01-01T00:00:00.000Z", status: "pending", statusLastUpdated: "" }],
+      Items: [{ commonSubjectId: "qwerty", dateForDeletion: "1978-11-29", userLastActive: "1970-01-01T00:00:00.000Z", emailAddress: "old@email.com", emailAddressSource: "AUTH_PREVIOUS_EVENT", emailAddressSourceId: "old-event-id", emailAddressLastUpdated: "1970-01-01T00:00:00.000Z", status: "pending", statusLastUpdated: "" }],
     });
     dynamoMock.on(TransactWriteCommand).resolves({});
     // generateDynamoStreamRecord uses timestamp = 123456789 seconds => 1973-11-29T21:33:09.000Z
@@ -572,4 +572,98 @@ describe("UpdateInactiveAccountTracker handler", () => {
       ]),
     });
   });
+
+  test("updates email address when event timestamp is newer than emailAddressLastUpdated", async () => {
+    dynamoMock.on(QueryCommand).resolves({
+      Items: [{ 
+        commonSubjectId: "asdf", 
+        dateForDeletion: "1975-01-01", 
+        userLastActive: "1970-01-01T00:16:40.000Z", 
+        status: "pending", 
+        emailAddress: "old-email@example.com", 
+        emailAddressLastUpdated: "1970-01-01T00:16:40.000Z",
+        statusLastUpdated: "" 
+      }],
+    });
+    dynamoMock.on(TransactWriteCommand).resolves({});
+
+    const event: DynamoDBStreamEvent = { Records: [generateDynamoStreamRecord("test-client")] };
+    if (event.Records[0].dynamodb?.NewImage?.event?.M) {
+      event.Records[0].dynamodb.NewImage.event.M.timestamp = { N: "1666769858" };
+      event.Records[0].dynamodb.NewImage.event.M.event_name = { S: "NEWER_EMAIL_EVENT" };
+      event.Records[0].dynamodb.NewImage.event.M.event_id = { S: "newre" };
+      event.Records[0].dynamodb.NewImage.event.M.user = { 
+        M: { 
+          user_id: { S: "test_id" }, 
+          email: { S: "test_newer_email@example.com" } 
+        } 
+      };
+    }
+
+    await handler(event, {} as Context);
+
+    expect(dynamoMock).toHaveReceivedCommandWith(TransactWriteCommand, {
+      TransactItems: expect.arrayContaining([
+        expect.objectContaining({
+          Put: expect.objectContaining({
+            Item: expect.objectContaining({ 
+              emailAddress: "test_newer_email@example.com",
+              emailAddressSource: "NEWER_EMAIL_EVENT",
+              emailAddressSourceId: "newre",
+              emailAddressLastUpdated: "2022-10-26T07:37:38.000Z"
+            }),
+          }),
+        }),
+      ]),
+    });
+  });
+
+  test("does not update email address when event timestamp is older than emailAddressLastUpdated", async () => {
+    dynamoMock.on(QueryCommand).resolves({
+      Items: [{ 
+        commonSubjectId: "asdf", 
+        dateForDeletion: "1975-01-01", 
+        userLastActive: "1970-01-01T00:33:20.000Z", 
+        status: "pending", 
+        emailAddress: "current-and-newest-email@example.com", 
+        emailAddressSource: "FRESH_EVENT",
+        emailAddressSourceId: "current-and-newestest",
+        emailAddressLastUpdated: "1970-01-01T00:33:20.000Z",
+        statusLastUpdated: "" 
+      }],
+    });
+    dynamoMock.on(TransactWriteCommand).resolves({});
+
+    const event: DynamoDBStreamEvent = { Records: [generateDynamoStreamRecord("test-client")] };
+    
+    if (event.Records[0].dynamodb?.NewImage?.event?.M) {
+      event.Records[0].dynamodb.NewImage.event.M.timestamp = { N: "1000" };
+      event.Records[0].dynamodb.NewImage.event.M.event_name = { S: "STALE_OUT_OF_ORDER_EVENT" };
+      event.Records[0].dynamodb.NewImage.event.M.event_id = { S: "stale_id" };
+      event.Records[0].dynamodb.NewImage.event.M.user = { 
+        M: { 
+          user_id: { S: "asdf" }, 
+          email: { S: "old-email@example.com" } 
+        } 
+      };
+    }
+
+    await handler(event, {} as Context);
+
+    expect(dynamoMock).toHaveReceivedCommandWith(TransactWriteCommand, {
+      TransactItems: expect.arrayContaining([
+        expect.objectContaining({
+          Put: expect.objectContaining({
+            Item: expect.objectContaining({ 
+              emailAddress: "current-and-newest-email@example.com",
+              emailAddressSource: "FRESH_EVENT",
+              emailAddressSourceId: "current-and-newestest",
+              emailAddressLastUpdated: "1970-01-01T00:33:20.000Z"
+            }),
+          }),
+        }),
+      ]),
+    });
+  });
+
 });

--- a/src/tests/update-user-email.test.ts
+++ b/src/tests/update-user-email.test.ts
@@ -240,4 +240,92 @@ describe("update-user-email", () => {
       handler(createEvent("test-user-id", "new-email@example.com"), {} as Context)
     ).rejects.toThrow('Environment variable "INACTIVE_ACCOUNT_TRACKER_TABLE_NAME" is not set.');
   });
+
+  it("updates email when incoming email is newer", async () => {
+    dynamoMock.on(QueryCommand).resolves({
+      Items: [{ 
+        dateForDeletion: "2031-06-30", 
+        commonSubjectId: "test-user-id",
+        emailAddress: "previous-email@example.com",
+        emailAddressSource: "AUTH_UPDATE_EMAIL",
+        emailAddressLastUpdated: "2022-10-19T10:00:00.000Z"
+      }],
+    });
+    dynamoMock.on(UpdateCommand).resolves({});
+
+    const explicitTimestampEvent = {
+      Records: [{
+        dynamodb: {
+          NewImage: {
+            event: {
+              M: {
+                event_name: { S: "AUTH_UPDATE_EMAIL" },
+                timestamp: { N: "1666769858" },
+                user: { M: { user_id: { S: "test-user-id" }, email: { S: "new-email@example.com" } } },
+              },
+            },
+          },
+        },
+      }],
+    } as unknown as DynamoDBStreamEvent;
+
+    await handler(explicitTimestampEvent, {} as Context);
+
+    expect(dynamoMock).toHaveReceivedCommandWith(UpdateCommand, {
+      TableName: "test-inactive-tracker-table",
+      Key: {
+        dateForDeletion: "2031-06-30",
+        commonSubjectId: "test-user-id",
+      },
+      ConditionExpression: "attribute_not_exists(emailAddressLastUpdated) OR emailAddressLastUpdated < :lastUpdated",
+      ExpressionAttributeValues: expect.objectContaining({
+        ":lastUpdated": new Date(1666769858 * 1000).toISOString(),
+      }),
+    });
+  });
+
+  it("logs for an out-of-order event", async () => {
+    dynamoMock.on(QueryCommand).resolves({
+      Items: [{ 
+        dateForDeletion: "2031-06-30", 
+        commonSubjectId: "test-user-id",
+        emailAddress: "newer-email@example.com",
+        emailAddressSource: "AUTH_UPDATE_EMAIL",
+        emailAddressLastUpdated: "2022-10-19T10:20:00.000Z"
+      }],
+    });
+    
+    const conditionalCheckError = new Error("The conditional request failed");
+    conditionalCheckError.name = "ConditionalCheckFailedException";
+    dynamoMock.on(UpdateCommand).rejects(conditionalCheckError);
+
+    const outOfOrderEvent = {
+      Records: [{
+        dynamodb: {
+          NewImage: {
+            event: {
+              M: {
+                event_name: { S: "AUTH_UPDATE_EMAIL" },
+                timestamp: { N: "1666169000" },
+                user: { M: { user_id: { S: "test-user-id" }, email: { S: "stale-email@example.com" } } },
+              },
+            },
+          },
+        },
+      }],
+    } as unknown as DynamoDBStreamEvent;
+
+    await expect(
+      handler(outOfOrderEvent, {} as Context)
+    ).resolves.not.toThrow();
+
+    expect(loggerWarnMock).toHaveBeenCalledWith(
+      "An email update event with a newer timestamp has already been processed.",
+      {
+        userId: "test-user-id",
+        incomingTimestamp: new Date(1666169000 * 1000).toISOString(),
+      }
+    );
+  });
+
 });

--- a/src/update-inactive-account-tracker.ts
+++ b/src/update-inactive-account-tracker.ts
@@ -30,7 +30,7 @@ const getCurrentRecordForUser = async (userId: string, tableName: string): Promi
   return response.Items.length > 0 ? response.Items[0] as InactiveAccountTrackerRecord : null;
 }
 
-const getLatestDate = (txmaEvent: TxmaEvent, trackerRecord: InactiveAccountTrackerRecord | null) => {
+const getEventDate = (txmaEvent: TxmaEvent): Date => {
   let timestamp = txmaEvent.timestamp;
 
   // some txma events timestamps are in milliseconds when they should be in seconds.
@@ -40,9 +40,11 @@ const getLatestDate = (txmaEvent: TxmaEvent, trackerRecord: InactiveAccountTrack
     timestamp = Math.floor(timestamp / 1000);
   }
 
-  // if the timestamp on the audit event is older than the last active timestamp we have for the user
-  // we should keep the existing date as it means the events have been receieved out of order
-  const eventDate = new Date(timestamp * 1000);
+  return new Date(timestamp * 1000);
+}
+
+const getLatestDate = (txmaEvent: TxmaEvent, trackerRecord: InactiveAccountTrackerRecord | null) => {
+  const eventDate = getEventDate(txmaEvent);
   const trackerDate = trackerRecord ? new Date(trackerRecord.userLastActive) : new Date(0);
 
   return eventDate > trackerDate ? eventDate : trackerDate;
@@ -110,12 +112,19 @@ const processRecord = async (
   }
 
   const eventDateTime = new Date(txmaEvent.event_timestamp_ms ?? (txmaEvent.timestamp * 1000)).toISOString();
+  const currentEventDate = getEventDate(txmaEvent);
+
+  const emailLastUpdatedDate = currentTrackerRecord?.emailAddressLastUpdated 
+    ? new Date(currentTrackerRecord.emailAddressLastUpdated) 
+    : new Date(0);
+  const eventHasNewerEmailLastUpdated = currentEventDate > emailLastUpdatedDate;
 
   const newEmailAddress = (() => {
-    if (txmaEvent.user?.email && txmaEvent.user.email !== currentTrackerRecord?.emailAddress) {
+    if (txmaEvent.user?.email && eventHasNewerEmailLastUpdated && txmaEvent.user.email !== currentTrackerRecord?.emailAddress) {
       return txmaEvent.user.email;
     }
   })();
+
   const emailAddress = newEmailAddress ?? currentTrackerRecord?.emailAddress ?? "";
   const emailAddressSource = newEmailAddress ? txmaEvent.event_name : (currentTrackerRecord?.emailAddressSource ?? "");
   const emailAddressSourceId = newEmailAddress ? txmaEvent.event_id : currentTrackerRecord?.emailAddressSourceId;
@@ -123,7 +132,7 @@ const processRecord = async (
 
   const latestDate = getLatestDate(txmaEvent, currentTrackerRecord);
   const publicSubjectId = txmaEvent.user?.public_subject_id ?? currentTrackerRecord?.publicSubjectId ?? "";
-  const isNewLatestDate = new Date(txmaEvent.timestamp * 1000) > (currentTrackerRecord ? new Date(currentTrackerRecord.userLastActive) : new Date(0));
+  const isNewLatestDate = currentEventDate > (currentTrackerRecord ? new Date(currentTrackerRecord.userLastActive) : new Date(0));
 
   const newItem: InactiveAccountTrackerRecord = {
     commonSubjectId: userId,

--- a/src/update-user-email.ts
+++ b/src/update-user-email.ts
@@ -1,4 +1,4 @@
-import { Context, DynamoDBStreamEvent } from "aws-lambda";
+import { Context, DynamoDBStreamEvent, DynamoDBRecord } from "aws-lambda";
 import { AttributeValue, DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { unmarshall } from "@aws-sdk/util-dynamodb";
 import { DynamoDBDocumentClient, QueryCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
@@ -10,6 +10,79 @@ const logger = new Logger();
 const dynamoClient = new DynamoDBClient({});
 const dynamoDocClient = DynamoDBDocumentClient.from(dynamoClient);
 
+const handleRecord = async (record: DynamoDBRecord, tableName: string): Promise<void> => {
+  const txmaEvent = unmarshall(
+    record.dynamodb?.NewImage?.event.M as Record<string, AttributeValue>
+  ) as TxmaEvent;
+
+  const userId = txmaEvent.user?.user_id;
+  if (!userId) {
+    throw new Error("user_id is missing from the event");
+  }
+
+  const newEmail = txmaEvent.user?.email;
+  if (!newEmail) {
+    throw new Error("email is missing from the event");
+  }
+
+  logger.info("Processing email update event", {
+    userId,
+    eventName: txmaEvent.event_name,
+  });
+
+  const queryResponse = await dynamoDocClient.send(
+    new QueryCommand({
+      IndexName: "CommonSubjectIdIndex",
+      TableName: tableName,
+      KeyConditionExpression: "commonSubjectId = :uid",
+      ExpressionAttributeValues: { ":uid": userId },
+    })
+  );
+
+  if (!queryResponse.Items || queryResponse.Items.length === 0) {
+    logger.warn("No inactive account tracker record found for user", { userId });
+    return;
+  }
+
+  const trackerRecord = queryResponse.Items[0];
+
+  const eventDateTime = new Date(txmaEvent.event_timestamp_ms ?? (txmaEvent.timestamp * 1000)).toISOString();
+
+  try {
+    await dynamoDocClient.send(
+      new UpdateCommand({
+        TableName: tableName,
+        Key: {
+          dateForDeletion: trackerRecord.dateForDeletion,
+          commonSubjectId: userId,
+        },
+        UpdateExpression:
+          "SET emailAddress = :email, emailAddressSource = :source, emailAddressLastUpdated = :lastUpdated" +
+          (txmaEvent.event_id ? ", emailAddressSourceId = :sourceId" : ""),
+        ConditionExpression:
+          "attribute_not_exists(emailAddressLastUpdated) OR emailAddressLastUpdated < :lastUpdated",
+        ExpressionAttributeValues: {
+          ":email": newEmail,
+          ":source": txmaEvent.event_name,
+          ":lastUpdated": eventDateTime,
+          ...(txmaEvent.event_id && { ":sourceId": txmaEvent.event_id }),
+        },
+      })
+    );
+    logger.info("Successfully updated email address in inactive account tracker", { userId });
+  } catch (error) {
+    const err = error as Error;
+    if (err.name === "ConditionalCheckFailedException") {
+      logger.warn("An email update event with a newer timestamp has already been processed.", {
+        userId,
+        incomingTimestamp: eventDateTime,
+      });
+    } else {
+      throw err;
+    }
+  }
+}
+
 export const handler = async (
   event: DynamoDBStreamEvent,
   context: Context
@@ -19,75 +92,6 @@ export const handler = async (
   const tableName = getEnvironmentVariable("INACTIVE_ACCOUNT_TRACKER_TABLE_NAME");
 
   for (const record of event.Records) {
-    const txmaEvent = unmarshall(
-      record.dynamodb?.NewImage?.event.M as Record<string, AttributeValue>
-    ) as TxmaEvent;
-
-    const userId = txmaEvent.user?.user_id;
-    if (!userId) {
-      throw new Error("user_id is missing from the event");
-    }
-
-    const newEmail = txmaEvent.user?.email;
-    if (!newEmail) {
-      throw new Error("email is missing from the event");
-    }
-
-    logger.info("Processing email update event", {
-      userId,
-      eventName: txmaEvent.event_name,
-    });
-
-    const queryResponse = await dynamoDocClient.send(
-      new QueryCommand({
-        IndexName: "CommonSubjectIdIndex",
-        TableName: tableName,
-        KeyConditionExpression: "commonSubjectId = :uid",
-        ExpressionAttributeValues: { ":uid": userId },
-      })
-    );
-
-    if (!queryResponse.Items || queryResponse.Items.length === 0) {
-      logger.warn("No inactive account tracker record found for user", { userId });
-      return;
-    }
-
-    const trackerRecord = queryResponse.Items[0];
-
-    const eventDateTime = new Date(txmaEvent.event_timestamp_ms ?? (txmaEvent.timestamp * 1000)).toISOString();
-
-    try {
-      await dynamoDocClient.send(
-        new UpdateCommand({
-          TableName: tableName,
-          Key: {
-            dateForDeletion: trackerRecord.dateForDeletion,
-            commonSubjectId: userId,
-          },
-          UpdateExpression:
-            "SET emailAddress = :email, emailAddressSource = :source, emailAddressLastUpdated = :lastUpdated" +
-            (txmaEvent.event_id ? ", emailAddressSourceId = :sourceId" : ""),
-          ConditionExpression:
-            "attribute_not_exists(emailAddressLastUpdated) OR emailAddressLastUpdated < :lastUpdated",
-          ExpressionAttributeValues: {
-            ":email": newEmail,
-            ":source": txmaEvent.event_name,
-            ":lastUpdated": eventDateTime,
-            ...(txmaEvent.event_id && { ":sourceId": txmaEvent.event_id }),
-          },
-        })
-      );
-      logger.info("Successfully updated email address in inactive account tracker", { userId });
-    } catch (error) {
-      const err = error as Error;
-      if (err.name === "ConditionalCheckFailedException") {
-        logger.warn("An email update event with a newer timestamp has already been processed.", {
-          userId,
-          incomingTimestamp: eventDateTime,
-        });
-      } else {
-        throw err;
-      }
-    }
+    await handleRecord(record, tableName);
   }
 };

--- a/src/update-user-email.ts
+++ b/src/update-user-email.ts
@@ -56,25 +56,38 @@ export const handler = async (
 
     const eventDateTime = new Date(txmaEvent.event_timestamp_ms ?? (txmaEvent.timestamp * 1000)).toISOString();
 
-    await dynamoDocClient.send(
-      new UpdateCommand({
-        TableName: tableName,
-        Key: {
-          dateForDeletion: trackerRecord.dateForDeletion,
-          commonSubjectId: userId,
-        },
-        UpdateExpression:
-          "SET emailAddress = :email, emailAddressSource = :source, emailAddressLastUpdated = :lastUpdated" +
-          (txmaEvent.event_id ? ", emailAddressSourceId = :sourceId" : ""),
-        ExpressionAttributeValues: {
-          ":email": newEmail,
-          ":source": txmaEvent.event_name,
-          ":lastUpdated": eventDateTime,
-          ...(txmaEvent.event_id && { ":sourceId": txmaEvent.event_id }),
-        },
-      })
-    );
-
-    logger.info("Successfully updated email address in inactive account tracker", { userId });
+    try {
+      await dynamoDocClient.send(
+        new UpdateCommand({
+          TableName: tableName,
+          Key: {
+            dateForDeletion: trackerRecord.dateForDeletion,
+            commonSubjectId: userId,
+          },
+          UpdateExpression:
+            "SET emailAddress = :email, emailAddressSource = :source, emailAddressLastUpdated = :lastUpdated" +
+            (txmaEvent.event_id ? ", emailAddressSourceId = :sourceId" : ""),
+          ConditionExpression:
+            "attribute_not_exists(emailAddressLastUpdated) OR emailAddressLastUpdated < :lastUpdated",
+          ExpressionAttributeValues: {
+            ":email": newEmail,
+            ":source": txmaEvent.event_name,
+            ":lastUpdated": eventDateTime,
+            ...(txmaEvent.event_id && { ":sourceId": txmaEvent.event_id }),
+          },
+        })
+      );
+      logger.info("Successfully updated email address in inactive account tracker", { userId });
+    } catch (error) {
+      const err = error as Error;
+      if (err.name === "ConditionalCheckFailedException") {
+        logger.warn("An email update event with a newer timestamp has already been processed.", {
+          userId,
+          incomingTimestamp: eventDateTime,
+        });
+      } else {
+        throw err;
+      }
+    }
   }
 };


### PR DESCRIPTION


## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->

### What changed
Introduce logic to prevent accidentally reverting a user's tracked email address to an older version, in the situation where events are sent/processed out of order.

When an event comes through with a timestamp that is earlier than the timestamp of when an email was last saved, the newest email address should be kept.
<!-- Describe the changes in detail - the "what"-->



### Environment variables or secrets

- [x] No environment variables or secrets were added or changed
