### PR TITLE
OLH-4482: removed regional endpoint format

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -6047,7 +6047,7 @@ Resources:
             - "UseExternalEvents"
             - Effect: Allow
               Principal:
-                Service: !Sub "dynamodb.${AWS::Region}.amazonaws.com"
+                Service: "dynamodb.amazonaws.com"
               Action:
                 - kms:Decrypt
                 - kms:GenerateDataKey*


### PR DESCRIPTION
## Proposed changes

[OLH-4482]: removed regional endpoint format

### What changed

The regional endpoint format (dynamodb.eu-west-2.amazonaws.com) was not a valid IAM/KMS service principal. Advised to drop the region

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists

<!-- Merging this PR deploys to production. Please answer accurately. -->

### Environment variables or secrets

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Added parameters to Cloudformation template
- [ ] Added new secret or systems manager parameter
- [ ] Added new environment variable

### Permissions

- [ ] This PR adds or changes permissions

### Monitoring

- [ ] This PR includes changes that need to be monitored in production as the scope of the change could cause issues

## Testing

<!-- Provide a summary of any manual testing you've done, for example deploying the branch to dev -->

## How to review

<!-- Describe any non-standard steps to review this work, or highlight any areas that you'd like the reviewer's opinion on -->


[OLH-4482]: https://govukverify.atlassian.net/browse/OLH-4482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ