### PR TITLE
Olh 4482 removed regional endpoint format

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -5993,6 +5993,21 @@ Resources:
               Resource:
                 - "*"
             - !Ref AWS::NoValue
+          - !If
+            - "UseExternalEvents"
+            - Effect: Allow
+              Principal:
+                Service: !Sub "dynamodb.${AWS::Region}.amazonaws.com"
+              Action:
+                - kms:Decrypt
+                - kms:GenerateDataKey*
+                - kms:ReEncrypt*
+              Resource:
+                - "*"
+              Condition:
+                StringEquals:
+                  kms:CallerAccount: !FindInMap [AuthenticationAccounts, !Ref Environment, "AccountNumber"]
+            - !Ref AWS::NoValue
 
   DatabaseKmsKeyAlias:
     Type: AWS::KMS::Alias

--- a/template.yaml
+++ b/template.yaml
@@ -638,6 +638,49 @@ Resources:
         SSEType: KMS
         KMSMasterKeyId: !GetAtt DatabaseKmsKey.Arn
 
+  InactiveAccountTrackerStoreCrossAccountRole:
+    Type: AWS::IAM::Role
+    Condition: UseExternalEvents
+    Properties:
+      PermissionsBoundary: !If
+        - UsePermissionsBoundary
+        - !Ref PermissionsBoundary
+        - !Ref AWS::NoValue
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !Sub
+                - "arn:aws:iam::${AccountId}:root"
+                - AccountId: !FindInMap [AuthenticationAccounts, !Ref Environment, AccountNumber]
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: InactiveAccountTrackerStoreWritePolicy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - dynamodb:PutItem
+                  - dynamodb:BatchWriteItem
+                Resource: !GetAtt InactiveAccountTrackerStore.Arn
+              - Effect: Allow
+                Action:
+                  - kms:Decrypt
+                  - kms:GenerateDataKey*
+                  - kms:ReEncrypt*
+                Resource: !GetAtt DatabaseKmsKey.Arn
+
+  InactiveAccountTrackerStoreCrossAccountRoleArnParameter:
+    Type: AWS::SSM::Parameter
+    Condition: UseExternalEvents
+    Properties:
+      Description: The ARN of the cross-account role for the authentication account to write to the InactiveAccountTrackerStore
+      Name: !Sub "/${AWS::StackName}/IAM/InactiveAccountTrackerStoreCrossAccountRole/ARN"
+      Type: String
+      Value: !GetAtt InactiveAccountTrackerStoreCrossAccountRole.Arn
+
   ######################################
   # User Notifications store
   ######################################
@@ -7276,6 +7319,12 @@ Outputs:
     Value: !GetAtt WrapperKey.Arn
     Export:
       Name: !Sub "${AWS::StackName}-WrappingKey"
+  InactiveAccountTrackerStoreCrossAccountRoleArn:
+    Condition: UseExternalEvents
+    Description: The ARN of the cross-account role for the authentication account to write to the InactiveAccountTrackerStore
+    Value: !GetAtt InactiveAccountTrackerStoreCrossAccountRole.Arn
+    Export:
+      Name: !Sub "${AWS::StackName}-InactiveAccountTrackerStoreCrossAccountRoleArn"
 
 # NOTES
 #

--- a/template.yaml
+++ b/template.yaml
@@ -667,9 +667,10 @@ Resources:
                 Resource: !GetAtt InactiveAccountTrackerStore.Arn
               - Effect: Allow
                 Action:
+                  - kms:Encrypt
                   - kms:Decrypt
                   - kms:GenerateDataKey*
-                  - kms:ReEncrypt*
+                  - kms:DescribeKey
                 Resource: !GetAtt DatabaseKmsKey.Arn
 
   InactiveAccountTrackerStoreCrossAccountRoleArnParameter:
@@ -6030,9 +6031,10 @@ Resources:
                       ]
                     - ":root"
               Action:
+                - kms:Encrypt
                 - kms:Decrypt
                 - kms:GenerateDataKey*
-                - kms:ReEncrypt*
+                - kms:DescribeKey
               Resource:
                 - "*"
             - !Ref AWS::NoValue

--- a/template.yaml
+++ b/template.yaml
@@ -5973,6 +5973,26 @@ Resources:
               - kms:*
             Resource:
               - "*"
+          - !If
+            - "UseExternalEvents"
+            - Effect: Allow
+              Principal:
+                AWS: !Join
+                  - ""
+                  - - "arn:aws:iam::"
+                    - !FindInMap [
+                        AuthenticationAccounts,
+                        !Ref Environment,
+                        "AccountNumber",
+                      ]
+                    - ":root"
+              Action:
+                - kms:Decrypt
+                - kms:GenerateDataKey*
+                - kms:ReEncrypt*
+              Resource:
+                - "*"
+            - !Ref AWS::NoValue
 
   DatabaseKmsKeyAlias:
     Type: AWS::KMS::Alias

--- a/template.yaml
+++ b/template.yaml
@@ -6042,7 +6042,7 @@ Resources:
             - "UseExternalEvents"
             - Effect: Allow
               Principal:
-                Service: !Sub "dynamodb.${AWS::Region}.amazonaws.com"
+                Service: "dynamodb.amazonaws.com"
               Action:
                 - kms:Decrypt
                 - kms:GenerateDataKey*


### PR DESCRIPTION
## Proposed changes

[OLH-4482]: removed regional endpoint format
### What changed

I changed the the regional endpoint format (dynamodb.eu-west-2.amazonaws.com) since the build was complained thats its not a valid IAM/KMS service principal. Advice is to drop the region.

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists

<!-- Merging this PR deploys to production. Please answer accurately. -->

### Environment variables or secrets

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Added parameters to Cloudformation template
- [ ] Added new secret or systems manager parameter
- [ ] Added new environment variable

### Permissions

- [ ] This PR adds or changes permissions

### Monitoring

- [ ] This PR includes changes that need to be monitored in production as the scope of the change could cause issues

## Testing

<!-- Provide a summary of any manual testing you've done, for example deploying the branch to dev -->

## How to review

<!-- Describe any non-standard steps to review this work, or highlight any areas that you'd like the reviewer's opinion on -->


[OLH-4482]: https://govukverify.atlassian.net/browse/OLH-4482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ